### PR TITLE
6642 testrunner output can be displayed in the wrong order

### DIFF
--- a/usr/src/test/test-runner/cmd/run.py
+++ b/usr/src/test/test-runner/cmd/run.py
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 import ConfigParser
@@ -277,8 +277,10 @@ class Cmd(object):
         else:
             logger.debug('%s%s%s' % (msga, pad, msgb))
 
-        lines = self.result.stdout + self.result.stderr
-        for dt, line in sorted(lines):
+        lines = sorted(self.result.stdout + self.result.stderr,
+                       cmp=lambda x, y: cmp(x[0], y[0]))
+
+        for dt, line in lines:
             logger.debug('%s %s' % (dt.strftime("%H:%M:%S.%f ")[:11], line))
 
         if len(self.result.stdout):
@@ -291,7 +293,7 @@ class Cmd(object):
                     os.write(err.fileno(), '%s\n' % line)
         if len(self.result.stdout) and len(self.result.stderr):
             with open(os.path.join(self.outputdir, 'merged'), 'w') as merged:
-                for _, line in sorted(lines):
+                for _, line in lines:
                     os.write(merged.fileno(), '%s\n' % line)
 
 

--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
 #
 
@@ -72,10 +72,6 @@ function verify_id
 
 	sudo -n id >/dev/null 2>&1
 	[[ $? -eq 0 ]] || fail "User must be able to sudo without a password."
-
-	typeset -i priv_cnt=$(ppriv $$ | egrep -v \
-	    ": basic$|	L:| <none>|$$:" | wc -l)
-	[[ $priv_cnt -ne 0 ]] && fail "User must only have basic privileges."
 }
 
 function verify_disks
@@ -131,6 +127,7 @@ fi
 num_disks=$(echo $DISKS | awk '{print NF}')
 [[ $num_disks -lt 3 ]] && fail "Not enough disks to run ZFS Test Suite"
 
-$runner $quiet -c $runfile
+# Ensure user has only basic privileges.
+/usr/bin/ppriv -s EIP=basic -e $runner $quiet -c $runfile
 
 exit $?

--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -29,7 +29,7 @@ function fail
 
 function find_disks
 {
-	typeset all_disks=$(echo '' | sudo /usr/sbin/format | awk \
+	typeset all_disks=$(echo '' | sudo -k /usr/sbin/format | awk \
 	    '/c[0-9]/ {print $2}')
 	typeset used_disks=$(/sbin/zpool status | awk \
 	    '/c[0-9]*t[0-9a-f]*d[0-9]/ {print $1}' | sed 's/s[0-9]//g')
@@ -70,7 +70,7 @@ function verify_id
 {
 	[[ $(id -u) = "0" ]] && fail "This script must not be run as root."
 
-	sudo -n id >/dev/null 2>&1
+	sudo -k -n id >/dev/null 2>&1
 	[[ $? -eq 0 ]] || fail "User must be able to sudo without a password."
 }
 
@@ -78,7 +78,7 @@ function verify_disks
 {
 	typeset disk
 	for disk in $DISKS; do
-		sudo /usr/sbin/prtvtoc /dev/rdsk/${disk}s0 >/dev/null 2>&1
+		sudo -k /usr/sbin/prtvtoc /dev/rdsk/${disk}s0 >/dev/null 2>&1
 		[[ $? -eq 0 ]] || return 1
 	done
 	return 0


### PR DESCRIPTION
6643 zfstest should enforce the required privileges before running.

Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Jonathan Mackenzie <jonathan.mackenzie@delphix.com>

Lines of output that happen in the same hundredth of a second are
printed in alphabetical order, not the order in which they were
received.

Fix is to modify the sorting done on output lines to sort by timestamp,
but leave the lines in the order they arrived.

The script currently requires users to drop privs before running it. It
should just run the runner script with the required privs.

Fix is to always run the tests under ppriv.