### PR TITLE
6527 Possible access beyond end of string in zpool comment

### DIFF
--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -590,7 +590,6 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 					error = SET_ERROR(EINVAL);
 					break;
 				}
-				check++;
 			}
 			if (strlen(strval) > ZPROP_MAX_COMMENT)
 				error = E2BIG;


### PR DESCRIPTION
The 'check' pointer is incremented in both the for-loop's update statement,
as well as, in the body of the loop. This means only every second character
is actually checked for low-ascii, and potentially, bytes beyond the
string's null-terminator can be attempted to be accessed.