### PR TITLE
6876 Stack corruption after importing a pool with a too-long name

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -1785,7 +1785,12 @@ zpool_import_props(libzfs_handle_t *hdl, nvlist_t *config, const char *newname,
 		case EEXIST:
 			(void) zpool_standard_error(hdl, error, desc);
 			break;
-
+		case ENAMETOOLONG:
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "new name of at least one dataset is longer than "
+			    "the maximum allowable length"));
+			(void) zfs_error(hdl, EZFS_NAMETOOLONG, desc);
+			break;
 		default:
 			(void) zpool_standard_error(hdl, error, desc);
 			zpool_explain_recover(hdl,

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -92,6 +92,8 @@ function cleanup
 
 	[[ -d $ALTER_ROOT ]] && \
 		log_must $RM -rf $ALTER_ROOT
+	[[ -e $VDEV_FILE ]] && \
+		log_must $RM $VDEV_FILE
 }
 
 log_onexit cleanup
@@ -158,5 +160,14 @@ while (( i < ${#pools[*]} )); do
 
 	((i = i + 1))
 done
+
+VDEV_FILE=$(mktemp /tmp/tmp.XXXXXX)
+
+log_must truncate --size=128M $VDEV_FILE
+log_must $ZPOOL create testpool $VDEV_FILE
+log_must $ZFS create testpool/testfs
+log_must $ZPOOL export testpool
+ID=$($ZPOOL import | grep -A 1 "pool: testpool" | tail -n 1 | sed 's/.*id: //')
+log_mustnot $ZPOOL import $(echo $ID) $(python -c "print 'c' * 250")
 
 log_pass "Successfully imported and renamed a ZPOOL"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
@@ -163,11 +163,11 @@ done
 
 VDEV_FILE=$(mktemp /tmp/tmp.XXXXXX)
 
-log_must truncate --size=128M $VDEV_FILE
+log_must $MKFILE -n 128M $VDEV_FILE
 log_must $ZPOOL create testpool $VDEV_FILE
 log_must $ZFS create testpool/testfs
+ID=$($ZPOOL get -Ho value guid testpool)
 log_must $ZPOOL export testpool
-ID=$($ZPOOL import | grep -A 1 "pool: testpool" | tail -n 1 | sed 's/.*id: //')
-log_mustnot $ZPOOL import $(echo $ID) $(python -c "print 'c' * 250")
+log_mustnot $ZPOOL import $(echo $ID) $($PRINTF "%*s\n" 250 "" | $TR ' ' 'c')
 
 log_pass "Successfully imported and renamed a ZPOOL"

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -1904,6 +1904,19 @@ spa_load_verify_cb(spa_t *spa, zilog_t *zilog, const blkptr_t *bp,
 	return (0);
 }
 
+/* ARGSUSED */
+int
+verify_dataset_name_len(dsl_pool_t *dp, dsl_dataset_t *ds, void *arg)
+{
+	char namebuf[MAXPATHLEN];
+	dsl_dataset_name(ds, namebuf);
+	if (strlen(namebuf) > MAXNAMELEN) {
+		return (SET_ERROR(ENAMETOOLONG));
+	}
+
+	return (0);
+}
+
 static int
 spa_load_verify(spa_t *spa)
 {
@@ -1917,6 +1930,14 @@ spa_load_verify(spa_t *spa)
 
 	if (policy.zrp_request & ZPOOL_NEVER_REWIND)
 		return (0);
+
+	dsl_pool_config_enter(spa->spa_dsl_pool, FTAG);
+	error = dmu_objset_find_dp(spa->spa_dsl_pool,
+	    spa->spa_dsl_pool->dp_root_dir_obj, verify_dataset_name_len, NULL,
+	    DS_FIND_CHILDREN);
+	dsl_pool_config_exit(spa->spa_dsl_pool, FTAG);
+	if (error != 0)
+		return (error);
 
 	rio = zio_root(spa, NULL, &sle,
 	    ZIO_FLAG_CANFAIL | ZIO_FLAG_SPECULATIVE);


### PR DESCRIPTION
Reviewed by: Prakash Surya prakash.surya@delphix.com
Reviewed by: Dan Kimmel dan.kimmel@delphix.com
Reviewed by: George Wilson george.wilson@delphix.com

Calling dsl_dataset_name on a dataset with a 256 byte buffer is asking
for trouble. We should check every dataset on import, using a 1024 byte
buffer and checking each time to see if the dataset's new name is longer
than 256 bytes.

Upstream bugs: DLPX-18221
