### PR TITLE
6465 zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_007_pos is broken

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/cleanup.ksh
@@ -27,19 +27,13 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
-function destroy_upgraded_pools {
-	for config in $CONFIGS; do
-		POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_NAME)
-		POOL_FILES=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_FILES)
-		poolexists $POOL_NAME && log_must $ZPOOL destroy -f $POOL_NAME
-	done
-}
-
-destroy_upgraded_pools
+for config in $CONFIGS; do
+	destroy_upgraded_pool $config
+done
 
 default_cleanup

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
@@ -26,9 +26,8 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
-
-. $STF_SUITE/include/libtest.shlib
 
 # The following variable names describe files, stored as gzip compressed files
 # in the test directory which can be used to construct a pool of a given
@@ -36,130 +35,127 @@
 # ZPOOL_VERSION_$var_FILES describes the files the pool is made from, and
 # ZPOOL_VERSION_$var_NAME describes the pool name.
 
-# Version 1 pools
-export ZPOOL_VERSION_1_FILES="zfs-pool-v1.dat"
-export ZPOOL_VERSION_1_NAME="v1-pool"
+# v1 pools
+ZPOOL_VERSION_1_FILES="zfs-pool-v1.dat"
+ZPOOL_VERSION_1_NAME="v1-pool"
 # v1 stripe
-export ZPOOL_VERSION_1stripe_FILES="zfs-pool-v1stripe1.dat \
+ZPOOL_VERSION_1stripe_FILES="zfs-pool-v1stripe1.dat \
 zfs-pool-v1stripe2.dat  zfs-pool-v1stripe3.dat"
-export ZPOOL_VERSION_1stripe_NAME="pool-v1stripe"
+ZPOOL_VERSION_1stripe_NAME="pool-v1stripe"
 # v1 raidz
-export ZPOOL_VERSION_1raidz_FILES="zfs-pool-v1raidz1.dat zfs-pool-v1raidz2.dat \
+ZPOOL_VERSION_1raidz_FILES="zfs-pool-v1raidz1.dat zfs-pool-v1raidz2.dat \
 zfs-pool-v1raidz3.dat"
-export ZPOOL_VERSION_1raidz_NAME="pool-v1raidz"
+ZPOOL_VERSION_1raidz_NAME="pool-v1raidz"
 # v1 mirror
-export ZPOOL_VERSION_1mirror_FILES="zfs-pool-v1mirror1.dat \
-zfs-pool-v1mirror2.dat zfs-pool-v1mirror3.dat"
-export ZPOOL_VERSION_1mirror_NAME="pool-v1mirror"
+ZPOOL_VERSION_1mirror_FILES="zfs-pool-v1mirror1.dat zfs-pool-v1mirror2.dat \
+zfs-pool-v1mirror3.dat"
+ZPOOL_VERSION_1mirror_NAME="pool-v1mirror"
 
-
-# Version 2 pools
-export ZPOOL_VERSION_2_FILES="zfs-pool-v2.dat"
-export ZPOOL_VERSION_2_NAME="v2-pool"
+# v2 pools
+ZPOOL_VERSION_2_FILES="zfs-pool-v2.dat"
+ZPOOL_VERSION_2_NAME="v2-pool"
 # v2 stripe
-export ZPOOL_VERSION_2stripe_FILES="zfs-pool-v2stripe1.dat \
-zfs-pool-v2stripe2.dat  zfs-pool-v2stripe3.dat"
-export ZPOOL_VERSION_2stripe_NAME="pool-v2stripe"
+ZPOOL_VERSION_2stripe_FILES="zfs-pool-v2stripe1.dat zfs-pool-v2stripe2.dat \
+zfs-pool-v2stripe3.dat"
+ZPOOL_VERSION_2stripe_NAME="pool-v2stripe"
 # v2 raidz
-export ZPOOL_VERSION_2raidz_FILES="zfs-pool-v2raidz1.dat zfs-pool-v2raidz2.dat \
+ZPOOL_VERSION_2raidz_FILES="zfs-pool-v2raidz1.dat zfs-pool-v2raidz2.dat \
 zfs-pool-v2raidz3.dat"
-export ZPOOL_VERSION_2raidz_NAME="pool-v2raidz"
+ZPOOL_VERSION_2raidz_NAME="pool-v2raidz"
 # v2 mirror
-export ZPOOL_VERSION_2mirror_FILES="zfs-pool-v2mirror1.dat \
-zfs-pool-v2mirror2.dat zfs-pool-v2mirror3.dat"
-export ZPOOL_VERSION_2mirror_NAME="pool-v2mirror"
+ZPOOL_VERSION_2mirror_FILES="zfs-pool-v2mirror1.dat zfs-pool-v2mirror2.dat \
+zfs-pool-v2mirror3.dat"
+ZPOOL_VERSION_2mirror_NAME="pool-v2mirror"
 
-
-# This is a v3 pool
-export ZPOOL_VERSION_3_FILES="zfs-pool-v3.dat"
-export ZPOOL_VERSION_3_NAME="v3-pool"
+# v3 pools
+ZPOOL_VERSION_3_FILES="zfs-pool-v3.dat"
+ZPOOL_VERSION_3_NAME="v3-pool"
 # v3 stripe
-export ZPOOL_VERSION_3stripe_FILES="zfs-pool-v3stripe1.dat \
-zfs-pool-v3stripe2.dat  zfs-pool-v3stripe3.dat"
-export ZPOOL_VERSION_3stripe_NAME="pool-v3stripe"
+ZPOOL_VERSION_3stripe_FILES="zfs-pool-v3stripe1.dat zfs-pool-v3stripe2.dat \
+zfs-pool-v3stripe3.dat"
+ZPOOL_VERSION_3stripe_NAME="pool-v3stripe"
 # v3 raidz
-export ZPOOL_VERSION_3raidz_FILES="zfs-pool-v3raidz1.dat zfs-pool-v3raidz2.dat \
+ZPOOL_VERSION_3raidz_FILES="zfs-pool-v3raidz1.dat zfs-pool-v3raidz2.dat \
 zfs-pool-v3raidz3.dat"
-export ZPOOL_VERSION_3raidz_NAME="pool-v3raidz"
+ZPOOL_VERSION_3raidz_NAME="pool-v3raidz"
 # v3 mirror
-export ZPOOL_VERSION_3mirror_FILES="zfs-pool-v3mirror1.dat \
-zfs-pool-v3mirror2.dat zfs-pool-v3mirror3.dat"
-export ZPOOL_VERSION_3mirror_NAME="pool-v3mirror"
+ZPOOL_VERSION_3mirror_FILES="zfs-pool-v3mirror1.dat zfs-pool-v3mirror2.dat \
+zfs-pool-v3mirror3.dat"
+ZPOOL_VERSION_3mirror_NAME="pool-v3mirror"
 # v3 raidz2
-export ZPOOL_VERSION_3dblraidz_FILES="zfs-pool-v3raidz21.dat \
-zfs-pool-v3raidz22.dat zfs-pool-v3raidz23.dat"
-export ZPOOL_VERSION_3dblraidz_NAME="pool-v3raidz2"
+ZPOOL_VERSION_3dblraidz_FILES="zfs-pool-v3raidz21.dat zfs-pool-v3raidz22.dat \
+zfs-pool-v3raidz23.dat"
+ZPOOL_VERSION_3dblraidz_NAME="pool-v3raidz2"
 # v3 hotspares
-export ZPOOL_VERSION_3hotspare_FILES="zfs-pool-v3hotspare1.dat \
+ZPOOL_VERSION_3hotspare_FILES="zfs-pool-v3hotspare1.dat \
 zfs-pool-v3hotspare2.dat zfs-pool-v3hotspare3.dat"
-export ZPOOL_VERSION_3hotspare_NAME="pool-v3hotspare"
+ZPOOL_VERSION_3hotspare_NAME="pool-v3hotspare"
 
 # v4 pool
-export ZPOOL_VERSION_4_FILES="zfs-pool-v4.dat"
-export ZPOOL_VERSION_4_NAME="v4-pool"
+ZPOOL_VERSION_4_FILES="zfs-pool-v4.dat"
+ZPOOL_VERSION_4_NAME="v4-pool"
 
 # v5 pool
-export ZPOOL_VERSION_5_FILES="zfs-pool-v5.dat"
-export ZPOOL_VERSION_5_NAME="v5-pool"
+ZPOOL_VERSION_5_FILES="zfs-pool-v5.dat"
+ZPOOL_VERSION_5_NAME="v5-pool"
 
 # v6 pool
-export ZPOOL_VERSION_6_FILES="zfs-pool-v6.dat"
-export ZPOOL_VERSION_6_NAME="v6-pool"
+ZPOOL_VERSION_6_FILES="zfs-pool-v6.dat"
+ZPOOL_VERSION_6_NAME="v6-pool"
 
 # v7 pool
-export ZPOOL_VERSION_7_FILES="zfs-pool-v7.dat"
-export ZPOOL_VERSION_7_NAME="v7-pool"
+ZPOOL_VERSION_7_FILES="zfs-pool-v7.dat"
+ZPOOL_VERSION_7_NAME="v7-pool"
 
 # v8 pool
-export ZPOOL_VERSION_8_FILES="zfs-pool-v8.dat"
-export ZPOOL_VERSION_8_NAME="v8-pool"
+ZPOOL_VERSION_8_FILES="zfs-pool-v8.dat"
+ZPOOL_VERSION_8_NAME="v8-pool"
 
 # v9 pool
-export ZPOOL_VERSION_9_FILES="zfs-pool-v9.dat"
-export ZPOOL_VERSION_9_NAME="v9-pool"
+ZPOOL_VERSION_9_FILES="zfs-pool-v9.dat"
+ZPOOL_VERSION_9_NAME="v9-pool"
 
 # v10 pool
-export ZPOOL_VERSION_10_FILES="zfs-pool-v10.dat"
-export ZPOOL_VERSION_10_NAME="v10-pool"
+ZPOOL_VERSION_10_FILES="zfs-pool-v10.dat"
+ZPOOL_VERSION_10_NAME="v10-pool"
 
 # v11 pool
-export ZPOOL_VERSION_11_FILES="zfs-pool-v11.dat"
-export ZPOOL_VERSION_11_NAME="v11-pool"
+ZPOOL_VERSION_11_FILES="zfs-pool-v11.dat"
+ZPOOL_VERSION_11_NAME="v11-pool"
 
 # v12 pool
-export ZPOOL_VERSION_12_FILES="zfs-pool-v12.dat"
-export ZPOOL_VERSION_12_NAME="v12-pool"
+ZPOOL_VERSION_12_FILES="zfs-pool-v12.dat"
+ZPOOL_VERSION_12_NAME="v12-pool"
 
 # v13 pool
-export ZPOOL_VERSION_13_FILES="zfs-pool-v13.dat"
-export ZPOOL_VERSION_13_NAME="v13-pool"
+ZPOOL_VERSION_13_FILES="zfs-pool-v13.dat"
+ZPOOL_VERSION_13_NAME="v13-pool"
 
 # v14 pool
-export ZPOOL_VERSION_14_FILES="zfs-pool-v14.dat"
-export ZPOOL_VERSION_14_NAME="v14-pool"
+ZPOOL_VERSION_14_FILES="zfs-pool-v14.dat"
+ZPOOL_VERSION_14_NAME="v14-pool"
 
 # v15 pool
-export ZPOOL_VERSION_15_FILES="zfs-pool-v15.dat"
-export ZPOOL_VERSION_15_NAME="v15-pool"
+ZPOOL_VERSION_15_FILES="zfs-pool-v15.dat"
+ZPOOL_VERSION_15_NAME="v15-pool"
 
-# This pool is a v2 pool, with device problems on one side of the mirror
+# v2 pool, with device problems on one side of the mirror
 # so that the pool appears as DEGRADED
-export ZPOOL_VERSION_2brokenmirror_FILES="zfs-broken-mirror1.dat \
+ZPOOL_VERSION_2brokenmirror_FILES="zfs-broken-mirror1.dat \
 zfs-broken-mirror2.dat"
-export ZPOOL_VERSION_2brokenmirror_NAME="zfs-broken-mirror"
+ZPOOL_VERSION_2brokenmirror_NAME="zfs-broken-mirror"
 
-
-# This pool is a v999 pool (an unknown version) which can be used to check
-# whether upgrade, import or other tests that should fail against unknown
-# pool versions should fail. It should not be listed in the CONFIGS
-# variable below, as these are pool versions that can be imported and upgraded
-export ZPOOL_VERSION_9999_FILES="zfs-pool-v999.dat"
-export ZPOOL_VERSION_9999_NAME="v999-pool"
-
+# v999 pool (an unknown version) which can be used to check whether upgrade,
+# import or other tests that should fail against unknown pool version.
+# It should not be listed in the CONFIGS variable below, as these are pool
+# versions that can be imported and upgraded.
+ZPOOL_VERSION_9999_FILES="zfs-pool-v999.dat"
+ZPOOL_VERSION_9999_NAME="v999-pool"
 
 # This is a list of pool configurations we should be able to upgrade from,
 # each entry should have corresponding ZPOOL_VERSION_*_FILES and
 # ZPOOL_VERSION_*_NAME variables defined above.
-export CONFIGS="1 1stripe 1raidz 1mirror \
+CONFIGS="1 1stripe 1raidz 1mirror \
 2 2stripe 2raidz 2mirror 2brokenmirror \
-3 3stripe 3raidz 3mirror 3dblraidz 3hotspare 4 5 6 7 8 9 10 11 12 13 14 15"
+3 3stripe 3raidz 3mirror 3dblraidz 3hotspare \
+4 5 6 7 8 9 10 11 12 13 14 15"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
@@ -26,6 +26,7 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -41,24 +42,22 @@
 # $1 a version number we can use to get information about the pool
 function create_old_pool
 {
-	VERSION=$1
-	POOL_FILES=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_FILES)
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_NAME)
+	typeset vers=$1
+	typeset -n pool_files=ZPOOL_VERSION_${vers}_FILES
+	typeset -n pool_name=ZPOOL_VERSION_${vers}_NAME
 
-	log_note "Creating $POOL_NAME from $POOL_FILES"
-	for pool_file in $POOL_FILES; do
+	log_note "Creating $pool_name from $pool_files"
+	for pool_file in $pool_files; do
 		log_must $BZCAT \
 		    $STF_SUITE/tests/functional/cli_root/zpool_upgrade/blockfiles/$pool_file.bz2 \
 		    >/$TESTPOOL/$pool_file
 	done
-	log_must $ZPOOL import -d /$TESTPOOL $POOL_NAME
+	log_must $ZPOOL import -d /$TESTPOOL $pool_name
 
-	# Now put some random contents into the pool.
-	COUNT=0
-	while [ $COUNT -lt 1024 ]; do
-		$DD if=/dev/urandom of=/$POOL_NAME/random.$COUNT \
-		count=1 bs=1024 > /dev/null 2>&1
-		COUNT=$(( $COUNT + 1 ))
+	# Put some random contents into the pool
+	for i in {1..1024} ; do
+		$DD if=/dev/urandom of=/$pool_name/random.$i \
+		    count=1 bs=1024 > /dev/null 2>&1
 	done
 }
 
@@ -68,35 +67,37 @@ function create_old_pool
 # not using "zpool status -x" to see if the pool is healthy, as it's possible
 # to also upgrade faulted, or degraded pools.
 # $1 a version number we can use to get information about the pool
-function check_upgrade {
-	VERSION=$1
-	POOL_FILES=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_FILES)
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_NAME)
+function check_upgrade
+{
+	typeset vers=$1
+	typeset -n pool_files=ZPOOL_VERSION_${vers}_FILES
+	typeset -n pool_name=ZPOOL_VERSION_${vers}_NAME
+	typeset pre_upgrade_checksum
+	typeset post_upgrade_checksum
 
-	log_note "Checking if we can upgrade from ZFS version ${VERSION}."
-	PRE_UPGRADE_CHECKSUM=$(check_pool $POOL_NAME pre )
-	log_must $ZPOOL upgrade $POOL_NAME > /dev/null
-	POST_UPGRADE_CHECKSUM=$(check_pool $POOL_NAME post )
+	log_note "Checking if we can upgrade from ZFS version $vers"
+	pre_upgrade_checksum=$(check_pool $pool_name pre)
+	log_must $ZPOOL upgrade $pool_name
+	post_upgrade_checksum=$(check_pool $pool_name post)
 
 	log_note "Checking that there are no differences between checksum output"
-	log_must $DIFF $PRE_UPGRADE_CHECKSUM $POST_UPGRADE_CHECKSUM
-	$RM $PRE_UPGRADE_CHECKSUM $POST_UPGRADE_CHECKSUM
+	log_must $DIFF $pre_upgrade_checksum $post_upgrade_checksum
+	$RM $pre_upgrade_checksum $post_upgrade_checksum
 }
 
 # A function to destroy an upgraded pool, plus the files it was based on.
 # $1 a version number we can use to get information about the pool
-function destroy_upgraded_pool {
-	VERSION=$1
-	POOL_FILES=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_FILES)
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${VERSION}_NAME)
+function destroy_upgraded_pool
+{
+	typeset vers=$1
+	typeset -n pool_files=ZPOOL_VERSION_${vers}_FILES
+	typeset -n pool_name=ZPOOL_VERSION_${vers}_NAME
 
-	if poolexists $POOL_NAME; then
-		log_must $ZPOOL destroy $POOL_NAME
+	if poolexists $pool_name; then
+		log_must $ZPOOL destroy $pool_name
 	fi
-	for file in $POOL_FILES; do
-		if [ -e /$TESTPOOL/$file ]; then
-			$RM /$TESTPOOL/$file
-		fi
+	for file in $pool_files; do
+		$RM -f /$TESTPOOL/$file
 	done
 }
 
@@ -106,37 +107,36 @@ function destroy_upgraded_pool {
 # $1 the name of the pool
 # $2 a flag we can use to determine when this check is being performed
 #    (ie. pre or post pool-upgrade)
-function check_pool { # pool state
-	POOL=$1
-	STATE=$2
-	$FIND /$POOL -type f -exec $CKSUM {} + > \
-		/$TESTPOOL/pool-checksums.$POOL.$STATE
-	echo /$TESTPOOL/pool-checksums.$POOL.$STATE
+function check_pool
+{
+	typeset pool=$1
+	typeset flag=$2
+	$FIND /$pool -type f -exec $CKSUM {} + > \
+		/$TESTPOOL/pool-checksums.$pool.$flag
+	echo /$TESTPOOL/pool-checksums.$pool.$flag
 }
 
 # This function simply checks that a pool has a particular version number
 # as reported by zdb and zpool upgrade -v
 # $1 the name of the pool
 # $2 the version of the pool we expect to see
-function check_poolversion { # pool version
-
-	POOL=$1
-	VERSION=$2
+function check_poolversion
+{
+	typeset pool=$1
+	typeset vers=$2
+	typeset actual
 
 	# check version using zdb
-	ACTUAL=$($ZDB -C $POOL | $SED -n 's/version: \(.*\)$/\1/p')
-
-	if [ $ACTUAL != $VERSION ]
-	then
-		log_fail "$POOL not upgraded, ver. $ACTUAL, expected $VERSION"
+	actual=$($ZDB -C $pool | $SED -n 's/^.*version: \(.*\)$/\1/p')
+	if [[ $actual != $vers ]] ; then
+		log_fail "$pool: zdb reported version $actual, expected $vers"
 	fi
 
 	# check version using zpool upgrade
-	ACTUAL=$($ZPOOL upgrade | $GREP $POOL$ | \
-	 $AWK '{print $1}' | $SED -e 's/ //g')
-	if [ $ACTUAL != $VERSION ]
-	then
-		log_fail "$POOL reported version $ACTUAL, expected $VERSION"
+	actual=$($ZPOOL upgrade | $GREP $pool$ | \
+	    $AWK '{print $1}' | $SED -e 's/ //g')
+	if [[ $actual != $vers ]] ; then
+		log_fail "$pool: zpool reported version $actual, expected $vers"
 	fi
 }
 
@@ -146,17 +146,15 @@ function check_poolversion { # pool version
 # can accept as the upper bound.
 # $1 lower bound
 # $2 upper bound
-function random { # min max
+function random
+{
+	typeset min=$1
+	typeset max=$2
+	typeset rand=0
 
-	typeset MIN=$1
-	typeset MAX=$2
-	typeset RAND=0
-
-	while [ $RAND -lt $MIN ]
-	do
-		RAND=$(( $RANDOM % $MAX + 1))
+	while [[ $rand -lt $min ]] ; do
+		rand=$(( $RANDOM % $max + 1))
 	done
 
-	echo $RAND
+	echo $rand
 }
-

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_001_pos.ksh
@@ -27,10 +27,10 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
 # DESCRIPTION:
@@ -45,7 +45,7 @@
 
 verify_runnable "global"
 
-log_assert "Executing 'zpool upgrade -v' command succeeds."
+log_assert "Executing 'zpool upgrade -v' command succeeds"
 
 log_must $ZPOOL upgrade -v
 
@@ -63,9 +63,9 @@ $ZPOOL upgrade -v > /tmp/zpool-versions.$$
 #  10  Cache devices
 #
 for version in {1..28}; do
-	log_note "Checking for a description of pool version $version."
+	log_note "Checking for a description of pool version $version"
 	log_must eval "$AWK '/^ $version / { print $1 }' /tmp/zpool-versions.$$ | $GREP $version"
 done
 $RM /tmp/zpool-versions.$$
 
-log_pass "Executing 'zpool upgrade -v' command succeeds."
+log_pass "Executing 'zpool upgrade -v' command succeeds"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_002_pos.ksh
@@ -24,9 +24,11 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
@@ -45,15 +47,13 @@ function cleanup
 	destroy_upgraded_pool $config
 }
 
-log_assert "Import pools of all versions - zpool upgrade on each pools works"
+log_assert "Import pools of all versions - zpool upgrade on each pool works"
 log_onexit cleanup
 
-# $CONFIGS gets set in the .cfg script
-for config in $CONFIGS
-do
+for config in $CONFIGS; do
     create_old_pool $config
     check_upgrade $config
     destroy_upgraded_pool $config
 done
 
-log_pass "Import pools of all versions - zpool upgrade on each pools works"
+log_pass "Import pools of all versions - zpool upgrade on each pool works"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_003_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_003_pos.ksh
@@ -24,9 +24,11 @@
 # Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
@@ -45,13 +47,13 @@ function cleanup
 	destroy_upgraded_pool 1
 }
 
-log_assert "Upgrading a pool that has already been upgraded succeeds."
+log_assert "Upgrading a pool that has already been upgraded succeeds"
 log_onexit cleanup
 
-# we just create a version 1 pool here
+# Create a version 1 pool
 create_old_pool 1
 check_upgrade 1
 check_upgrade 1
 destroy_upgraded_pool 1
 
-log_pass "Upgrading a pool that has already been upgraded succeeds."
+log_pass "Upgrading a pool that has already been upgraded succeeds"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_004_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_004_pos.ksh
@@ -27,9 +27,9 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
@@ -45,7 +45,7 @@ verify_runnable "global"
 
 function cleanup
 {
-	for config in $CONFIGS ; do
+	for config in $CONFIGS; do
 		destroy_upgraded_pool $config
 	done
 }
@@ -55,15 +55,12 @@ log_onexit cleanup
 
 TEST_POOLS=
 # Now build all of our pools
-for config in $CONFIGS
-do
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${config}_NAME)
+for config in $CONFIGS; do
+	typeset -n pool_name=ZPOOL_VERSION_${config}_NAME
 
-	TEST_POOLS="$TEST_POOLS $POOL_NAME"
+	TEST_POOLS="$TEST_POOLS $pool_name"
 	create_old_pool $config
-	# a side effect of the check_pool here, is that we get a checksum written
-	# called /$TESTPOOL/pool-checksums.$POOL.pre
-	check_pool $POOL_NAME pre > /dev/null
+	check_pool $pool_name pre > /dev/null
 done
 
 # upgrade them all at once
@@ -72,18 +69,14 @@ log_must $ZPOOL upgrade -a
 unset __ZFS_POOL_RESTRICT
 
 # verify their contents then destroy them
-for config in $CONFIGS
-do
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${config}_NAME)
+for config in $CONFIGS ; do
+	typeset -n pool_name=ZPOOL_VERSION_${config}_NAME
 
-	check_pool $POOL_NAME post > /dev/null
-
-	# a side effect of the check_pool here, is that we get a checksum written
-	# called /$TESTPOOL/pool-checksums.$POOL_NAME.post
-	log_must $DIFF /$TESTPOOL/pool-checksums.$POOL_NAME.pre \
-		/$TESTPOOL/pool-checksums.$POOL_NAME.post
-
-	$RM /$TESTPOOL/pool-checksums.$POOL_NAME.pre /$TESTPOOL/pool-checksums.$POOL_NAME.post
+	check_pool $pool_name post > /dev/null
+	log_must $DIFF /$TESTPOOL/pool-checksums.$pool_name.pre \
+	    /$TESTPOOL/pool-checksums.$pool_name.post
+	$RM /$TESTPOOL/pool-checksums.$pool_name.pre \
+	    /$TESTPOOL/pool-checksums.$pool_name.post
 	destroy_upgraded_pool $config
 done
 

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_005_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_005_neg.ksh
@@ -27,10 +27,10 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
 # DESCRIPTION:
@@ -43,19 +43,12 @@
 
 verify_runnable "global"
 
-set -A args "/tmp" "-?" "-va" "-v fakepool" "-a fakepool"
+log_assert "Variations of upgrade -v print usage message," \
+    "return with non-zero status"
 
-log_assert "Variations of upgrade -v print usage message, \
- return with non-zero status"
-
-typeset -i i=0
-
-while [[ $i -lt ${#args[*]} ]]; do
-
-        log_mustnot $ZPOOL upgrade ${args[$i]} > /dev/null
-
-        (( i = i + 1 ))
+for arg in "/tmp" "-?" "-va" "-v fakepool" "-a fakepool" ; do
+        log_mustnot $ZPOOL upgrade $arg
 done
 
-log_pass "Variations of upgrade -v print usage message, \
- return with non-zero status"
+log_pass "Variations of upgrade -v print usage message," \
+    "return with non-zero status"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_006_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_006_neg.ksh
@@ -27,34 +27,31 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
-. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.cfg
+. $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
 # DESCRIPTION:
 # Attempting to upgrade a non-existent pool will return an error
 #
 # STRATEGY:
-# 1. Verify a pool doesn't exist, then try to upgrade it
-# 2. Verify a 0 exit status
+# 1. Compose non-existent pool name, try to upgrade it
+# 2. Verify non-zero exit status
 #
 
 log_assert "Attempting to upgrade a non-existent pool will return an error"
-NO_POOL=notapool
-FOUND=""
 
-while [ -z "$FOUND" ]
-do
-   $ZPOOL list $NO_POOL 2>&1 > /dev/null
-   if [ $? -ne 0 ]
-   then
-      FOUND="true"
-      log_mustnot $ZPOOL upgrade $NO_POOL
-   else
-      NO_POOL="${NO_POOL}x"
-   fi
+NO_POOL=notapool
+
+while true ; do
+	if poolexists $NO_POOL ; then
+		NO_POOL="${NO_POOL}x"
+	else
+		log_mustnot $ZPOOL upgrade $NO_POOL
+		break
+	fi
 done
 
 log_pass "Attempting to upgrade a non-existent pool will return an error"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_007_pos.ksh
@@ -27,9 +27,9 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 . $STF_SUITE/tests/functional/cli_root/zfs_upgrade/zfs_upgrade.kshlib
 
@@ -53,17 +53,16 @@ function cleanup
 	destroy_upgraded_pool $config
 }
 
-log_assert "Import pools of all versions - 'zfs upgrade' on each pools works"
+log_assert "Import pools of all versions - 'zfs upgrade' on each pool works"
 log_onexit cleanup
 
 # $CONFIGS gets set in the .cfg script
-for config in $CONFIGS
-do
-	create_old_pool $config
-	POOL_NAME=$(eval $ECHO \$ZPOOL_VERSION_${config}_NAME)
+for config in $CONFIGS; do
+	typeset -n pool_name=ZPOOL_VERSION_${config}_NAME
 
-	default_check_zfs_upgrade $pool
+	create_old_pool $config
+	default_check_zfs_upgrade $pool_name
 	destroy_upgraded_pool $config
 done
 
-log_pass "Import pools of all versions - 'zfs upgrade' on each pools works"
+log_pass "Import pools of all versions - 'zfs upgrade' on each pool works"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_008_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_008_pos.ksh
@@ -27,15 +27,15 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
 # DESCRIPTION:
 #
-# Zpool upgrade should be able to upgrade pools to a given version using -V
+# zpool upgrade should be able to upgrade pools to a given version using -V
 #
 # STRATEGY:
 # 1. For all versions pools that can be upgraded on a given OS version
@@ -50,30 +50,30 @@ verify_runnable "global"
 
 function cleanup
 {
-	destroy_upgraded_pool $config
+	destroy_upgraded_pool $ver_old
 }
 
-log_assert \
- "Zpool upgrade should be able to upgrade pools to a given version using -V"
+log_assert "zpool upgrade should be able to upgrade pools to a given version" \
+    "using -V"
 
 log_onexit cleanup
 
 # We're just using the single disk version of the pool, which should be
 # enough to determine if upgrade works correctly. Also set a MAX_VER
 # variable, which specifies the highest version that we should expect
-# a zpool upgrade operation to succeed from. (latest version - 1)
-CONFIGS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
+# a zpool upgrade operation to succeed from.
+VERSIONS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15"
 MAX_VER=15
 
-for config in $CONFIGS
-do
-        create_old_pool $config
-	pool=$(eval $ECHO \$ZPOOL_VERSION_${config}_NAME)
-	NEXT=$(random $config $MAX_VER)
-	log_must $ZPOOL upgrade -V $NEXT $pool
-        check_poolversion $pool $NEXT
-        destroy_upgraded_pool $config
+for ver_old in $VERSIONS; do
+	typeset -n pool_name=ZPOOL_VERSION_${ver_old}_NAME
+	typeset ver_new=$(random $ver_old $MAX_VER)
+
+	create_old_pool $ver_old
+	log_must $ZPOOL upgrade -V $ver_new $pool_name > /dev/null
+	check_poolversion $pool_name $ver_new
+	destroy_upgraded_pool $ver_old
 done
 
-log_pass "zpool upgrade should be able to upgrade pools to a given version " \
+log_pass "zpool upgrade should be able to upgrade pools to a given version" \
     "using -V"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_009_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade_009_neg.ksh
@@ -27,15 +27,15 @@
 
 #
 # Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
-. $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
 
 #
 # DESCRIPTION:
 #
-# Zpool upgrade -V shouldn't be able to upgrade a pool to an unknown version
+# zpool upgrade -V shouldn't be able to upgrade a pool to an unknown version
 #
 # STRATEGY:
 # 1. Take an existing pool
@@ -50,21 +50,17 @@ function cleanup
 	destroy_upgraded_pool $config
 }
 
-log_assert \
-"Zpool upgrade -V shouldn't be able to upgrade a pool to an unknown version"
+log_assert "zpool upgrade -V shouldn't be able to upgrade a pool to" \
+    "unknown version"
 
-# Create a version 2 pool
 typeset -i config=2
+typeset -n pool_name=ZPOOL_VERSION_${config}_NAME
+
 create_old_pool $config
-pool=$(eval $ECHO \$ZPOOL_VERSION_${config}_NAME)
-
-# Attempt to upgrade it
-log_mustnot $ZPOOL upgrade -V 999 $pool
+log_mustnot $ZPOOL upgrade -V 999 $pool_name
 log_mustnot $ZPOOL upgrade -V 999
-
-# Verify we're still on the old version
-check_poolversion $pool $config
+check_poolversion $pool_name $config
 destroy_upgraded_pool $config
 
-log_pass \
- "Zpool upgrade -V shouldn't be able to upgrade a pool to an unknown version"
+log_pass "zpool upgrade -V shouldn't be able to upgrade a pool to" \
+    "unknown version"


### PR DESCRIPTION
Moving this review here as well. It was updated according to John's comments.

This fixes the zpool_upgrade_007_pos test case. I have done some cleanup
for zpool_upgrade test cases as well, using variable indirect references
(which seem cleaner than using eval), making variables local to
functions, fixing messages, etc.