### PR TITLE
IllumOS 6183 upgrade soft panic

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/Makefile
@@ -28,7 +28,8 @@ PROGS = cleanup \
 	zpool_upgrade_006_neg \
 	zpool_upgrade_007_pos \
 	zpool_upgrade_008_pos \
-	zpool_upgrade_009_neg
+	zpool_upgrade_009_neg \
+	zpool_upgrade_010_pos
 
 FILES = zpool_upgrade.cfg \
 	zpool_upgrade.kshlib

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_010_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_010_pos.ksh
@@ -1,0 +1,75 @@
+#!/usr/bin/env ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2015 by Brendon Humphrey (brendon.humphrey@mac.com). All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
+
+#
+# DESCRIPTION:
+# Replication of OpenZFS bug 6183 (https://www.illumos.org/issues/6183)
+#
+# STRATEGY:
+# 1. create a pool with specific version
+# 2. incrementally upgrade pool and dataset until completion or failure.
+#
+
+verify_runnable "global"
+
+function cleanup {
+    destroy_pool $TESTPOOL
+    destroy_pool $FILE_POOL
+    if [[ -f $VDEV ]]; then
+        log_must $RM -f $VDEV
+    fi
+}
+
+
+log_assert "Executing specific zpool and zfs upgrade command succeeds (success = no panic)"
+
+typeset VDEV=$TESTDIR/filepool.bin
+typeset FILE_POOL=fp
+
+if [[ -n "$OSX" ]]; then
+    log_must $MKFILE $MKFILE_SPARSE 256m $VDEV
+else
+    log_must $MKFILE -s 256m $VDEV
+fi
+
+log_must $ZPOOL create -o version=1 -O version=1 $FILE_POOL $VDEV
+$ZFS upgrade -V 2 $FILE_POOL
+$ZFS upgrade -V 3 $FILE_POOL
+$ZPOOL upgrade -V 9 $FILE_POOL
+$ZFS upgrade -V 3 $FILE_POOL
+$ZFS upgrade -V 4 $FILE_POOL
+$ZPOOL upgrade -V 15 $FILE_POOL
+$ZFS upgrade -V 4 $FILE_POOL
+
+log_pass "Executing specific zpool and zfs upgrade command succeeds (success - no panic)"

--- a/usr/src/uts/common/fs/zfs/dmu_objset.c
+++ b/usr/src/uts/common/fs/zfs/dmu_objset.c
@@ -632,7 +632,6 @@ dmu_objset_refresh_ownership(objset_t *os, void *tag)
 	dsl_pool_config_enter(dp, FTAG);
 	dmu_objset_disown(os, tag);
 	VERIFY0(dsl_dataset_own(dp, name, tag, &newds));
-	VERIFY3P(newds, ==, os->os_dsl_dataset);
 	dsl_pool_config_exit(dp, FTAG);
 }
 


### PR DESCRIPTION
"Fixing" a problem by removing the VERIFY() call that panics is a bit weak, but I am hoping to start a discussion on this problem to see what should be done. This pull request includes zfs-tester file `zpool_upgrade_010_pos.ksh` which triggers it.

Very old dataset upgrade path, fails with:

VERIFY3 " "failed ("
"0xffffff824e87a100" " " "==" " " "0xffffff824e87b980" ")\n"@dmu_objset.c:579

Can be triggered with:

mkfile 256m filepool.bin
zpool create -o version=1 -O version=1 fp `pwd`/filepool.bin
zfs upgrade -V 2 fp
zfs upgrade -V 3 fp
zpool upgrade -V 9 fp
zfs upgrade -V 3 fp
zfs upgrade -V 4 fp
zpool upgrade -V 15 fp
zfs upgrade -V 4 fp

triggers on IllumOS, ZOL, FreeBSD and OS X.

Removing the VERIFY does technically stop it from causing a panic, and the
pool/dataset is upgraded, but, well, I don't know if there are side-effects
from doing that.
