### PR TITLE
6754, 6580 zfs-tests cleanup fixes

### DIFF
--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -22,10 +22,8 @@
 #
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
-#
-
-#
 # Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+# Copyright 2016 Nexenta Systems, Inc.
 #
 
 . ${STF_TOOLS}/contrib/include/logapi.shlib
@@ -2297,21 +2295,6 @@ function get_rootpool
 	else
 		log_fail "This is not a zfsroot system."
 	fi
-}
-
-#
-# Get the sub string from specified source string
-#
-# $1 source string
-# $2 start position. Count from 1
-# $3 offset
-#
-function get_substr #src_str pos offset
-{
-	typeset pos offset
-
-	$ECHO $1 | \
-		$NAWK -v pos=$2 -v offset=$3 '{print substr($0, pos, offset)}'
 }
 
 #

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_aclmode_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_aclmode_001_pos.ksh
@@ -237,8 +237,8 @@ function check_new_acl # bit newmode isdir
 	typeset gbit
 	typeset ebit
 	typeset str=":"
-	gbit=$(get_substr $mode 2 1)
-	ebit=$(get_substr $mode 3 1)
+	gbit=${mode:1:1}
+	ebit=${mode:2:1}
 	if (( ((bits & 4)) == 0 )); then
 		if (( ((gbit & 4)) != 0 || \
 		    ((ebit & 4)) != 0 )); then
@@ -278,12 +278,12 @@ function build_new_acl # newmode isdir
 	typeset expect
 	if ((flag == 0)); then
 		prefix="owner@"
-		bit=$(get_substr $newmode 1 1)
+		bit=${newmode:0:1}
 		status=$(check_new_acl $bit $newmode $isdir)
 
 	else
 		prefix="group@"
-		bit=$(get_substr $newmode 2 1)
+		bit=${newmode:1:1}
 		status=$(check_new_acl $bit $newmode $isdir)
 	fi
 	expect=$prefix$status:deny
@@ -375,13 +375,13 @@ function verify_aclmode # <aclmode> <node> <newmode>
 					#
 					case $who in
 						owner@)
-							pos=1
+							pos=0
 							;;
 						group@)
-							pos=2
+							pos=1
 							;;
 						everyone@)
-							pos=3
+							pos=2
 							;;
 						user)
 							acltemp=${expect1#*:}
@@ -390,35 +390,33 @@ function verify_aclmode # <aclmode> <node> <newmode>
 							group=$(get_group $node)
 							if [[ $acltemp == \
 							    $owner ]]; then
-								pos=1
+								pos=0
 							else
-								pos=2
+								pos=1
 							fi
 							prefix=$prefix:$acltemp
 							;;
 						group)
 							acltemp=${expect1#*:}
 							acltemp=${acltemp%%:*}
-							pos=2
+							pos=1
 							prefix=$prefix:$acltemp
 							reduce=1
 							;;
 					esac
-					obits=$(get_substr $newmode $pos 1)
+					obits=${newmode:$pos:1}
 					((bits = $obits))
 					#
-					# permission should no greater than the
+					# permission should be no greater than the
 					# group permission bits
 					#
 					if ((reduce != 0)); then
-						((bits &= \
-						    $(get_substr $newmode 2 1)))
+						((bits &= ${newmode:1:1}))
 					# The ACL permissions are reduced so
 					# that they are no greater than owner
 					# permission bits.
 
-						((bits_owner = \
-						    $(get_substr $newmode 1 1)))
+						((bits_owner = ${newmode:0:1}))
 						((bits &= $bits_owner))
 					fi
 

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_inherit_003_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_inherit_003_pos.ksh
@@ -124,18 +124,18 @@ function verify_inherit #<aclinherit> <object> [strategy]
 	log_must usr_exec $TOUCH $nfile1 $nfile2 $nfile3
 
 	# Get the files which inherited ACE.
-	if [[ $(get_substr $obj 1 1) == f ]]; then
+	if [[ ${obj:0:1} == "f" ]]; then
 		inherit_nodes="$inherit_nodes $nfile1"
 
-		if [[ $(get_substr $str 2 1) != n ]]; then
+		if [[ ${str:1:1} != "n" ]]; then
 			inherit_nodes="$inherit_nodes $nfile2 $nfile3"
 		fi
 	fi
 	# Get the directores which inherited ACE.
-	if [[ $(get_substr $obj 2 1) == d ]]; then
+	if [[ ${obj:1:1} == "d" ]]; then
 		inherit_nodes="$inherit_nodes $ndir1"
 
-		if [[ $(get_substr $str 2 1) != n ]]; then
+		if [[ ${str:1:1} != "n" ]]; then
 			inherit_nodes="$inherit_nodes $ndir2 $ndir3"
 		fi
 	fi
@@ -212,7 +212,7 @@ function verify_inherit #<aclinherit> <object> [strategy]
 				inh=${acltemp##*:}
 
 				if [[ -d $node ]]; then
-					if [[ $(get_substr $inh 4 1) == n ]]; then
+					if [[ ${inh:3:1} == "n" ]]; then
 
 						#
 						# if no_propagate is set,
@@ -223,7 +223,7 @@ function verify_inherit #<aclinherit> <object> [strategy]
 						step=0
 						expect1=""
 
-					elif [[ $(get_substr $inh 3 1) != i ]]; then
+					elif [[ ${inh:2:1} != "i" ]]; then
 
 						#
 						# directory should append

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_rwx_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_rwx_002_pos.ksh
@@ -107,7 +107,7 @@ function cal_bits #bits acl_access acl_type
 	set -A bit r w x
 
 	typeset tmpbits=""
-	typeset -i i=0 j
+	typeset -i i=0
 	while (( i < 3 )); do
 		if [[ $acl_access == *"${a_access[i]}"* ]]; then
 			if [[ $acl_type == "allow" ]]; then
@@ -116,8 +116,7 @@ function cal_bits #bits acl_access acl_type
 				tmpbits="${tmpbits}-"
 			fi
 		else
-			(( j = i + 1 ))
-			tmpbits="$tmpbits$(get_substr $bits $j 1)"
+			tmpbits="$tmpbits${bits:$i:1}"
 		fi
 
 		(( i += 1 ))
@@ -139,7 +138,7 @@ function check_test_result #init_mode node acl_flag acl_access a_type
 	typeset acl_type=$5
 
 	typeset -L3 u_bits=$init_mode
-	typeset g_bits=$(get_substr $init_mode 4 3)
+	typeset g_bits=${init_mode:3:3}
 	typeset -R3 o_bits=$init_mode
 
 	if [[ $acl_flag == "owner" || $acl_flag == "everyone" ]]; then
@@ -153,7 +152,7 @@ function check_test_result #init_mode node acl_flag acl_access a_type
 	fi
 
 	typeset cur_mode=$(get_mode $node)
-	cur_mode=$(get_substr $cur_mode 2 9)
+	cur_mode=${cur_mode:1:9}
 
 	if [[ $cur_mode == $u_bits$g_bits$o_bits ]]; then
 		log_note "SUCCESS: Current map($cur_mode) == " \
@@ -192,7 +191,7 @@ function test_chmod_map #<node>
 	for operator in "A0+" "A0="; do
 		log_must usr_exec $CHMOD $init_mask $node
 		init_mode=$(get_mode $node)
-		init_mode=$(get_substr $init_mode 2 9)
+		init_mode=${init_mode:1:9}
 		log_must usr_exec eval "$LS -vd $node > $orig_ace"
 
 		# To "A=", firstly add one ACE which can't modify map

--- a/usr/src/test/zfs-tests/tests/functional/cache/cache.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cache/cache.kshlib
@@ -88,13 +88,6 @@ function verify_cache_device
 			"<status> [type]"
 	fi
 
-	if [[ $WRAPPER == *"smi"* ]]; then
-		$ECHO $device | $EGREP "^c[0-F]+([td][0-F]+)+$" > /dev/null 2>&1
-		if (( $? == 0 )); then
-			device=${device}s2
-		fi
-	fi
-
 	#
 	# Get all the cache devices and status table like below
 	#

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
@@ -67,12 +67,7 @@ PREVDUMPDEV=`$DUMPADM | $GREP "Dump device" | $AWK '{print $3}'`
 log_note "Zero $FS_DISK0 and place free space in to slice 0"
 log_must cleanup_devices $FS_DISK0
 
-if [[ $WRAPPER == *"smi"* ]]; then
-	diskslice="/dev/dsk/${FS_DISK0}s2"
-else
-	diskslice="/dev/dsk/${FS_DISK0}s0"
-fi
-
+diskslice="/dev/dsk/${FS_DISK0}s0"
 log_note "Configuring $diskslice as dump device"
 log_must $DUMPADM -d $diskslice > /dev/null
 

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
@@ -103,14 +103,7 @@ for num in 0 1 2; do
 	eval typeset slice=\${FS_SIDE$num}
 	disk=${slice%s*}
 	slice=${slice##*s}
-	if [[ $WRAPPER == *"smi"* && $disk == ${saved_disk} ]]; then
-		cyl=$(get_endslice $disk ${saved_slice})
-		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	else
-		log_must set_partition $slice "" $FS_SIZE $disk
-	fi
-	saved_disk=$disk
-	saved_slice=$slice
+	log_must set_partition $slice "" $FS_SIZE $disk
 done
 
 log_note "Make a ufs filesystem on source $rawdisk1"

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
@@ -82,15 +82,7 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%s*}
 		slice=${slice##*s}
-		if [[ $WRAPPER == *"smi"* && \
-			$disk == ${saved_disk} ]]; then
-			cyl=$(get_endslice $disk ${saved_slice})
-			log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		else
-			log_must set_partition $slice "" $FS_SIZE $disk
-		fi
-		saved_disk=$disk
-		saved_slice=$slice
+		log_must set_partition $slice "" $FS_SIZE $disk
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
@@ -85,15 +85,7 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%s*}
 		slice=${slice##*s}
-		if [[ $WRAPPER == *"smi"* && \
-			$disk == ${saved_disk} ]]; then
-			cyl=$(get_endslice $disk ${saved_slice})
-			log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		else
-			log_must set_partition $slice "" $FS_SIZE $disk
-		fi
-		saved_disk=$disk
-		saved_slice=$slice
+		log_must set_partition $slice "" $FS_SIZE $disk
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_007_pos.ksh
@@ -90,15 +90,7 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%s*}
 		slice=${slice##*s}
-		if [[ $WRAPPER == *"smi"* && \
-			$disk == ${saved_disk} ]]; then
-			cyl=$(get_endslice $disk ${saved_slice})
-			log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		else
-			log_must set_partition $slice "" $FS_SIZE $disk
-		fi
-		saved_disk=$disk
-		saved_slice=$slice
+		log_must set_partition $slice "" $FS_SIZE $disk
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_008_pos.ksh
@@ -83,15 +83,7 @@ for num in 0 1 2 3 ; do
 	eval typeset slice=\${FS_SIDE$num}
 	disk=${slice%s*}
 	slice=${slice##*s}
-	if [[ $WRAPPER == *"smi"* && \
-		$disk == ${saved_disk} ]]; then
-		cyl=$(get_endslice $disk ${saved_slice})
-		log_must set_partition $slice "$cyl" $FS_SIZE $disk
-	else
-		log_must set_partition $slice "" $FS_SIZE $disk
-	fi
-	saved_disk=$disk
-	saved_slice=$slice
+	log_must set_partition $slice "" $FS_SIZE $disk
 done
 
 while (( i < ${#vdevs[*]} )); do

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_009_pos.ksh
@@ -82,15 +82,7 @@ while (( i < ${#vdevs[*]} )); do
 		eval typeset slice=\${FS_SIDE$num}
 		disk=${slice%s*}
 		slice=${slice##*s}
-		if [[ $WRAPPER == *"smi"* && \
-			$disk == ${saved_disk} ]]; then
-			cyl=$(get_endslice $disk ${saved_slice})
-			log_must set_partition $slice "$cyl" $FS_SIZE $disk
-		else
-			log_must set_partition $slice "" $FS_SIZE $disk
-		fi
-		saved_disk=$disk
-		saved_slice=$slice
+		log_must set_partition $slice "" $FS_SIZE $disk
 	done
 
 	if [[ -n $SINGLE_DISK && -n ${vdevs[i]} ]]; then

--- a/usr/src/test/zfs-tests/tests/functional/slog/slog.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/slog/slog.kshlib
@@ -89,13 +89,6 @@ function verify_slog_device
 			"<status> [type]"
 	fi
 
-	if [[ $WRAPPER == *"smi"* ]]; then
-		$ECHO $device | $EGREP "^c[0-F]+([td][0-F]+)+$" > /dev/null 2>&1
-		if (( $? == 0 )); then
-			device=${device}s2
-		fi
-	fi
-
 	#
 	# Get all the slog devices and status table like below
 	#

--- a/usr/src/test/zfs-tests/tests/functional/utils_test/utils_test_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/utils_test/utils_test_007_pos.ksh
@@ -63,8 +63,6 @@ log_must $ZFS unmount $TESTDIR
 
 if ! $(is_physical_device $DISK); then
 	log_must $FSTYP $DISK
-elif [[ $WRAPPER == "smi" ]]; then
-	log_must $FSTYP /dev/rdsk/${DISK}s2
 else
 	log_must $FSTYP /dev/rdsk/${DISK}s0
 fi


### PR DESCRIPTION
Two simple zfs-tests cleanup fixes:

6580 zfs-tests use undefined variable WRAPPER
Remove the WRAPPER variable, which isn't set and isn't described anywhere - I *hope* that we don't need the smi logic anymore.

6754 zfs-tests: get_substr() function is redundant
Remove redundant get_substr() function and use ${string:start:len} built-in.