### PR TITLE
6737 pbchk checks unmodified files

### DIFF
--- a/usr/src/tools/scripts/git-pbchk.py
+++ b/usr/src/tools/scripts/git-pbchk.py
@@ -19,6 +19,7 @@
 # Copyright 2008, 2012 Richard Lowe
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
 # Copyright (c) 2014, Joyent, Inc.
+# Copyright (c) 2015 by Delphix. All rights reserved.
 #
 
 import getopt
@@ -163,7 +164,9 @@ def git_file_list(parent, paths=None):
 
     ret = set()
     for fname in p:
-        if fname and not fname.isspace() and fname not in ret:
+        res = git("diff %s HEAD %s" % (parent, fname))
+        empty = not res.readline()
+        if fname and not fname.isspace() and fname not in ret and not empty:
             ret.add(fname.strip())
 
     return ret


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Alex Reece <alex@delphix.com>

pbchk attempts to detect which files have changed so that it can tell us
which files to update copyright for. This ends up including all files
that have been touched at all, including ones where all changes have
been reverted. This can be resolved by squashing commits together in the
git log, but fixing this in pbchk itself would be preferable.

Upstream-bugs: TOOL-921