### PR TITLE
6543 Fix memory leak in uu_avl_pool_destroy

### DIFF
--- a/usr/src/lib/libuutil/common/uu_avl.c
+++ b/usr/src/lib/libuutil/common/uu_avl.c
@@ -128,6 +128,7 @@ uu_avl_pool_destroy(uu_avl_pool_t *pp)
 	pp->uap_next->uap_prev = pp->uap_prev;
 	pp->uap_prev->uap_next = pp->uap_next;
 	(void) pthread_mutex_unlock(&uu_apool_list_lock);
+	(void) pthread_mutex_destroy(&pp->uap_lock);
 	pp->uap_prev = NULL;
 	pp->uap_next = NULL;
 	uu_free(pp);


### PR DESCRIPTION
Built and tested on illumos/illumos-gate.  I ran the ZFS test suite before and after and there were no regressions.