### PR TITLE
7083 create_ramdisk.sh need not check for inuse devices

### DIFF
--- a/usr/src/cmd/boot/scripts/create_ramdisk.ksh
+++ b/usr/src/cmd/boot/scripts/create_ramdisk.ksh
@@ -23,6 +23,10 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
 format=ufs
 ALT_ROOT=
 EXTRACT_ARGS=
@@ -255,7 +259,7 @@ function create_ufs
 		list="$list32"
 	fi
 
-	newfs $lofidev < /dev/null 2> /dev/null
+	NOINUSE_CHECK=1 newfs $lofidev < /dev/null 2> /dev/null
 	mkdir "$rdmnt"
 	mount -F mntfs mnttab /etc/mnttab > /dev/null 2>&1
 	mount -F ufs -o nologging $lofidev "$rdmnt"


### PR DESCRIPTION
Changes extracted from https://github.com/openzfs/openzfs/pull/105
