### PR TITLE
6865 want zfs-tests cases for zpool labelclear command

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
+ * Copyright 2016 Nexenta Systems, Inc.
  */
 
 #include <stdio.h>
@@ -119,7 +120,7 @@ static void
 usage(void)
 {
 	(void) fprintf(stderr,
-	    "Usage: %s [-CumMdibcsDvhLXFPAG] [-t txg] [-e [-p path...]] "
+	    "Usage: %s [-CmMdibcsDvhLXFPAG] [-t txg] [-e [-p path...]] "
 	    "[-U config] [-I inflight I/Os] [-x dumpdir] [-o var=value] "
 	    "poolname [object...]\n"
 	    "       %s [-divPA] [-e -p path...] [-U config] dataset "
@@ -129,7 +130,7 @@ usage(void)
 	    "       %s -R [-A] [-e [-p path...]] poolname "
 	    "vdev:offset:size[:flags]\n"
 	    "       %s -S [-PA] [-e [-p path...]] [-U config] poolname\n"
-	    "       %s -l [-uA] device\n"
+	    "       %s -l [-Aqu] device\n"
 	    "       %s -C [-A] [-U config]\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname);
 
@@ -140,7 +141,6 @@ usage(void)
 	(void) fprintf(stderr, "    If object numbers are specified, only "
 	    "those objects are dumped\n\n");
 	(void) fprintf(stderr, "    Options to control amount of output:\n");
-	(void) fprintf(stderr, "        -u uberblock\n");
 	(void) fprintf(stderr, "        -d dataset(s)\n");
 	(void) fprintf(stderr, "        -i intent logs\n");
 	(void) fprintf(stderr, "        -C config (or cachefile if alone)\n");
@@ -154,7 +154,7 @@ usage(void)
 	(void) fprintf(stderr, "        -D dedup statistics\n");
 	(void) fprintf(stderr, "        -S simulate dedup to measure effect\n");
 	(void) fprintf(stderr, "        -v verbose (applies to all others)\n");
-	(void) fprintf(stderr, "        -l dump label contents\n");
+	(void) fprintf(stderr, "        -l read label contents\n");
 	(void) fprintf(stderr, "        -L disable leak tracking (do not "
 	    "load spacemaps)\n");
 	(void) fprintf(stderr, "        -R read and display block from a "
@@ -185,6 +185,8 @@ usage(void)
 	    "exiting\n");
 	(void) fprintf(stderr, "        -o <variable>=<value> set global "
 	    "variable to an unsigned 32-bit integer value\n");
+	(void) fprintf(stderr, "        -q don't print label contents\n");
+	(void) fprintf(stderr, "        -u uberblock\n");
 	(void) fprintf(stderr, "Specify an option more than once (e.g. -bb) "
 	    "to make only that option verbose\n");
 	(void) fprintf(stderr, "Default is to dump everything non-verbosely\n");
@@ -2139,45 +2141,48 @@ dump_label_uberblocks(vdev_label_t *lbl, uint64_t ashift)
 	}
 }
 
-static void
+static int
 dump_label(const char *dev)
 {
 	int fd;
 	vdev_label_t label;
-	char *path, *buf = label.vl_vdev_phys.vp_nvlist;
+	char path[MAXPATHLEN];
+	char *buf = label.vl_vdev_phys.vp_nvlist;
 	size_t buflen = sizeof (label.vl_vdev_phys.vp_nvlist);
 	struct stat64 statbuf;
 	uint64_t psize, ashift;
-	int len = strlen(dev) + 1;
+	boolean_t label_found = B_FALSE;
 
-	if (strncmp(dev, ZFS_DISK_ROOTD, strlen(ZFS_DISK_ROOTD)) == 0) {
-		len++;
-		path = malloc(len);
-		(void) snprintf(path, len, "%s%s", ZFS_RDISK_ROOTD,
-		    dev + strlen(ZFS_DISK_ROOTD));
-	} else {
-		path = strdup(dev);
+	(void) strlcpy(path, dev, sizeof (path));
+	if (dev[0] == '/') {
+		if (strncmp(dev, ZFS_DISK_ROOTD,
+		    strlen(ZFS_DISK_ROOTD)) == 0) {
+			(void) snprintf(path, sizeof (path), "%s%s",
+			    ZFS_RDISK_ROOTD, dev + strlen(ZFS_DISK_ROOTD));
+		}
+	} else if (stat64(path, &statbuf) != 0) {
+		char *s;
+
+		(void) snprintf(path, sizeof (path), "%s%s", ZFS_RDISK_ROOTD,
+		    dev);
+		if ((s = strrchr(dev, 's')) == NULL || !isdigit(*(s + 1)))
+			(void) strlcat(path, "s0", sizeof (path));
 	}
 
-	if ((fd = open64(path, O_RDONLY)) < 0) {
-		(void) printf("cannot open '%s': %s\n", path, strerror(errno));
-		free(path);
-		exit(1);
-	}
-
-	if (fstat64(fd, &statbuf) != 0) {
+	if (stat64(path, &statbuf) != 0) {
 		(void) printf("failed to stat '%s': %s\n", path,
 		    strerror(errno));
-		free(path);
-		(void) close(fd);
 		exit(1);
 	}
 
 	if (S_ISBLK(statbuf.st_mode)) {
 		(void) printf("cannot use '%s': character device required\n",
 		    path);
-		free(path);
-		(void) close(fd);
+		exit(1);
+	}
+
+	if ((fd = open64(path, O_RDONLY)) < 0) {
+		(void) printf("cannot open '%s': %s\n", path, strerror(errno));
 		exit(1);
 	}
 
@@ -2187,36 +2192,43 @@ dump_label(const char *dev)
 	for (int l = 0; l < VDEV_LABELS; l++) {
 		nvlist_t *config = NULL;
 
-		(void) printf("--------------------------------------------\n");
-		(void) printf("LABEL %d\n", l);
-		(void) printf("--------------------------------------------\n");
+		if (!dump_opt['q']) {
+			(void) printf("------------------------------------\n");
+			(void) printf("LABEL %d\n", l);
+			(void) printf("------------------------------------\n");
+		}
 
 		if (pread64(fd, &label, sizeof (label),
 		    vdev_label_offset(psize, l, 0)) != sizeof (label)) {
-			(void) printf("failed to read label %d\n", l);
+			if (!dump_opt['q'])
+				(void) printf("failed to read label %d\n", l);
 			continue;
 		}
 
 		if (nvlist_unpack(buf, buflen, &config, 0) != 0) {
-			(void) printf("failed to unpack label %d\n", l);
+			if (!dump_opt['q'])
+				(void) printf("failed to unpack label %d\n", l);
 			ashift = SPA_MINBLOCKSHIFT;
 		} else {
 			nvlist_t *vdev_tree = NULL;
 
-			dump_nvlist(config, 4);
+			if (!dump_opt['q'])
+				dump_nvlist(config, 4);
 			if ((nvlist_lookup_nvlist(config,
 			    ZPOOL_CONFIG_VDEV_TREE, &vdev_tree) != 0) ||
 			    (nvlist_lookup_uint64(vdev_tree,
 			    ZPOOL_CONFIG_ASHIFT, &ashift) != 0))
 				ashift = SPA_MINBLOCKSHIFT;
 			nvlist_free(config);
+			label_found = B_TRUE;
 		}
 		if (dump_opt['u'])
 			dump_label_uberblocks(&label, ashift);
 	}
 
-	free(path);
 	(void) close(fd);
+
+	return (label_found ? 0 : 2);
 }
 
 static uint64_t dataset_feature_count[SPA_FEATURES];
@@ -3587,7 +3599,7 @@ main(int argc, char **argv)
 		spa_config_path = spa_config_path_env;
 
 	while ((c = getopt(argc, argv,
-	    "bcdhilmMI:suCDRSAFLXx:evp:t:U:PGo:")) != -1) {
+	    "bcdhilmMI:suCDRSAFLXx:evp:t:U:PGo:q")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -3613,6 +3625,7 @@ main(int argc, char **argv)
 		case 'X':
 		case 'e':
 		case 'P':
+		case 'q':
 			dump_opt[c]++;
 			break;
 		case 'I':
@@ -3720,10 +3733,8 @@ main(int argc, char **argv)
 		usage();
 	}
 
-	if (dump_opt['l']) {
-		dump_label(argv[0]);
-		return (0);
-	}
+	if (dump_opt['l'])
+		return (dump_label(argv[0]));
 
 	if (dump_opt['X'] || dump_opt['F'])
 		rewind = ZPOOL_DO_REWIND |

--- a/usr/src/man/man1m/zdb.1m
+++ b/usr/src/man/man1m/zdb.1m
@@ -12,14 +12,15 @@
 .\"
 .\" Copyright 2012, Richard Lowe.
 .\" Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+.\" Copyright 2016 Nexenta Systems, Inc.
 .\"
-.TH "ZDB" "1M" "Feb 4, 2016" "" ""
+.TH "ZDB" "1M" "April 9, 2016"
 
 .SH "NAME"
 \fBzdb\fR - Display zpool debugging and consistency information
 
 .SH "SYNOPSIS"
-\fBzdb\fR [-CumdibcsDvhLMXFPAG] [-e [-p \fIpath\fR...]] [-t \fItxg\fR]
+\fBzdb\fR [-CmdibcsDvhLMXFPAG] [-e [-p \fIpath\fR...]] [-t \fItxg\fR]
     [-U \fIcache\fR] [-I \fIinflight I/Os\fR] [-x \fIdumpdir\fR]
     [-o \fIvar\fR=\fIvalue\fR] ... [\fIpoolname\fR [\fIobject\fR ...]]
 
@@ -39,7 +40,7 @@
 \fBzdb\fR -S [-AP] [-e [-p \fIpath\fR...]] [-U \fIcache\fR] \fIpoolname\fR
 
 .P
-\fBzdb\fR -l [-uA] \fIdevice\fR
+\fBzdb\fR -l [-Aqu] \fIdevice\fR
 
 .P
 \fBzdb\fR -C [-A] [-U \fIcache\fR]
@@ -176,8 +177,13 @@ transaction type.
 .ad
 .sp .6
 .RS 4n
-Display the vdev labels from the specified device. If the \fB-u\fR option is
-also specified, also display the uberblocks on this device.
+Read the vdev labels from the specified device. \fBzdb -l\fR will return 0 if
+valid label was found, 1 if error occured, and 2 if no valid labels were found.
+.P
+If the \fB-u\fR option is also specified, also display the uberblocks on this
+device.
+.P
+If the \fB-q\fR option is also specified, don't print the labels.
 .RE
 
 .sp

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -11,8 +11,8 @@
 
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
-# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2016 Nexenta Systems, Inc.
 #
 
 set name=pkg.fmri value=pkg:/system/test/zfstest@$(PKGVERS)
@@ -75,6 +75,7 @@ dir path=opt/zfs-tests/tests/functional/cli_root/zpool_get
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_history
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_import
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_import/blockfiles
+dir path=opt/zfs-tests/tests/functional/cli_root/zpool_labelclear
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_offline
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_online
 dir path=opt/zfs-tests/tests/functional/cli_root/zpool_remove
@@ -1295,6 +1296,15 @@ file \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg \
+    mode=0444
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_offline/cleanup \
     mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -272,6 +272,11 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
     'zpool_import_rename_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zpool_labelclear]
+tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/cli_root/zpool_offline]
 tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
 

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -269,6 +269,11 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
     'zpool_import_rename_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zpool_labelclear]
+tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/cli_root/zpool_offline]
 tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
 

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -269,6 +269,11 @@ tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_missing_002_pos', 'zpool_import_missing_003_pos',
     'zpool_import_rename_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zpool_labelclear]
+tests = ['zpool_labelclear_active', 'zpool_labelclear_exported']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/cli_root/zpool_offline]
 tests = ['zpool_offline_001_pos', 'zpool_offline_002_neg']
 

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
@@ -56,8 +56,8 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "add mirror fakepool" "add raidz fakepool" \
     "add raidz1 fakepool" "add raidz2 fakepool" \
     "setvprop" "blah blah" "-%" "--?" "-*" "-=" \
-    "-a" "-f" "-g" "-h" "-j" "-k" "-m" "-n" "-o" "-p" "-p /tmp" \
-    "-q" "-r" "-t" "-w" "-x" "-y" "-z" \
+    "-a" "-f" "-g" "-h" "-j" "-k" "-m" "-n" "-o" "-p" \
+    "-p /tmp" "-r" "-t" "-w" "-x" "-y" "-z" \
     "-D" "-E" "-G" "-H" "-I" "-J" "-K" "-M" \
     "-N" "-Q" "-R" "-S" "-T" "-V" "-W" "-Y" "-Z"
 

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+include		$(SRC)/Makefile.master
+
+ROOTOPTPKG=	$(ROOT)/opt/zfs-tests
+TARGETDIR=	$(ROOTOPTPKG)/tests/functional/cli_root/zpool_labelclear
+
+include		$(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
@@ -1,0 +1,26 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+typeset LABELCLEAR="zpool labelclear"
+typeset LABELREAD="zdb -lq"
+
+typeset disks=(${DISKS[*]})
+typeset disk1=${disks[0]}
+typeset disk2=${disks[1]}
+typeset disk3=${disks[2]}

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_active.ksh
@@ -1,0 +1,68 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+# Check that zpool labelclear will refuse to clear the label
+# (with or without -f) on any vdevs of the imported pool.
+#
+# STRATEGY:
+# 1. Create the pool with log device.
+# 2. Try clearing the label on data and log devices.
+# 3. Add auxilary (cache/spare) vdevs.
+# 4. Try clearing the label on auxilary vdevs.
+# 5. Check that zpool labelclear will return non-zero and
+#    labels are intact.
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear will fail on all vdevs of imported pool"
+
+# Create simple pool, skip any mounts
+log_must zpool create -O mountpoint=none -f $TESTPOOL $disk1 log $disk2
+
+# Check that labelclear [-f] will fail on ACTIVE pool vdevs
+log_mustnot $LABELCLEAR $disk1
+log_must $LABELREAD $disk1
+log_mustnot $LABELCLEAR -f $disk1
+log_must $LABELREAD $disk1
+log_mustnot $LABELCLEAR $disk2
+log_must $LABELREAD $disk2
+log_mustnot $LABELCLEAR -f $disk2
+log_must $LABELREAD $disk2
+
+# Add a cache/spare to the pool, check that labelclear [-f] will fail
+# on the vdev and will succeed once it's removed from pool config
+for vdevtype in "cache" "spare"; do
+	log_must zpool add $TESTPOOL $vdevtype $disk3
+	log_mustnot $LABELCLEAR $disk3
+	log_must $LABELREAD $disk3
+	log_mustnot $LABELCLEAR -f $disk3
+	log_must $LABELREAD $disk3
+	log_must zpool remove $TESTPOOL $disk3
+	log_must $LABELCLEAR $disk3
+	log_mustnot $LABELREAD $disk3
+done
+
+log_pass "zpool labelclear will fail on all vdevs of imported pool"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_labelclear/zpool_labelclear_exported.ksh
@@ -1,0 +1,74 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc.
+#
+
+. $STF_SUITE/tests/functional/cli_root/zpool_labelclear/labelclear.cfg
+
+# DESCRIPTION:
+# Check that zpool labelclear will refuse to clear the label
+# on ACTIVE vdevs of exported pool without -f, and will succeeded with -f.
+#
+# STRATEGY:
+# 1. Create a pool with log device.
+# 2. Export the pool.
+# 3. Check that zpool labelclear returns non-zero when trying to
+#    clear the label on ACTIVE vdevs, and succeeds with -f.
+# 4. Add auxilary vdevs (cache/spare).
+# 5. Check that zpool labelclear succeeds on auxilary vdevs of
+#    exported pool.
+
+verify_runnable "global"
+
+function cleanup
+{
+	poolexists $TESTPOOL && destroy_pool $TESTPOOL
+}
+
+log_onexit cleanup
+log_assert "zpool labelclear will fail on ACTIVE vdevs of exported pool and" \
+    "succeed with -f"
+
+for vdevtype in "" "cache" "spare"; do
+	# Create simple pool, skip any mounts
+	log_must zpool create -O mountpoint=none -f $TESTPOOL $disk1 log $disk2
+	# Add auxilary vdevs (cache/spare)
+	if [[ -n $vdevtype ]]; then
+		log_must zpool add $TESTPOOL $vdevtype $disk3
+	fi
+	# Export the pool
+	log_must zpool export $TESTPOOL
+
+	# Check that labelclear will fail without -f
+	log_mustnot $LABELCLEAR $disk1
+	log_must $LABELREAD $disk1
+	log_mustnot $LABELCLEAR $disk2
+	log_must $LABELREAD $disk2
+
+	# Check that labelclear will succeed with -f
+	log_must $LABELCLEAR -f $disk1
+	log_mustnot $LABELREAD $disk1
+	log_must $LABELCLEAR -f $disk2
+	log_mustnot $LABELREAD $disk2
+
+	# Check that labelclear on auxilary vdevs will succeed
+	if [[ -n $vdevtype ]]; then
+		log_must $LABELCLEAR $disk3
+		log_mustnot $LABELREAD $disk3
+	fi
+done
+
+log_pass "zpool labelclear will fail on ACTIVE vdevs of exported pool and" \
+    "succeed with -f"


### PR DESCRIPTION
This is still a WIP, and I'm interested in feedback at the moment.

To make the task simpler, I've done some changes to zdb (tracked as 6866):
- make it return 2 when it fails to find any valid label
- add '-q' option to supress printing label contents
- use the same logic as in the zpool labelclear command, allowing to use short vdev names (prepend /dev/rdsk, append s0 if needed), the current behavior with absolute paths should be unaffected

Back to the zfs-tests... Currently I've only added the tests for imported and exported pools. What's missing is "foreign" (or "potentially active") tests - I simply haven't found a way to create such pool - it will probably require modifying the vdev labels? Need help/hints/ideas here.

And any ideas for other tests I need to add are welcome as well.
