### PR TITLE
6459 cstyle doesn't detect opening braces on the same line as function header

### DIFF
--- a/usr/src/cmd/zoneadmd/zcons.c
+++ b/usr/src/cmd/zoneadmd/zcons.c
@@ -511,7 +511,7 @@ destroy_console_sock(int servfd)
  */
 static int
 get_client_ident(int clifd, pid_t *pid, char *locale, size_t locale_len,
-	int *disconnect)
+    int *disconnect)
 {
 	char buf[BUFSIZ], *bufp;
 	size_t buflen = sizeof (buf);
@@ -575,7 +575,7 @@ get_client_ident(int clifd, pid_t *pid, char *locale, size_t locale_len,
 
 static int
 accept_client(int servfd, pid_t *pid, char *locale, size_t locale_len,
-	int *disconnect)
+    int *disconnect)
 {
 	int connfd;
 	struct sockaddr_un cliaddr;

--- a/usr/src/common/net/wanboot/p12aux.h
+++ b/usr/src/common/net/wanboot/p12aux.h
@@ -44,8 +44,9 @@ extern "C" {
  *
  * My apologies.
  */
-/* CSTYLED */
+/* BEGIN CSTYLED */
 DECLARE_STACK_OF(EVP_PKEY)
+/* END CSTYLED */
 
 #define	sk_EVP_PKEY_new_null() SKM_sk_new_null(EVP_PKEY)
 #define	sk_EVP_PKEY_free(st) SKM_sk_free(EVP_PKEY, (st))

--- a/usr/src/tools/scripts/cstyle.pl
+++ b/usr/src/tools/scripts/cstyle.pl
@@ -24,6 +24,8 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2015 by Delphix. All rights reserved.
+#
 # @(#)cstyle 1.58 98/09/09 (from shannon)
 #
 # cstyle - check for some common stylistic errors.
@@ -239,6 +241,7 @@ my $comment_done = 0;
 my $in_warlock_comment = 0;
 my $in_function = 0;
 my $in_function_header = 0;
+my $function_header_full_indent = 0;
 my $in_declaration = 0;
 my $note_level = 0;
 my $nextok = 0;
@@ -384,6 +387,7 @@ line: while (<$filehandle>) {
 		$in_function = 1;
 		$in_declaration = 1;
 		$in_function_header = 0;
+		$function_header_full_indent = 0;
 		$prev = $line;
 		next line;
 	}
@@ -396,8 +400,43 @@ line: while (<$filehandle>) {
 		$prev = $line;
 		next line;
 	}
-	if (/^\w*\($/) {
+	if ($in_function_header && ! /^    \w/ ) {
+		if (/^{}$/) {
+			$in_function_header = 0;
+			$function_header_full_indent = 0;
+		} elsif ($picky && ! (/^\t/ && $function_header_full_indent != 0)) {
+			err("continuation line should be indented by 4 spaces");
+		}
+	}
+
+	#
+	# If this matches something of form "foo(", it's probably a function
+	# definition, unless it ends with ") bar;", in which case it's a declaration
+	# that uses a macro to generate the type.
+	#
+	if (/^\w+\(/ && !/\) \w+;$/) {
 		$in_function_header = 1;
+		if (/\($/) {
+			$function_header_full_indent = 1;
+		}
+	}
+	if ($in_function_header && /^{$/) {
+		$in_function_header = 0;
+		$function_header_full_indent = 0;
+		$in_function = 1;
+	}
+	if ($in_function_header && /\);$/) {
+		$in_function_header = 0;
+		$function_header_full_indent = 0;
+	}
+	if ($in_function_header && /{$/ ) {
+		if ($picky == 1) {
+			err("opening brace on same line as function header");
+		}
+		$in_function_header = 0;
+		$function_header_full_indent = 0;
+		$in_function = 1;
+		next line;
 	}
 
 	if ($in_warlock_comment && /\*\//) {


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Alex Reece <alex@delphix.com>

Our style guidelines require that the opening brace of a function
definition be on the line after the header, but the cstyle script
doesn't check it.

Additionally, if a function has a very long header, it is split onto to
two lines.  These continuation lines are supposed to be indented by four
spaces, not a tab. However, cstyle does not verify that this is the
case.

This change updates the regular expressions to correctly detect these
cases.