### PR TITLE
7087 assertion failed on dnode_sync_free(): avl_is_empty(dn_dbufs)

### DIFF
--- a/usr/src/uts/common/fs/zfs/dsl_pool.c
+++ b/usr/src/uts/common/fs/zfs/dsl_pool.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -579,6 +579,15 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 		ASSERT3U(spa_sync_pass(dp->dp_spa), ==, 1);
 		while ((dst = txg_list_remove(&dp->dp_sync_tasks, txg)) != NULL)
 			dsl_sync_task_sync(dst, tx);
+
+		/*
+		 * If we destroyed a dataset, we need to be sure that its
+		 * eviction callback is invoked so that its holds on other
+		 * objects (e.g. deadlist, bpobjs) are dropped before we
+		 * sync the deletion of those objects (from the next
+		 * sync pass's dsl_pool_sync_mos()).
+		 */
+		dmu_buf_user_evict_wait();
 	}
 
 	dmu_tx_commit(tx);


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com (@grwilson)
Reviewed by: Prakash Surya prakash.surya@delphix.com (@prakashsurya)

When syncing the free of a bpobj that was part of a dead list
(dnode_sync_free()), we find that it still has held dbufs. The bpobj is
still open. It should be closed by dsl_dataset_evict(). The user evict
func (dbu_evict_user = dsl_dataset_evict) was dispatched when
dsl_destroy_head_sync() released the last hold on the dataset's bonus
buffer. However, the task but not yet been executed by the taskq.

We can fix this by calling dmu_buf_user_evict_wait() after processing
sync tasks.

Upstream bug: DLPX-37660
