### PR TITLE
6051 lzc_receive: allow the caller to read the begin record

### DIFF
--- a/usr/src/lib/libzfs_core/common/libzfs_core.c
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.c
@@ -550,7 +550,7 @@ recv_read(int fd, void *buf, int ilen)
 static int
 recv_impl(const char *snapname, nvlist_t *props, const char *origin,
     boolean_t force, boolean_t resumable, int fd,
-    const struct drr_begin *begin_record)
+    const dmu_replay_record_t *begin_record)
 {
 	/*
 	 * The receive ioctl is still legacy, so we need to construct our own
@@ -601,7 +601,7 @@ recv_impl(const char *snapname, nvlist_t *props, const char *origin,
 		if (error != 0)
 			goto out;
 	} else {
-		zc.zc_begin_record.drr_u.drr_begin = *begin_record;
+		zc.zc_begin_record = *begin_record;
 	}
 
 	/* zc_cookie is fd to read from */
@@ -673,7 +673,7 @@ lzc_receive_resumable(const char *snapname, nvlist_t *props, const char *origin,
 int
 lzc_receive_with_header(const char *snapname, nvlist_t *props,
     const char *origin, boolean_t force, boolean_t resumable, int fd,
-    const struct drr_begin *begin_record)
+    const dmu_replay_record_t *begin_record)
 {
 	if (begin_record == NULL)
 		return (EINVAL);

--- a/usr/src/lib/libzfs_core/common/libzfs_core.c
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.c
@@ -548,8 +548,9 @@ recv_read(int fd, void *buf, int ilen)
 }
 
 static int
-lzc_receive_impl(const char *snapname, nvlist_t *props, const char *origin,
-    boolean_t force, boolean_t resumable, int fd)
+recv_impl(const char *snapname, nvlist_t *props, const char *origin,
+    boolean_t force, boolean_t resumable, int fd,
+    const struct drr_begin *begin_record)
 {
 	/*
 	 * The receive ioctl is still legacy, so we need to construct our own
@@ -594,9 +595,14 @@ lzc_receive_impl(const char *snapname, nvlist_t *props, const char *origin,
 		(void) strlcpy(zc.zc_string, origin, sizeof (zc.zc_string));
 
 	/* zc_begin_record is non-byteswapped BEGIN record */
-	error = recv_read(fd, &zc.zc_begin_record, sizeof (zc.zc_begin_record));
-	if (error != 0)
-		goto out;
+	if (begin_record == NULL) {
+		error = recv_read(fd, &zc.zc_begin_record,
+		    sizeof (zc.zc_begin_record));
+		if (error != 0)
+			goto out;
+	} else {
+		zc.zc_begin_record.drr_u.drr_begin = *begin_record;
+	}
 
 	/* zc_cookie is fd to read from */
 	zc.zc_cookie = fd;
@@ -637,7 +643,7 @@ int
 lzc_receive(const char *snapname, nvlist_t *props, const char *origin,
     boolean_t force, int fd)
 {
-	return (lzc_receive_impl(snapname, props, origin, force, B_FALSE, fd));
+	return (recv_impl(snapname, props, origin, force, B_FALSE, fd, NULL));
 }
 
 /*
@@ -650,7 +656,27 @@ int
 lzc_receive_resumable(const char *snapname, nvlist_t *props, const char *origin,
     boolean_t force, int fd)
 {
-	return (lzc_receive_impl(snapname, props, origin, force, B_TRUE, fd));
+	return (recv_impl(snapname, props, origin, force, B_TRUE, fd, NULL));
+}
+
+/*
+ * Like lzc_receive, but allows the caller to read the begin record and then to
+ * pass it in.  That could be useful if the caller wants to derive, for example,
+ * the snapname or the origin parameters based on the information contained in
+ * the begin record.
+ * The begin record must be in its original form as read from the stream,
+ * in other words, it should not be byteswapped.
+ *
+ * The 'resumable' parameter allows to obtain the same behavior as with
+ * lzc_receive_resumable.
+ */
+int
+lzc_receive_with_header(const char *snapname, nvlist_t *props,
+    const char *origin, boolean_t force, boolean_t resumable, int fd,
+    const struct drr_begin *begin_record)
+{
+	return (recv_impl(snapname, props, origin, force, resumable, fd,
+	    begin_record));
 }
 
 /*

--- a/usr/src/lib/libzfs_core/common/libzfs_core.c
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.c
@@ -675,6 +675,8 @@ lzc_receive_with_header(const char *snapname, nvlist_t *props,
     const char *origin, boolean_t force, boolean_t resumable, int fd,
     const struct drr_begin *begin_record)
 {
+	if (begin_record == NULL)
+		return (EINVAL);
 	return (recv_impl(snapname, props, origin, force, resumable, fd,
 	    begin_record));
 }

--- a/usr/src/lib/libzfs_core/common/libzfs_core.h
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.h
@@ -62,13 +62,13 @@ int lzc_send_resume(const char *, const char *, int,
     enum lzc_send_flags, uint64_t, uint64_t);
 int lzc_send_space(const char *, const char *, uint64_t *);
 
-struct drr_begin;
+struct dmu_replay_record;
 
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_receive_resumable(const char *, nvlist_t *, const char *,
     boolean_t, int);
 int lzc_receive_with_header(const char *, nvlist_t *, const char *, boolean_t,
-    boolean_t, int, const struct drr_begin *);
+    boolean_t, int, const struct dmu_replay_record *);
 
 boolean_t lzc_exists(const char *);
 

--- a/usr/src/lib/libzfs_core/common/libzfs_core.h
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.h
@@ -60,10 +60,15 @@ enum lzc_send_flags {
 int lzc_send(const char *, const char *, int, enum lzc_send_flags);
 int lzc_send_resume(const char *, const char *, int,
     enum lzc_send_flags, uint64_t, uint64_t);
+int lzc_send_space(const char *, const char *, uint64_t *);
+
+struct drr_begin;
+
 int lzc_receive(const char *, nvlist_t *, const char *, boolean_t, int);
 int lzc_receive_resumable(const char *, nvlist_t *, const char *,
     boolean_t, int);
-int lzc_send_space(const char *, const char *, uint64_t *);
+int lzc_receive_with_header(const char *, nvlist_t *, const char *, boolean_t,
+    boolean_t, int, const struct drr_begin *);
 
 boolean_t lzc_exists(const char *);
 

--- a/usr/src/lib/libzfs_core/common/mapfile-vers
+++ b/usr/src/lib/libzfs_core/common/mapfile-vers
@@ -52,6 +52,7 @@ SYMBOL_VERSION ILLUMOS_0.1 {
 	lzc_hold;
 	lzc_receive;
 	lzc_receive_resumable;
+	lzc_receive_with_header;
 	lzc_release;
 	lzc_rollback;
 	lzc_send;


### PR DESCRIPTION
The begin record contains useful information that the caller might
want to have the access to, so that it can be used to derive values
for 'snapname' and 'origin' parameters.
New lzc_receive_with_header function is added.

Review request on the reviewboard: https://reviews.csiden.org/r/256/
An example of the intended usage: ClusterHQ/pyzfs@340f585d100e4e8cca82e620b0d44e7da314e4cb
(see `test_recv_with_header_full`)