### PR TITLE
6368 Remove superfluous statement

### DIFF
--- a/usr/src/cmd/zstreamdump/zstreamdump.c
+++ b/usr/src/cmd/zstreamdump/zstreamdump.c
@@ -262,7 +262,6 @@ main(int argc, char *argv[])
 	}
 
 	send_stream = stdin;
-	pcksum = zc;
 	while (read_hdr(drr, &zc)) {
 
 		/*


### PR DESCRIPTION
Clang's static analyzer reported that the value assigned to pcksum is
never used. That is because we initialize both zc and pcksum to {{ 0 }}
and then do `pcksum = zc;`. That is fairly pointless. However, it has
the effect of generating a false positive in Clang's static analyzer.
Since noise from false positives can obscure real issues, we fix it
anyway.

https://github.com/zfsonlinux/zfs/commit/2024041b6c5134a925a33c10eff24a47ecb541a6

Signed-off-by: Richard Yao <ryao@gentoo.org>
Signed-off-by: Ned Bass <bass6@llnl.gov>
Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>