### PR TITLE
7027 zfs_written_property_001_pos makes unreasonable assumptions abou…

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_property/zfs_written_property_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_property/zfs_written_property_001_pos.ksh
@@ -11,7 +11,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 #
@@ -63,11 +63,8 @@ typeset -l total=0
 typeset -l snap1_size=0
 typeset -l snap2_size=0
 typeset -l snap3_size=0
-typeset -l metadata=0
 typeset -l mb_block=0
 ((mb_block = 1024 * 1024))
-# approximate metadata on dataset when empty is 32KB
-((metadata = 32 * 1024))
 
 log_note "verify written property statistics for dataset"
 log_must $ZFS create -p $TESTPOOL/$TESTFS1/$TESTFS2/$TESTFS3
@@ -89,7 +86,10 @@ blocks=0
 for i in 1 2 3; do
 	written=$(get_prop written $TESTPOOL/$TESTFS1@snap$i)
 	if [[ $blocks -eq 0 ]]; then
-		expected_written=$metadata
+		# Written value for the frist non-clone snapshot is
+		# expected to be equal to the referenced value.
+		expected_written=$( \
+		    get_prop referenced $TESTPOOL/$TESTFS1@snap$i)
 	else
 		((expected_written = blocks * mb_block))
 	fi


### PR DESCRIPTION
…t metadata space usage

upstream:
commit a9dabe1d201e9ebf06db62c05f7388bb9620db61
Author: Akash Ayare <aayare@delphix.com>
Date:   Mon Aug 3 22:56:26 2015 +0000
    QA-2250 zfs_written_property_001_pos makes unreasonable assumptions about metadata space usage
