### PR TITLE
6458 kmem reap thread gets blocked in reclaim callback

### DIFF
--- a/usr/src/uts/common/fs/nfs/nfs_auth.c
+++ b/usr/src/uts/common/fs/nfs/nfs_auth.c
@@ -1452,6 +1452,7 @@ exi_cache_trim(struct exportinfo *exi)
 			 */
 			if (rw_tryenter(&c->authc_lock, RW_WRITER) == 0) {
 				exi_cache_auth_reclaim_failed++;
+				rw_exit(&exi->exi_cache_lock);
 				return;
 			}
 

--- a/usr/src/uts/common/fs/nfs/nfs_auth.c
+++ b/usr/src/uts/common/fs/nfs/nfs_auth.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 1995, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -59,6 +60,8 @@ volatile uint_t nfsauth_cache_hit;
 volatile uint_t nfsauth_cache_miss;
 volatile uint_t nfsauth_cache_refresh;
 volatile uint_t nfsauth_cache_reclaim;
+volatile uint_t exi_cache_auth_reclaim_failed;
+volatile uint_t exi_cache_clnt_reclaim_failed;
 
 /*
  * The lifetime of an auth cache entry:
@@ -1434,10 +1437,8 @@ exi_cache_trim(struct exportinfo *exi)
 	avl_tree_t *tree;
 
 	for (i = 0; i < AUTH_TABLESIZE; i++) {
-
 		tree = exi->exi_cache[i];
 		stale_time = gethrestime_sec() - NFSAUTH_CACHE_TRIM;
-
 		rw_enter(&exi->exi_cache_lock, RW_READER);
 
 		/*
@@ -1445,7 +1446,15 @@ exi_cache_trim(struct exportinfo *exi)
 		 * used for NFSAUTH_CACHE_TRIM seconds.
 		 */
 		for (c = avl_first(tree); c != NULL; c = AVL_NEXT(tree, c)) {
-			rw_enter(&c->authc_lock, RW_WRITER);
+			/*
+			 * We are being called by the kmem subsystem to reclaim
+			 * memory so don't block if we can't get the lock.
+			 */
+			if (rw_tryenter(&exi->exi_cache_lock, RW_WRITER) == 0) {
+				exi_cache_auth_reclaim_failed++;
+				return;
+			}
+
 			for (p = avl_first(&c->authc_tree); p != NULL;
 			    p = next) {
 				next = AVL_NEXT(&c->authc_tree, p);
@@ -1491,7 +1500,8 @@ exi_cache_trim(struct exportinfo *exi)
 
 		if (rw_tryupgrade(&exi->exi_cache_lock) == 0) {
 			rw_exit(&exi->exi_cache_lock);
-			rw_enter(&exi->exi_cache_lock, RW_WRITER);
+			exi_cache_clnt_reclaim_failed++;
+			continue;
 		}
 
 		for (c = avl_first(tree); c != NULL; c = nextc) {

--- a/usr/src/uts/common/fs/nfs/nfs_auth.c
+++ b/usr/src/uts/common/fs/nfs/nfs_auth.c
@@ -1450,7 +1450,7 @@ exi_cache_trim(struct exportinfo *exi)
 			 * We are being called by the kmem subsystem to reclaim
 			 * memory so don't block if we can't get the lock.
 			 */
-			if (rw_tryenter(&exi->exi_cache_lock, RW_WRITER) == 0) {
+			if (rw_tryenter(&c->authc_lock, RW_WRITER) == 0) {
 				exi_cache_auth_reclaim_failed++;
 				return;
 			}


### PR DESCRIPTION
Reviewed by: Paul Dagnelie pcd@delphix.com
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Sebastien Roy sebastien.roy@delphix.com

When the system runs low on memory it will invoke kmem_reap() to reap
all the kmem caches. The reaping processes each cache serially, first
calling the reclaim callback. We have seen a couple of caches where the
reclaim callback can block the reaping thread for a significant amount
of time. The stack looks like this:

```
ffffff00d2417c40 SLEEP    RWLOCK                  1
             swtch+0x141
             turnstile_block+0x262
             rw_enter_sleep+0x21d
             exi_cache_trim+0x40
             exi_cache_reclaim+0x40
             kmem_cache_reap+0x3b
             taskq_thread+0x2d0
             thread_start+8
```

Since the reaping is treated like a queue it's not possible to reap any
other caches until we're finished reclaiming the exi_cache[s]. The
exi_cache_trim() function is trying to grab the rw lock as writer and
has to wait for all readers to finish processing any work. The problem
is that the threads holding the rw lock as reader may end up getting
stuck waiting on an allocation. It would make more sense to make this a
best effort attempt and only process the reclaim if we're able to obtain
the rw lock as writer.

The reclaim callback should call rw_tryenter() instead of blocking. This
will ensure that we don't block the main thread which is trying to free
memory.
