### PR TITLE
7072 zfs fails to expand if lun added when os is in shutdown state

### DIFF
--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -381,7 +381,13 @@ metaslab_class_expandable_space(metaslab_class_t *mc)
 			continue;
 		}
 
-		space += tvd->vdev_max_asize - tvd->vdev_asize;
+		/*
+		 * Calculate if we have enough space to add additional
+		 * metaslabs. We report the expandable space in terms
+		 * of the metaslab size since that's the unit of expansion.
+		 */
+		space += P2ALIGN(tvd->vdev_max_asize - tvd->vdev_asize,
+		    1ULL << tvd->vdev_ms_shift);
 	}
 	spa_config_exit(mc->mc_spa, SCL_VDEV, FTAG);
 	return (space);


### PR DESCRIPTION
upstream
f35989d64cdd913ace899f478a03b7e8f16a4ed8
38733 zfs fails to expand if lun added when os is in shutdown state
and
bc957393044fee4716cb027676b04fc25adfeb24
DLPX-39262 vdev_disk_open spam zfs_dbgmsg buffer
and
https://github.com/delphix/delphix-os/commit/5c91704f70876986db29c066f67d1c94d86eb941
DLPX-36910 spares and caches should not display expandable space