### PR TITLE
6404, 6405 zvol test suite fixes

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_common.shlib
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_common.shlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -47,8 +47,6 @@ function default_zvol_setup # disk_device volume_size
         create_pool $TESTPOOL "$disk"
 
         log_must $ZFS create -V $size $TESTPOOL/$TESTVOL
-
-	set_dumpsize $TESTPOOL/$TESTVOL
 }
 
 #

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -44,6 +44,8 @@
 
 verify_runnable "global"
 
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
+
 function cleanup
 {
 	typeset dumpdev=$(get_dumpdevice)
@@ -51,6 +53,7 @@ function cleanup
 	if [[ $dumpdev != $savedumpdev ]] ; then
 		safe_dumpadm $savedumpdev
 	fi
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 log_assert "Verify that a ZFS volume can act as dump device."

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -43,6 +43,8 @@
 
 verify_runnable "global"
 
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
+
 function cleanup
 {
 	snapexists $TESTPOOL/$TESTVOL@snap && \
@@ -52,6 +54,7 @@ function cleanup
 	(( $? == 0 )) && log_must $UMOUNT $TESTDIR
 
 	[[ -e $TESTDIR ]] && $RM -rf $TESTDIR
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 log_assert "Verify that ZFS volume snapshot could be fscked"
@@ -60,6 +63,8 @@ log_onexit cleanup
 TESTVOL='testvol'
 BLOCKSZ=$(( 1024 * 1024 ))
 NUM_WRITES=40
+
+log_must zfs set volsize=128m $TESTPOOL/$TESTVOL
 
 $ECHO "y" | $NEWFS -v /dev/zvol/rdsk/$TESTPOOL/$TESTVOL >/dev/null 2>&1
 (( $? != 0 )) && log_fail "Unable to newfs(1M) $TESTPOOL/$TESTVOL"

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -45,6 +45,8 @@
 
 verify_runnable "global"
 
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
+
 function cleanup
 {
 	typeset dumpdev=$(get_dumpdevice)
@@ -55,6 +57,7 @@ function cleanup
 	if poolexists $TESTPOOL1 ; then
 		destroy_pool $TESTPOOL1
 	fi
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 log_assert "Verify zpool creation and newfs on dump zvol is denied."

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_004_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -43,6 +43,8 @@
 #
 
 verify_runnable "global"
+
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
 
 function cleanup
 {
@@ -62,6 +64,7 @@ function cleanup
 			log_must $ZFS destroy $TESTPOOL/$TESTVOL@$snap
 		fi
 	done
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 function verify_snapshot

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -44,6 +44,8 @@
 
 verify_runnable "global"
 
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
+
 function cleanup
 {
 	$SWAP -l | $GREP $voldev > /dev/null 2>&1
@@ -55,6 +57,7 @@ function cleanup
 	if [[ $dumpdev != $savedumpdev ]] ; then
 		safe_dumpadm $savedumpdev
 	fi
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 log_assert "Verify a device cannot be dump and swap at the same time."

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -44,12 +44,15 @@
 
 verify_runnable "global"
 
+volsize=$(zfs get -H -o value volsize $TESTPOOL/$TESTVOL)
+
 function cleanup
 {
 	typeset dumpdev=$(get_dumpdevice)
 	if [[ $dumpdev != $savedumpdev ]] ; then
 		safe_dumpadm $savedumpdev
 	fi
+	zfs set volsize=$volsize $TESTPOOL/$TESTVOL
 }
 
 log_assert "zfs volume as dumpdevice should have 128k volblocksize"

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_004_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -51,7 +51,7 @@ typeset -i min max mem
 ((min = 2 * 1024 * 1024 * 1024))
 ((max = 16 * 1024 * 1024 * 1024))
 
-for vbs in 512 1024 2048 4096 8192 16384 32768 65536 131072; do
+for vbs in 8192 16384 32768 65536 131072; do
 	for multiplier in 1 32 16384 131072; do
 		((volsize = vbs * multiplier))
 		vol="$TESTPOOL/vol_$volsize"

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap_006_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -75,13 +75,13 @@ log_note "Verify volume can be add as several segments."
 #
 #		swaplow			swaplen
 set -A swap_opt	$((pageblocks))	    \
-		$((pageblocks * ((RANDOM % 50) + 1) + (RANDOM % pageblocks) )) \
+		$((RANDOM % (50 * pageblocks) + 2 * pageblocks)) \
 		$((volblocks / 3))  \
-		$((pageblocks * ((RANDOM % 50) + 1) + (RANDOM % pageblocks) )) \
+		$((RANDOM % (50 * pageblocks) + 2 * pageblocks)) \
 		$((volblocks / 2))  \
-		$((pageblocks * ((RANDOM % 50) + 1) + (RANDOM % pageblocks) )) \
+		$((RANDOM % (50 * pageblocks) + 2 * pageblocks)) \
 		$(((volblocks*2) / 3))  \
-		$((pageblocks * ((RANDOM % 50) + 1) + (RANDOM % pageblocks) ))
+		$((RANDOM % (50 * pageblocks) + 2 * pageblocks))
 
 swapname=/dev/zvol/dsk/$vol
 typeset -i i=0 count=0


### PR DESCRIPTION
[6404](https://www.illumos.org/issues/6404) zvol_swap_006_pos can occasionally fail due to swaplen being < 16
[6405](https://www.illumos.org/issues/6405) zvol test setup is non deterministic
