### PR TITLE
Add zio_ddt_free()+ddt_phys_decref() error handling

### DIFF
--- a/usr/src/uts/common/fs/zfs/ddt.c
+++ b/usr/src/uts/common/fs/zfs/ddt.c
@@ -310,8 +310,10 @@ ddt_phys_addref(ddt_phys_t *ddp)
 void
 ddt_phys_decref(ddt_phys_t *ddp)
 {
-	ASSERT((int64_t)ddp->ddp_refcnt > 0);
-	ddp->ddp_refcnt--;
+	if (ddp) {
+		ASSERT((int64_t)ddp->ddp_refcnt > 0);
+		ddp->ddp_refcnt--;
+	}
 }
 
 void

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -2411,8 +2411,11 @@ zio_ddt_free(zio_t *zio)
 
 	ddt_enter(ddt);
 	freedde = dde = ddt_lookup(ddt, bp, B_TRUE);
-	ddp = ddt_phys_select(dde, bp);
-	ddt_phys_decref(ddp);
+	if (dde) {
+		ddp = ddt_phys_select(dde, bp);
+		if (ddp)
+			ddt_phys_decref(ddp);
+	}
 	ddt_exit(ddt);
 
 	return (ZIO_PIPELINE_CONTINUE);


### PR DESCRIPTION
The assumption in zio_ddt_free() is that ddt_phys_select() must
always find a match.  However, if that fails due to a damaged
DDT or some other reason the code will NULL dereference in
ddt_phys_decref().

While this should never happen it has been observed on various
platforms.  The result is that unless your willing to patch the
ZFS code the pool is inaccessible.  Therefore, we're choosing
to more gracefully handle this case rather than leave it fatal.

http://mail.opensolaris.org/pipermail/zfs-discuss/2012-February/050972.html
https://github.com/zfsonlinux/zfs/issues/1308
https://github.com/zfsonlinux/zfs/commit/5dc6af0

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
