### PR TITLE
ASSERT supported zio_types for file and disk vdevs

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -796,6 +796,8 @@ vdev_disk_io_start(zio_t *zio)
 		return;
 	}
 
+	ASSERT(zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE);
+
 	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
 
 	vb->vb_io = zio;

--- a/usr/src/uts/common/fs/zfs/vdev_file.c
+++ b/usr/src/uts/common/fs/zfs/vdev_file.c
@@ -211,6 +211,8 @@ vdev_file_io_start(zio_t *zio)
 		return;
 	}
 
+	ASSERT(zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE);
+
 	vb = kmem_alloc(sizeof (vdev_buf_t), KM_SLEEP);
 
 	vb->vb_io = zio;


### PR DESCRIPTION
ASSERT the type of zio's processed by file and disk vdevs, which helps protect against invalid zio being processed by these vdev types e.g. on FreeBSD which uses ZIO_TYPE_FREE for TRIM support.

This was included in FreeBSD at part of r274619 (Nov 17 2014).