### PR TITLE
6871 libzpool implementation of thread_create should enforce length is 0

### DIFF
--- a/usr/src/lib/libzpool/common/kernel.c
+++ b/usr/src/lib/libzpool/common/kernel.c
@@ -69,10 +69,11 @@ struct proc p0;
  */
 /*ARGSUSED*/
 kthread_t *
-zk_thread_create(void (*func)(), void *arg)
+zk_thread_create(void (*func)(), void *arg, uint64_t len)
 {
 	thread_t tid;
 
+	ASSERT0(len);
 	VERIFY(thr_create(0, 0, (void *(*)(void *))func, arg, THR_DETACHED,
 	    &tid) == 0);
 

--- a/usr/src/lib/libzpool/common/sys/zfs_context.h
+++ b/usr/src/lib/libzpool/common/sys/zfs_context.h
@@ -180,7 +180,7 @@ extern int aok;
 typedef struct kthread kthread_t;
 
 #define	thread_create(stk, stksize, func, arg, len, pp, state, pri)	\
-	zk_thread_create(func, arg)
+	zk_thread_create(func, arg, len)
 #define	thread_exit() thr_exit(NULL)
 #define	thread_join(t)	panic("libzpool cannot join threads")
 
@@ -196,7 +196,7 @@ extern struct proc p0;
 
 #define	PS_NONE		-1
 
-extern kthread_t *zk_thread_create(void (*func)(), void *arg);
+extern kthread_t *zk_thread_create(void (*func)(), void *arg, uint64_t len);
 
 #define	issig(why)	(FALSE)
 #define	ISSIG(thr, why)	(FALSE)


### PR DESCRIPTION
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>

The thread_create function has a `length` parameter that is never used,
and ignored when passed in userland. The libzpool code should assert
length is 0 instead of ignoring it.

Upstream bugs: DLPX-39392