### PR TITLE
7085 add support for "if" and "else" statements in dtrace

### DIFF
--- a/usr/src/cmd/dtrace/test/cmd/scripts/dstyle.pl
+++ b/usr/src/cmd/dtrace/test/cmd/scripts/dstyle.pl
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2014 by Delphix. All rights reserved.
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
 #
 
 require 5.8.4;

--- a/usr/src/cmd/dtrace/test/cmd/scripts/dstyle.pl
+++ b/usr/src/cmd/dtrace/test/cmd/scripts/dstyle.pl
@@ -25,6 +25,10 @@
 # Use is subject to license terms.
 #
 
+#
+# Copyright (c) 2014 by Delphix. All rights reserved.
+#
+
 require 5.8.4;
 
 $PNAME = $0;
@@ -131,7 +135,8 @@ sub dstyle
 		}
 
 		if (!/^enum/ && !/^\t*struct/ && !/^\t*union/ && !/^typedef/ &&
-		    !/^translator/ && !/^provider/) {
+		    !/^translator/ && !/^provider/ && !/\tif / &&
+		    !/ else /) {
 			if (/[\w\s]+{/) {
 				err "left brace not on its own line";
 			}
@@ -141,7 +146,7 @@ sub dstyle
 			}
 		}
 
-		if (!/;$/) {
+		if (!/;$/ && !/\t*}$/ && !/ else /) {
 			if (/[\w\s]+}/) {
 				err "right brace not on its own line";
 			}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.else.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.else.d
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   "else" statement is executed
+ */
+
+BEGIN
+{
+	if (0) {
+		n = 1;
+	} else {
+		n = 0;
+	}
+	exit(n)
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.else.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.else.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if.d
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   "if" statement executes the correct body.
+ */
+
+BEGIN
+{
+	if (1) {
+		n = 0;
+	} else {
+		n = 1;
+	}
+	exit(n)
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if2.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if2.d
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   "if" statement executes the correct body.
+ *   parses single-statement, braceless bodies correctly.
+ */
+
+BEGIN
+{
+	if (1)
+		n = 0;
+	else
+		n = 1;
+	exit(n)
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if2.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if2.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_before_after.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_before_after.d
@@ -1,0 +1,46 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   statements before and after an if statement are executed.
+ */
+
+BEGIN
+{
+	i = 1;
+	if (1) {
+		i++;
+	} else {
+		i++;
+	}
+	i++;
+}
+
+BEGIN
+/i == 3/
+{
+	exit(0);
+}
+
+BEGIN
+/i != 3/
+{
+	exit(1);
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_before_after.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_before_after.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_nested.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_nested.d
@@ -1,0 +1,38 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   nested "if" statement executes the correct body.
+ */
+
+BEGIN
+{
+	if (0) {
+		exit(1);
+	} else {
+		if (0) {
+			exit(1);
+		} else {
+			exit(0);
+		}
+		exit(1);
+	}
+	exit(1);
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_nested.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_nested.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon.d
@@ -1,0 +1,30 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   "if" body without trailing semicolon parses correctly
+ */
+
+BEGIN
+{
+	if (1) {
+		exit(0)
+	}
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon2.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon2.d
@@ -1,0 +1,31 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
+ * ASSERTION:
+ *   "if" body without trailing semicolon parses correctly
+ */
+
+BEGIN
+{
+	if (1) {
+		i = 1;
+		exit(0)
+	}
+}

--- a/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon2.d
+++ b/usr/src/cmd/dtrace/test/tst/common/sugar/tst.if_trailing_semicolon2.d
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/lib/libdtrace/Makefile.com
+++ b/usr/src/lib/libdtrace/Makefile.com
@@ -20,7 +20,7 @@
 #
 #
 # Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2011, 2014 by Delphix. All rights reserved.
 #
 
 LIBRARY = libdtrace.a
@@ -38,6 +38,7 @@ LIBSRCS = \
 	dt_dof.c \
 	dt_error.c \
 	dt_errtags.c \
+	dt_sugar.c \
 	dt_handle.c \
 	dt_ident.c \
 	dt_inttab.c \

--- a/usr/src/lib/libdtrace/Makefile.com
+++ b/usr/src/lib/libdtrace/Makefile.com
@@ -20,7 +20,7 @@
 #
 #
 # Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2011, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2011, 2016 by Delphix. All rights reserved.
 #
 
 LIBRARY = libdtrace.a

--- a/usr/src/lib/libdtrace/common/dt_cc.c
+++ b/usr/src/lib/libdtrace/common/dt_cc.c
@@ -21,8 +21,8 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
  * Copyright 2015 Gary Mills
  */
 
@@ -118,7 +118,6 @@ static const dtrace_diftype_t dt_int_rtype = {
 
 static void *dt_compile(dtrace_hdl_t *, int, dtrace_probespec_t, void *,
     uint_t, int, char *const[], FILE *, const char *);
-
 
 /*ARGSUSED*/
 static int
@@ -2419,6 +2418,28 @@ dt_compile(dtrace_hdl_t *dtp, int context, dtrace_probespec_t pspec, void *arg,
 	}
 
 	/*
+	 * Perform sugar transformations (for "if" / "else") and replace the
+	 * existing clause chain with the new one.
+	 */
+	if (context == DT_CTX_DPROG) {
+		dt_node_t *dnp, *next_dnp;
+		dt_node_t *new_list = NULL;
+
+		for (dnp = yypcb->pcb_root->dn_list;
+		    dnp != NULL; dnp = next_dnp) {
+			/* remove this node from the list */
+			next_dnp = dnp->dn_list;
+			dnp->dn_list = NULL;
+
+			if (dnp->dn_kind == DT_NODE_CLAUSE)
+				dnp = dt_compile_sugar(dtp, dnp);
+			/* append node to the new list */
+			new_list = dt_node_link(new_list, dnp);
+		}
+		yypcb->pcb_root->dn_list = new_list;
+	}
+
+	/*
 	 * If we have successfully created a parse tree for a D program, loop
 	 * over the clauses and actions and instantiate the corresponding
 	 * libdtrace program.  If we are parsing a D expression, then we
@@ -2438,6 +2459,8 @@ dt_compile(dtrace_hdl_t *dtp, int context, dtrace_probespec_t pspec, void *arg,
 		for (; dnp != NULL; dnp = dnp->dn_list) {
 			switch (dnp->dn_kind) {
 			case DT_NODE_CLAUSE:
+				if (DT_TREEDUMP_PASS(dtp, 4))
+					dt_printd(dnp, stderr, 0);
 				dt_compile_clause(dtp, dnp);
 				break;
 			case DT_NODE_XLATOR:

--- a/usr/src/lib/libdtrace/common/dt_cc.c
+++ b/usr/src/lib/libdtrace/common/dt_cc.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
  * Copyright 2015 Gary Mills
  */

--- a/usr/src/lib/libdtrace/common/dt_grammar.y
+++ b/usr/src/lib/libdtrace/common/dt_grammar.y
@@ -23,8 +23,9 @@
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+
 /*
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  */
 
@@ -155,6 +156,8 @@
 %type	<l_node>	probe_specifier_list
 %type	<l_node>	probe_specifier
 %type	<l_node>	statement_list
+%type	<l_node>	statement_list_impl
+%type	<l_node>	statement_or_block
 %type	<l_node>	statement
 %type	<l_node>	declaration
 %type	<l_node>	init_declarator_list
@@ -317,9 +320,11 @@ probe_definition:
 				    "or actions following probe description\n");
 			}
 			$$ = dt_node_clause($1, NULL, NULL);
+			yybegin(YYS_CLAUSE);
 		}
 	|	probe_specifiers '{' statement_list '}' {
 			$$ = dt_node_clause($1, NULL, $3);
+			yybegin(YYS_CLAUSE);
 		}
 	|	probe_specifiers DT_TOK_DIV expression DT_TOK_EPRED {
 			dnerror($3, D_SYNTAX, "expected actions { } following "
@@ -328,6 +333,7 @@ probe_definition:
 	|	probe_specifiers DT_TOK_DIV expression DT_TOK_EPRED
 		    '{' statement_list '}' {
 			$$ = dt_node_clause($1, $3, $6);
+			yybegin(YYS_CLAUSE);
 		}
 	;
 
@@ -347,12 +353,30 @@ probe_specifier:
 	|	DT_TOK_INT   { $$ = dt_node_pdesc_by_id($1); }
 	;
 
-statement_list:	statement { $$ = $1; }
-	|	statement_list ';' statement { $$ = LINK($1, $3); }
+statement_list_impl: /* empty */ { $$ = NULL; }
+	|	statement_list_impl statement { $$ = LINK($1, $2); }
 	;
 
-statement:	/* empty */ { $$ = NULL; }
-	|	expression { $$ = dt_node_statement($1); }
+statement_list:
+		statement_list_impl { $$ = $1; }
+	|	statement_list_impl expression {
+			$$ = LINK($1, dt_node_statement($2));
+		}
+	;
+
+statement_or_block:
+		statement
+	|	'{' statement_list '}' { $$ = $2; }
+
+statement:	';' { $$ = NULL; }
+	|	expression ';' { $$ = dt_node_statement($1); }
+	|	DT_KEY_IF DT_TOK_LPAR expression DT_TOK_RPAR statement_or_block {
+			$$ = dt_node_if($3, $5, NULL);
+		}
+	|	DT_KEY_IF DT_TOK_LPAR expression DT_TOK_RPAR
+		statement_or_block DT_KEY_ELSE statement_or_block {
+			$$ = dt_node_if($3, $5, $7);
+		}
 	;
 
 argument_expression_list:

--- a/usr/src/lib/libdtrace/common/dt_grammar.y
+++ b/usr/src/lib/libdtrace/common/dt_grammar.y
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  */
 

--- a/usr/src/lib/libdtrace/common/dt_impl.h
+++ b/usr/src/lib/libdtrace/common/dt_impl.h
@@ -26,7 +26,7 @@
 
 /*
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
  */
 
 #ifndef	_DT_IMPL_H
@@ -320,6 +320,7 @@ struct dtrace_hdl {
 	int dt_indent;		/* recommended flow indent */
 	dtrace_epid_t dt_last_epid;	/* most recently consumed EPID */
 	uint64_t dt_last_timestamp;	/* most recently consumed timestamp */
+	boolean_t dt_has_sugar;	/* syntactic sugar used? */
 };
 
 /*

--- a/usr/src/lib/libdtrace/common/dt_impl.h
+++ b/usr/src/lib/libdtrace/common/dt_impl.h
@@ -26,7 +26,7 @@
 
 /*
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	_DT_IMPL_H

--- a/usr/src/lib/libdtrace/common/dt_open.c
+++ b/usr/src/lib/libdtrace/common/dt_open.c
@@ -115,9 +115,9 @@
 #define	DT_VERS_1_11	DT_VERSION_NUMBER(1, 11, 0)
 #define	DT_VERS_1_12	DT_VERSION_NUMBER(1, 12, 0)
 #define	DT_VERS_1_12_1	DT_VERSION_NUMBER(1, 12, 1)
-#define	DT_VERS_1_12_2	DT_VERSION_NUMBER(1, 12, 2)
-#define	DT_VERS_LATEST	DT_VERS_1_12_2
-#define	DT_VERS_STRING	"Sun D 1.12.2"
+#define	DT_VERS_1_13	DT_VERSION_NUMBER(1, 13, 0)
+#define	DT_VERS_LATEST	DT_VERS_1_13
+#define	DT_VERS_STRING	"Sun D 1.13"
 
 const dt_version_t _dtrace_versions[] = {
 	DT_VERS_1_0,	/* D API 1.0.0 (PSARC 2001/466) Solaris 10 FCS */
@@ -143,7 +143,7 @@ const dt_version_t _dtrace_versions[] = {
 	DT_VERS_1_11,	/* D API 1.11 */
 	DT_VERS_1_12,	/* D API 1.12 */
 	DT_VERS_1_12_1,	/* D API 1.12.1 */
-	DT_VERS_1_12_2,	/* D API 1.12.2 */
+	DT_VERS_1_13,	/* D API 1.13 */
 	0
 };
 

--- a/usr/src/lib/libdtrace/common/dt_open.c
+++ b/usr/src/lib/libdtrace/common/dt_open.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>

--- a/usr/src/lib/libdtrace/common/dt_open.c
+++ b/usr/src/lib/libdtrace/common/dt_open.c
@@ -115,8 +115,9 @@
 #define	DT_VERS_1_11	DT_VERSION_NUMBER(1, 11, 0)
 #define	DT_VERS_1_12	DT_VERSION_NUMBER(1, 12, 0)
 #define	DT_VERS_1_12_1	DT_VERSION_NUMBER(1, 12, 1)
-#define	DT_VERS_LATEST	DT_VERS_1_12_1
-#define	DT_VERS_STRING	"Sun D 1.12.1"
+#define	DT_VERS_1_12_2	DT_VERSION_NUMBER(1, 12, 2)
+#define	DT_VERS_LATEST	DT_VERS_1_12_2
+#define	DT_VERS_STRING	"Sun D 1.12.2"
 
 const dt_version_t _dtrace_versions[] = {
 	DT_VERS_1_0,	/* D API 1.0.0 (PSARC 2001/466) Solaris 10 FCS */
@@ -142,6 +143,7 @@ const dt_version_t _dtrace_versions[] = {
 	DT_VERS_1_11,	/* D API 1.11 */
 	DT_VERS_1_12,	/* D API 1.12 */
 	DT_VERS_1_12_1,	/* D API 1.12.1 */
+	DT_VERS_1_12_2,	/* D API 1.12.2 */
 	0
 };
 

--- a/usr/src/lib/libdtrace/common/dt_parser.c
+++ b/usr/src/lib/libdtrace/common/dt_parser.c
@@ -21,8 +21,8 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
- * Copyright (c) 2013 by Delphix. All rights reserved.
  */
 
 /*
@@ -2137,6 +2137,17 @@ dt_node_statement(dt_node_t *expr)
 }
 
 dt_node_t *
+dt_node_if(dt_node_t *pred, dt_node_t *acts, dt_node_t *else_acts)
+{
+	dt_node_t *dnp = dt_node_alloc(DT_NODE_IF);
+	dnp->dn_conditional = pred;
+	dnp->dn_body = acts;
+	dnp->dn_alternate_body = else_acts;
+
+	return (dnp);
+}
+
+dt_node_t *
 dt_node_pdesc_by_name(char *spec)
 {
 	dtrace_hdl_t *dtp = yypcb->pcb_hdl;
@@ -2205,7 +2216,6 @@ dt_node_clause(dt_node_t *pdescs, dt_node_t *pred, dt_node_t *acts)
 	dnp->dn_pred = pred;
 	dnp->dn_acts = acts;
 
-	yybegin(YYS_CLAUSE);
 	return (dnp);
 }
 
@@ -3197,8 +3207,9 @@ dt_cook_op2(dt_node_t *dnp, uint_t idflags)
 				dt_xcook_ident(lp, dhp, idkind, B_TRUE);
 			else
 				dt_xcook_ident(lp, dhp, idp->di_kind, B_FALSE);
-		} else
+		} else {
 			lp = dnp->dn_left = dt_node_cook(lp, 0);
+		}
 
 		/*
 		 * Switch op to '+' for *(E1 + E2) array mode in these cases:
@@ -3212,10 +3223,12 @@ dt_cook_op2(dt_node_t *dnp, uint_t idflags)
 			if (lp->dn_ident->di_kind == DT_IDENT_ARRAY) {
 				if (lp->dn_args != NULL)
 					op = DT_TOK_ADD;
-			} else if (!dt_ident_unref(lp->dn_ident))
+			} else if (!dt_ident_unref(lp->dn_ident)) {
 				op = DT_TOK_ADD;
-		} else if (lp->dn_kind != DT_NODE_AGG)
+			}
+		} else if (lp->dn_kind != DT_NODE_AGG) {
 			op = DT_TOK_ADD;
+		}
 	}
 
 	switch (op) {
@@ -3639,45 +3652,34 @@ asgn_common:
 
 	case DT_TOK_PTR:
 		/*
-		 * If the left-hand side of operator -> is the name "self",
-		 * then we permit a TLS variable to be created or referenced.
+		 * If the left-hand side of operator -> is one of the
+		 * scoping keywords, permit a local or thread
+		 * variable to be created or referenced.
 		 */
-		if (lp->dn_kind == DT_NODE_IDENT &&
-		    strcmp(lp->dn_string, "self") == 0) {
-			if (rp->dn_kind != DT_NODE_VAR) {
-				dt_xcook_ident(rp, dtp->dt_tls,
-				    DT_IDENT_SCALAR, B_TRUE);
+		if (lp->dn_kind == DT_NODE_IDENT) {
+			dt_idhash_t *dhp = NULL;
+
+			if (strcmp(lp->dn_string, "self") == 0) {
+				dhp = dtp->dt_tls;
+			} else if (strcmp(lp->dn_string, "this") == 0) {
+				dhp = yypcb->pcb_locals;
 			}
+			if (dhp != NULL) {
+				if (rp->dn_kind != DT_NODE_VAR) {
+					dt_xcook_ident(rp, dhp,
+					    DT_IDENT_SCALAR, B_TRUE);
+				}
 
-			if (idflags != 0)
-				rp = dt_node_cook(rp, idflags);
+				if (idflags != 0)
+					rp = dt_node_cook(rp, idflags);
 
-			dnp->dn_right = dnp->dn_left; /* avoid freeing rp */
-			dt_node_free(dnp);
-			return (rp);
-		}
-
-		/*
-		 * If the left-hand side of operator -> is the name "this",
-		 * then we permit a local variable to be created or referenced.
-		 */
-		if (lp->dn_kind == DT_NODE_IDENT &&
-		    strcmp(lp->dn_string, "this") == 0) {
-			if (rp->dn_kind != DT_NODE_VAR) {
-				dt_xcook_ident(rp, yypcb->pcb_locals,
-				    DT_IDENT_SCALAR, B_TRUE);
+				/* avoid freeing rp */
+				dnp->dn_right = dnp->dn_left;
+				dt_node_free(dnp);
+				return (rp);
 			}
-
-			if (idflags != 0)
-				rp = dt_node_cook(rp, idflags);
-
-			dnp->dn_right = dnp->dn_left; /* avoid freeing rp */
-			dt_node_free(dnp);
-			return (rp);
 		}
-
 		/*FALLTHRU*/
-
 	case DT_TOK_DOT:
 		lp = dnp->dn_left = dt_node_cook(lp, DT_IDFLG_REF);
 
@@ -4496,7 +4498,8 @@ static dt_node_t *(*dt_cook_funcs[])(dt_node_t *, uint_t) = {
 	dt_cook_xlator,		/* DT_NODE_XLATOR */
 	dt_cook_none,		/* DT_NODE_PROBE */
 	dt_cook_provider,	/* DT_NODE_PROVIDER */
-	dt_cook_none		/* DT_NODE_PROG */
+	dt_cook_none,		/* DT_NODE_PROG */
+	dt_cook_none,		/* DT_NODE_IF */
 };
 
 /*
@@ -4511,6 +4514,8 @@ dt_node_cook(dt_node_t *dnp, uint_t idflags)
 
 	yylineno = dnp->dn_line;
 
+	assert(dnp->dn_kind <
+	    sizeof (dt_cook_funcs) / sizeof (dt_cook_funcs[0]));
 	dnp = dt_cook_funcs[dnp->dn_kind](dnp, idflags);
 	dnp->dn_flags |= DT_NF_COOKED;
 
@@ -4611,6 +4616,181 @@ dt_node_diftype(dtrace_hdl_t *dtp, const dt_node_t *dnp, dtrace_diftype_t *tp)
 	    DIF_TF_BYREF : 0;
 	tp->dtdt_pad = 0;
 	tp->dtdt_size = ctf_type_size(dnp->dn_ctfp, dnp->dn_type);
+}
+
+/*
+ * Output the parse tree as D.  The "-xtree=8" argument will call this
+ * function to print out the program after any syntactic sugar
+ * transformations have been applied (e.g. to implement "if").  The
+ * resulting output can be used to understand the transformations
+ * applied by these features, or to run such a script on a system that
+ * does not support these features
+ *
+ * Note that the output does not express precisely the same program as
+ * the input.  In particular:
+ *  - Only the clauses are output.  #pragma options, variable
+ *    declarations, etc. are excluded.
+ *  - Command argument substitution has already been done, so the output
+ *    will not contain e.g. $$1, but rather the substituted string.
+ */
+void
+dt_printd(dt_node_t *dnp, FILE *fp, int depth)
+{
+	dt_node_t *arg;
+
+	switch (dnp->dn_kind) {
+	case DT_NODE_INT:
+		(void) fprintf(fp, "0x%llx", (u_longlong_t)dnp->dn_value);
+		if (!(dnp->dn_flags & DT_NF_SIGNED))
+			(void) fprintf(fp, "u");
+		break;
+
+	case DT_NODE_STRING: {
+		char *escd = strchr2esc(dnp->dn_string, strlen(dnp->dn_string));
+		(void) fprintf(fp, "\"%s\"", escd);
+		free(escd);
+		break;
+	}
+
+	case DT_NODE_IDENT:
+		(void) fprintf(fp, "%s", dnp->dn_string);
+		break;
+
+	case DT_NODE_VAR:
+		(void) fprintf(fp, "%s%s",
+		    (dnp->dn_ident->di_flags & DT_IDFLG_LOCAL) ? "this->" :
+		    (dnp->dn_ident->di_flags & DT_IDFLG_TLS) ? "self->" : "",
+		    dnp->dn_ident->di_name);
+
+		if (dnp->dn_args != NULL) {
+			(void) fprintf(fp, "[");
+
+			for (arg = dnp->dn_args; arg != NULL;
+			    arg = arg->dn_list) {
+				dt_printd(arg, fp, 0);
+				if (arg->dn_list != NULL)
+					(void) fprintf(fp, ", ");
+			}
+
+			(void) fprintf(fp, "]");
+		}
+		break;
+
+	case DT_NODE_SYM: {
+		const dtrace_syminfo_t *dts = dnp->dn_ident->di_data;
+		(void) fprintf(fp, "%s`%s", dts->dts_object, dts->dts_name);
+		break;
+	}
+	case DT_NODE_FUNC:
+		(void) fprintf(fp, "%s(", dnp->dn_ident->di_name);
+
+		for (arg = dnp->dn_args; arg != NULL; arg = arg->dn_list) {
+			dt_printd(arg, fp, 0);
+			if (arg->dn_list != NULL)
+				(void) fprintf(fp, ", ");
+		}
+		(void) fprintf(fp, ")");
+		break;
+
+	case DT_NODE_OP1:
+		(void) fprintf(fp, "%s(", opstr(dnp->dn_op));
+		dt_printd(dnp->dn_child, fp, 0);
+		(void) fprintf(fp, ")");
+		break;
+
+	case DT_NODE_OP2:
+		(void) fprintf(fp, "(");
+		dt_printd(dnp->dn_left, fp, 0);
+		if (dnp->dn_op == DT_TOK_LPAR) {
+			(void) fprintf(fp, ")");
+			dt_printd(dnp->dn_right, fp, 0);
+			break;
+		}
+		if (dnp->dn_op == DT_TOK_PTR || dnp->dn_op == DT_TOK_DOT ||
+		    dnp->dn_op == DT_TOK_LBRAC)
+			(void) fprintf(fp, "%s", opstr(dnp->dn_op));
+		else
+			(void) fprintf(fp, " %s ", opstr(dnp->dn_op));
+		dt_printd(dnp->dn_right, fp, 0);
+		if (dnp->dn_op == DT_TOK_LBRAC) {
+			dt_node_t *ln = dnp->dn_right;
+			while (ln->dn_list != NULL) {
+				(void) fprintf(fp, ", ");
+				dt_printd(ln->dn_list, fp, depth);
+				ln = ln->dn_list;
+			}
+			(void) fprintf(fp, "]");
+		}
+		(void) fprintf(fp, ")");
+		break;
+
+	case DT_NODE_OP3:
+		(void) fprintf(fp, "(");
+		dt_printd(dnp->dn_expr, fp, 0);
+		(void) fprintf(fp, " ? ");
+		dt_printd(dnp->dn_left, fp, 0);
+		(void) fprintf(fp, " : ");
+		dt_printd(dnp->dn_right, fp, 0);
+		(void) fprintf(fp, ")");
+		break;
+
+	case DT_NODE_DEXPR:
+	case DT_NODE_DFUNC:
+		(void) fprintf(fp, "%*s", depth * 8, "");
+		dt_printd(dnp->dn_expr, fp, depth + 1);
+		(void) fprintf(fp, ";\n");
+		break;
+
+	case DT_NODE_PDESC:
+		(void) fprintf(fp, "%s:%s:%s:%s",
+		    dnp->dn_desc->dtpd_provider, dnp->dn_desc->dtpd_mod,
+		    dnp->dn_desc->dtpd_func, dnp->dn_desc->dtpd_name);
+		break;
+
+	case DT_NODE_CLAUSE:
+		for (arg = dnp->dn_pdescs; arg != NULL; arg = arg->dn_list) {
+			dt_printd(arg, fp, 0);
+			if (arg->dn_list != NULL)
+				(void) fprintf(fp, ",");
+			(void) fprintf(fp, "\n");
+		}
+
+		if (dnp->dn_pred != NULL) {
+			(void) fprintf(fp, "/");
+			dt_printd(dnp->dn_pred, fp, 0);
+			(void) fprintf(fp, "/\n");
+		}
+			(void) fprintf(fp, "{\n");
+
+		for (arg = dnp->dn_acts; arg != NULL; arg = arg->dn_list)
+			dt_printd(arg, fp, depth + 1);
+		(void) fprintf(fp, "}\n");
+		(void) fprintf(fp, "\n");
+		break;
+
+	case DT_NODE_IF:
+		(void) fprintf(fp, "%*sif (", depth * 8, "");
+		dt_printd(dnp->dn_conditional, fp, 0);
+		(void) fprintf(fp, ") {\n");
+
+		for (arg = dnp->dn_body; arg != NULL; arg = arg->dn_list)
+			dt_printd(arg, fp, depth + 1);
+		if (dnp->dn_alternate_body == NULL) {
+			(void) fprintf(fp, "%*s}\n", depth * 8, "");
+		} else {
+			(void) fprintf(fp, "%*s} else {\n", depth * 8, "");
+			for (arg = dnp->dn_alternate_body; arg != NULL;
+			    arg = arg->dn_list)
+				dt_printd(arg, fp, depth + 1);
+			(void) fprintf(fp, "%*s}\n", depth * 8, "");
+		}
+
+		break;
+
+	default:
+		(void) fprintf(fp, "/* bad node %p, kind %d */\n",
+		    (void *)dnp, dnp->dn_kind);
+	}
 }
 
 void
@@ -4723,6 +4903,13 @@ dt_node_printr(dt_node_t *dnp, FILE *fp, int depth)
 		(void) fprintf(fp, "OP2 %s (%s)\n", opstr(dnp->dn_op), buf);
 		dt_node_printr(dnp->dn_left, fp, depth + 1);
 		dt_node_printr(dnp->dn_right, fp, depth + 1);
+		if (dnp->dn_op == DT_TOK_LBRAC) {
+			dt_node_t *ln = dnp->dn_right;
+			while (ln->dn_list != NULL) {
+				dt_node_printr(ln->dn_list, fp, depth + 1);
+				ln = ln->dn_list;
+			}
+		}
 		break;
 
 	case DT_NODE_OP3:
@@ -4784,6 +4971,7 @@ dt_node_printr(dt_node_t *dnp, FILE *fp, int depth)
 
 		for (arg = dnp->dn_acts; arg != NULL; arg = arg->dn_list)
 			dt_node_printr(arg, fp, depth + 1);
+		(void) fprintf(fp, "\n");
 		break;
 
 	case DT_NODE_INLINE:
@@ -4832,6 +5020,24 @@ dt_node_printr(dt_node_t *dnp, FILE *fp, int depth)
 		(void) fprintf(fp, "PROGRAM attr=%s\n", a);
 		for (arg = dnp->dn_list; arg != NULL; arg = arg->dn_list)
 			dt_node_printr(arg, fp, depth + 1);
+		break;
+
+	case DT_NODE_IF:
+		(void) fprintf(fp, "IF attr=%s CONDITION:\n", a);
+
+		dt_node_printr(dnp->dn_conditional, fp, depth + 1);
+
+		(void) fprintf(fp, "%*sIF BODY: \n", depth * 2, "");
+		for (arg = dnp->dn_body; arg != NULL; arg = arg->dn_list)
+			dt_node_printr(arg, fp, depth + 1);
+
+		if (dnp->dn_alternate_body != NULL) {
+			(void) fprintf(fp, "%*sIF ELSE: \n", depth * 2, "");
+			for (arg = dnp->dn_alternate_body; arg != NULL;
+			    arg = arg->dn_list)
+				dt_node_printr(arg, fp, depth + 1);
+		}
+
 		break;
 
 	default:

--- a/usr/src/lib/libdtrace/common/dt_parser.c
+++ b/usr/src/lib/libdtrace/common/dt_parser.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/lib/libdtrace/common/dt_parser.c
+++ b/usr/src/lib/libdtrace/common/dt_parser.c
@@ -3652,9 +3652,9 @@ asgn_common:
 
 	case DT_TOK_PTR:
 		/*
-		 * If the left-hand side of operator -> is one of the
-		 * scoping keywords, permit a local or thread
-		 * variable to be created or referenced.
+		 * If the left-hand side of operator -> is one of the scoping
+		 * keywords, permit a local or thread variable to be created or
+		 * referenced.
 		 */
 		if (lp->dn_kind == DT_NODE_IDENT) {
 			dt_idhash_t *dhp = NULL;

--- a/usr/src/lib/libdtrace/common/dt_parser.c
+++ b/usr/src/lib/libdtrace/common/dt_parser.c
@@ -21,8 +21,8 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
+ * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  */
 
 /*

--- a/usr/src/lib/libdtrace/common/dt_parser.h
+++ b/usr/src/lib/libdtrace/common/dt_parser.h
@@ -23,7 +23,7 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013 Joyent, Inc. All rights reserved.
  */
 

--- a/usr/src/lib/libdtrace/common/dt_parser.h
+++ b/usr/src/lib/libdtrace/common/dt_parser.h
@@ -23,12 +23,8 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013 Joyent, Inc. All rights reserved.
- */
-
-/*
- * Copyright (c) 2014 by Delphix. All rights reserved.
  */
 
 #ifndef	_DT_PARSER_H

--- a/usr/src/lib/libdtrace/common/dt_parser.h
+++ b/usr/src/lib/libdtrace/common/dt_parser.h
@@ -27,6 +27,10 @@
  * Copyright (c) 2013 Joyent, Inc. All rights reserved.
  */
 
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
 #ifndef	_DT_PARSER_H
 #define	_DT_PARSER_H
 
@@ -105,6 +109,12 @@ typedef struct dt_node {
 			struct dt_node *_probes;  /* list of probe nodes */
 			int _redecl;		/* provider redeclared */
 		} _provider;
+
+		struct {
+			struct dt_node *_conditional;
+			struct dt_node *_body;
+			struct dt_node *_alternate_body;
+		} _conditional;
 	} dn_u;
 
 	struct dt_node *dn_list; /* parse tree list link */
@@ -140,6 +150,11 @@ typedef struct dt_node {
 #define	dn_provred	dn_u._provider._redecl	/* DT_NODE_PROVIDER */
 #define	dn_probes	dn_u._provider._probes	/* DT_NODE_PROVIDER */
 
+/* DT_NODE_IF: */
+#define	dn_conditional		dn_u._conditional._conditional
+#define	dn_body			dn_u._conditional._body
+#define	dn_alternate_body	dn_u._conditional._alternate_body
+
 #define	DT_NODE_FREE	0	/* unused node (waiting to be freed) */
 #define	DT_NODE_INT	1	/* integer value */
 #define	DT_NODE_STRING	2	/* string value */
@@ -162,6 +177,7 @@ typedef struct dt_node {
 #define	DT_NODE_PROBE	19	/* probe definition */
 #define	DT_NODE_PROVIDER 20	/* provider definition */
 #define	DT_NODE_PROG	21	/* program translation unit */
+#define	DT_NODE_IF	22	/* if statement */
 
 #define	DT_NF_SIGNED	0x01	/* data is a signed quantity (else unsigned) */
 #define	DT_NF_COOKED	0x02	/* data is a known type (else still cooking) */
@@ -213,6 +229,7 @@ extern dt_node_t *dt_node_xlator(dt_decl_t *, dt_decl_t *, char *, dt_node_t *);
 extern dt_node_t *dt_node_probe(char *, int, dt_node_t *, dt_node_t *);
 extern dt_node_t *dt_node_provider(char *, dt_node_t *);
 extern dt_node_t *dt_node_program(dt_node_t *);
+extern dt_node_t *dt_node_if(dt_node_t *, dt_node_t *, dt_node_t *);
 
 extern dt_node_t *dt_node_link(dt_node_t *, dt_node_t *);
 extern dt_node_t *dt_node_cook(dt_node_t *, uint_t);
@@ -237,6 +254,7 @@ extern void dt_node_promote(dt_node_t *, dt_node_t *, dt_node_t *);
 extern void dt_node_diftype(dtrace_hdl_t *,
     const dt_node_t *, dtrace_diftype_t *);
 extern void dt_node_printr(dt_node_t *, FILE *, int);
+extern void dt_printd(dt_node_t *, FILE *, int);
 extern const char *dt_node_name(const dt_node_t *, char *, size_t);
 extern int dt_node_root(dt_node_t *);
 

--- a/usr/src/lib/libdtrace/common/dt_sugar.c
+++ b/usr/src/lib/libdtrace/common/dt_sugar.c
@@ -1,0 +1,508 @@
+/*
+ * CDDL HEADER START
+ *
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ */
+
+/*
+ * These syntactic sugar features are implemented by transforming the D
+ * parse tree such that it only uses the subset of D that is supported
+ * by the rest of the compiler / the kernel.  A clause containing these
+ * language features is referred to as a "super-clause", and its
+ * transformation typically entails creating several "sub-clauses" to
+ * implement it. For diagnosability, the sub-clauses will be printed if
+ * the "-xtree=8" flag is specified.
+ *
+ * The features are:
+ *
+ * "if/else" statements.  Each basic block (e.g. the body of the "if"
+ * and "else" statements, and the statements before and after) is turned
+ * into its own sub-clause, with a predicate that causes it to be
+ * executed only if the code flows to this point.  Nested if/else
+ * statements are supported.
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/sysmacros.h>
+
+#include <assert.h>
+#include <strings.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <dt_module.h>
+#include <dt_program.h>
+#include <dt_provider.h>
+#include <dt_printf.h>
+#include <dt_pid.h>
+#include <dt_grammar.h>
+#include <dt_ident.h>
+#include <dt_string.h>
+#include <dt_impl.h>
+
+typedef struct xd_parse {
+	dtrace_hdl_t *xp_dtp;
+	dt_node_t *xp_pdescs;		/* probe descriptions */
+	int xp_num_conditions;
+	int xp_num_ifs;
+	dt_node_t *xp_clause_list;
+} xd_parse_t;
+
+static void xd_visit_stmts(xd_parse_t *, dt_node_t *, int);
+
+/*
+ * Return a node for "self->%error".
+ *
+ * Note that the "%" is part of the variable name, and is included so that
+ * this variable name can not collide with any user-specified variable.
+ *
+ * This error variable is used to keep track of if there has been an error
+ * in any of the sub-clauses, and is used to prevent execution of subsequent
+ * sub-clauses following an error.
+ */
+static dt_node_t *
+xd_new_error_var(void)
+{
+	return (dt_node_op2(DT_TOK_PTR, dt_node_ident(strdup("self")),
+	    dt_node_ident(strdup("%error"))));
+}
+
+/*
+ * Append this clause to the clause list.
+ */
+static void
+xd_append_clause(xd_parse_t *dp, dt_node_t *clause)
+{
+	dp->xp_clause_list = dt_node_link(dp->xp_clause_list, clause);
+}
+
+/*
+ * Prepend this clause to the clause list.
+ */
+static void
+xd_prepend_clause(xd_parse_t *dp, dt_node_t *clause)
+{
+	dp->xp_clause_list = dt_node_link(clause, dp->xp_clause_list);
+}
+
+/*
+ * Return a node for "this->%condition_<condid>", or NULL if condid==0.
+ *
+ * Note that the "%" is part of the variable name, and is included so that
+ * this variable name can not collide with any user-specified variable.
+ */
+static dt_node_t *
+xd_new_condition_var(int condid)
+{
+	char *str;
+
+	if (condid == 0)
+		return (NULL);
+	assert(condid > 0);
+
+	(void) asprintf(&str, "%%condition_%d", ABS(condid));
+	return (dt_node_op2(DT_TOK_PTR, dt_node_ident(strdup("this")),
+	    dt_node_ident(str)));
+}
+
+/*
+ * Return new clause to evaluate predicate and set newcond.  condid is
+ * the condition that we are already under, or 0 if none.
+ * The new clause will be of the form:
+ *
+ * dp_pdescs
+ * /!self->%error/
+ * {
+ *	this->%condition_<newcond> =
+ *	    (this->%condition_<condid> && pred);
+ * }
+ *
+ * Note: if condid==0, we will instead do "... = (1 && pred)", to effectively
+ * convert the pred to a boolean.
+ *
+ * Note: Unless an error has been encountered, we always set the condition
+ * variable (either to 0 or 1).  This lets us avoid resetting the condition
+ * variables back to 0 when the super-clause completes.
+ */
+static dt_node_t *
+xd_new_condition_impl(xd_parse_t *dp, dt_node_t *pred, int condid, int newcond)
+{
+	dt_node_t *value, *body, *newpred;
+
+	/* predicate is !self->%error */
+	newpred = dt_node_op1(DT_TOK_LNEG, xd_new_error_var());
+
+	if (condid == 0) {
+		/*
+		 * value is (1 && pred)
+		 *
+		 * Note, D doesn't allow a probe-local "this" variable to
+		 * be reused as a different type, even from a different probe.
+		 * Therefore, value can't simply be <pred>, because then
+		 * its type could be different when we reuse this condid
+		 * in a different meta-clause.
+		 */
+		value = dt_node_op2(DT_TOK_LAND, dt_node_int(1), pred);
+	} else {
+		/* value is (this->%condition_<condid> && pred) */
+		value = dt_node_op2(DT_TOK_LAND,
+		    xd_new_condition_var(condid), pred);
+	}
+
+	/* body is "this->%condition_<retval> = <value>;" */
+	body = dt_node_statement(dt_node_op2(DT_TOK_ASGN,
+	    xd_new_condition_var(newcond), value));
+
+	return (dt_node_clause(dp->xp_pdescs, newpred, body));
+}
+
+/*
+ * Generate a new clause to evaluate predicate and set a new condition variable,
+ * whose ID will be returned.  The new clause will be appended to
+ * dp_first_new_clause.
+ */
+static int
+xd_new_condition(xd_parse_t *dp, dt_node_t *pred, int condid)
+{
+	dp->xp_num_conditions++;
+	xd_append_clause(dp, xd_new_condition_impl(dp,
+	    pred, condid, dp->xp_num_conditions));
+	return (dp->xp_num_conditions);
+}
+
+/*
+ * Visit the specified node and all of its descendants.  Replace any
+ * entry_* variables (e.g. entry_walltimestamp,entry_args[1], entry_elapsed_us)
+ * and callers[""] variables (e.g. callers["spa_sync"]) with the corresponding
+ * straight-D nodes.
+ */
+static void
+xd_visit_all(xd_parse_t *dp, dt_node_t *dnp)
+{
+	dt_node_t *arg;
+
+	switch (dnp->dn_kind) {
+	case DT_NODE_FREE:
+	case DT_NODE_INT:
+	case DT_NODE_STRING:
+	case DT_NODE_SYM:
+	case DT_NODE_TYPE:
+	case DT_NODE_PROBE:
+	case DT_NODE_PDESC:
+	case DT_NODE_IDENT:
+		break;
+
+	case DT_NODE_FUNC:
+		for (arg = dnp->dn_args; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		break;
+
+	case DT_NODE_OP1:
+		xd_visit_all(dp, dnp->dn_child);
+		break;
+
+	case DT_NODE_OP2:
+		xd_visit_all(dp, dnp->dn_left);
+		xd_visit_all(dp, dnp->dn_right);
+		if (dnp->dn_op == DT_TOK_LBRAC) {
+			dt_node_t *ln = dnp->dn_right;
+			while (ln->dn_list != NULL) {
+				xd_visit_all(dp, ln->dn_list);
+				ln = ln->dn_list;
+			}
+		}
+		break;
+
+	case DT_NODE_OP3:
+		xd_visit_all(dp, dnp->dn_expr);
+		xd_visit_all(dp, dnp->dn_left);
+		xd_visit_all(dp, dnp->dn_right);
+		break;
+
+	case DT_NODE_DEXPR:
+	case DT_NODE_DFUNC:
+		xd_visit_all(dp, dnp->dn_expr);
+		break;
+
+	case DT_NODE_AGG:
+
+		for (arg = dnp->dn_aggtup; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+
+		if (dnp->dn_aggfun)
+			xd_visit_all(dp, dnp->dn_aggfun);
+		break;
+
+	case DT_NODE_CLAUSE:
+		for (arg = dnp->dn_pdescs; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+
+		if (dnp->dn_pred != NULL)
+			xd_visit_all(dp, dnp->dn_pred);
+
+		for (arg = dnp->dn_acts; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		break;
+
+	case DT_NODE_INLINE: {
+		const dt_idnode_t *inp = dnp->dn_ident->di_iarg;
+
+		xd_visit_all(dp, inp->din_root);
+		break;
+	}
+	case DT_NODE_MEMBER:
+		if (dnp->dn_membexpr)
+			xd_visit_all(dp, dnp->dn_membexpr);
+		break;
+
+	case DT_NODE_XLATOR:
+		for (arg = dnp->dn_members; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		break;
+
+	case DT_NODE_PROVIDER:
+		for (arg = dnp->dn_probes; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		break;
+
+	case DT_NODE_PROG:
+		for (arg = dnp->dn_list; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		break;
+
+	case DT_NODE_IF:
+		dp->xp_num_ifs++;
+		xd_visit_all(dp, dnp->dn_conditional);
+
+		for (arg = dnp->dn_body; arg != NULL; arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+		for (arg = dnp->dn_alternate_body; arg != NULL;
+		    arg = arg->dn_list)
+			xd_visit_all(dp, arg);
+
+		break;
+
+	default:
+		(void) dnerror(dnp, D_UNKNOWN, "bad node %p, kind %d\n",
+		    (void *)dnp, dnp->dn_kind);
+	}
+}
+
+/*
+ * Return a new clause which resets the error variable to zero:
+ *
+ *   dp_pdescs{ self->%error = 0; }
+ *
+ * This clause will be executed at the beginning of each meta-clause, to
+ * ensure the error variable is unset (in case the previous meta-clause
+ * failed).
+ */
+static dt_node_t *
+xd_new_clearerror_clause(xd_parse_t *dp)
+{
+	dt_node_t *stmt = dt_node_statement(dt_node_op2(DT_TOK_ASGN,
+	    xd_new_error_var(), dt_node_int(0)));
+	return (dt_node_clause(dp->xp_pdescs, NULL, stmt));
+}
+
+/*
+ * Evaluate the conditional, and recursively visit the body of the "if"
+ * statement (and the "else", if present).
+ */
+static void
+xd_do_if(xd_parse_t *dp, dt_node_t *if_stmt, int precondition)
+{
+	int newid;
+
+	assert(if_stmt->dn_kind == DT_NODE_IF);
+
+	/* condition */
+	newid = xd_new_condition(dp, if_stmt->dn_conditional, precondition);
+
+	/* body of if */
+	xd_visit_stmts(dp, if_stmt->dn_body, newid);
+
+	/*
+	 * Visit the body of the "else" statement, if present.  Note that we
+	 * generate a new condition which is the inverse of the previous
+	 * condition.
+	 */
+	if (if_stmt->dn_alternate_body != NULL) {
+		dt_node_t *pred =
+		    dt_node_op1(DT_TOK_LNEG, xd_new_condition_var(newid));
+		xd_visit_stmts(dp, if_stmt->dn_alternate_body,
+		    xd_new_condition(dp, pred, precondition));
+	}
+}
+
+/*
+ * Generate a new clause to evaluate the statements based on the condition.
+ * The new clause will be appended to dp_first_new_clause.
+ *
+ * dp_pdescs
+ * /!self->%error && this->%condition_<condid>/
+ * {
+ *	stmts
+ * }
+ */
+static void
+xd_new_basic_block(xd_parse_t *dp, int condid, dt_node_t *stmts)
+{
+	dt_node_t *pred = NULL;
+
+	if (condid == 0) {
+		/*
+		 * Don't bother with !error on the first clause, because if
+		 * there is only one clause, we don't add the prelude to
+		 * zero out %error.
+		 */
+		if (dp->xp_num_conditions != 0)
+			pred = dt_node_op1(DT_TOK_LNEG, xd_new_error_var());
+	} else {
+		pred = dt_node_op2(DT_TOK_LAND,
+		    dt_node_op1(DT_TOK_LNEG, xd_new_error_var()),
+		    xd_new_condition_var(condid));
+	}
+	xd_append_clause(dp,
+	    dt_node_clause(dp->xp_pdescs, pred, stmts));
+}
+
+/*
+ * Visit all the statements in this list, and break them into basic blocks,
+ * generating new clauses for "if" and "else" statements.
+ */
+static void
+xd_visit_stmts(xd_parse_t *dp, dt_node_t *stmts, int precondition)
+{
+	dt_node_t *stmt;
+	dt_node_t *prev_stmt = NULL;
+	dt_node_t *next_stmt;
+	dt_node_t *first_stmt_in_basic_block = NULL;
+
+	for (stmt = stmts; stmt != NULL; stmt = next_stmt) {
+		next_stmt = stmt->dn_list;
+
+		if (stmt->dn_kind != DT_NODE_IF) {
+			if (first_stmt_in_basic_block == NULL)
+				first_stmt_in_basic_block = stmt;
+			prev_stmt = stmt;
+			continue;
+		}
+
+		/*
+		 * Remove this and following statements from the previous
+		 * clause.
+		 */
+		if (prev_stmt != NULL)
+			prev_stmt->dn_list = NULL;
+
+		/*
+		 * Generate clause for statements preceding the "if"
+		 */
+		if (first_stmt_in_basic_block != NULL) {
+			xd_new_basic_block(dp, precondition,
+			    first_stmt_in_basic_block);
+		}
+
+		xd_do_if(dp, stmt, precondition);
+
+		first_stmt_in_basic_block = NULL;
+
+		prev_stmt = stmt;
+	}
+
+	/* generate clause for statements after last "if". */
+	if (first_stmt_in_basic_block != NULL)
+		xd_new_basic_block(dp, precondition, first_stmt_in_basic_block);
+}
+
+/*
+ * Generate a new clause which will set the error variable when an error occurs.
+ * Only one of these clauses is created per program (e.g. script file).
+ * The clause is:
+ *
+ * dtrace:::ERROR{ self->%error = 1; }
+ */
+static dt_node_t *
+xd_makeerrorclause(void)
+{
+	dt_node_t *acts, *pdesc;
+
+	pdesc = dt_node_pdesc_by_name(strdup("dtrace:::ERROR"));
+
+	acts = dt_node_statement(dt_node_op2(DT_TOK_ASGN,
+	    xd_new_error_var(), dt_node_int(1)));
+
+	return (dt_node_clause(pdesc, NULL, acts));
+}
+
+/*
+ * Transform the super-clause into straight-D, returning the new list of
+ * sub-clauses.
+ */
+dt_node_t *
+dt_compile_sugar(dtrace_hdl_t *dtp, dt_node_t *clause)
+{
+	xd_parse_t dp = { 0 };
+	int condid = 0;
+
+	dp.xp_dtp = dtp;
+	dp.xp_pdescs = clause->dn_pdescs;
+
+	/* make dt_node_int() generate an "int"-typed integer */
+	yyintdecimal = B_TRUE;
+	yyintsuffix[0] = '\0';
+	yyintprefix = 0;
+
+	xd_visit_all(&dp, clause);
+
+	if (dp.xp_num_ifs == 0 && dp.xp_num_conditions == 0) {
+		/*
+		 * There is nothing that modifies the number of clauses.
+		 * Use the existing clause as-is, with its predicate intact.
+		 * This ensures that in the absence of D++, the body of the
+		 * clause can create a variable that is referenced in the
+		 * predicate.
+		 */
+		xd_append_clause(&dp, dt_node_clause(clause->dn_pdescs,
+		    clause->dn_pred, clause->dn_acts));
+	} else {
+		if (clause->dn_pred != NULL)
+			condid = xd_new_condition(&dp, clause->dn_pred, condid);
+
+		if (clause->dn_acts == NULL) {
+			/*
+			 * xd_visit_stmts() does not emit a clause with
+			 * an empty body (e.g. if there's an empty "if" body),
+			 * but we need the empty body here so that we
+			 * continue to get the default tracing action.
+			 */
+			xd_new_basic_block(&dp, condid, NULL);
+		} else {
+			xd_visit_stmts(&dp, clause->dn_acts, condid);
+		}
+	}
+
+	if (dp.xp_num_conditions != 0)
+		xd_prepend_clause(&dp, xd_new_clearerror_clause(&dp));
+	if (dp.xp_clause_list != NULL &&
+	    dp.xp_clause_list->dn_list != NULL && !dtp->dt_has_sugar) {
+		dtp->dt_has_sugar = B_TRUE;
+		xd_prepend_clause(&dp, xd_makeerrorclause());
+	}
+	return (dp.xp_clause_list);
+}

--- a/usr/src/lib/libdtrace/common/dtrace.h
+++ b/usr/src/lib/libdtrace/common/dtrace.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2014 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  */
 
@@ -55,6 +55,7 @@ extern "C" {
 #define	DTRACE_VERSION	3		/* library ABI interface version */
 
 struct ps_prochandle;
+struct dt_node;
 typedef struct dtrace_hdl dtrace_hdl_t;
 typedef struct dtrace_prog dtrace_prog_t;
 typedef struct dtrace_vector dtrace_vector_t;
@@ -111,7 +112,7 @@ typedef struct dtrace_proginfo {
 #define	DTRACE_C_CPP	0x0010	/* Preprocess input file with cpp(1) utility */
 #define	DTRACE_C_KNODEF	0x0020	/* Permit unresolved kernel symbols in DIFO */
 #define	DTRACE_C_UNODEF	0x0040	/* Permit unresolved user symbols in DIFO */
-#define	DTRACE_C_PSPEC	0x0080	/* Intepret ambiguous specifiers as probes */
+#define	DTRACE_C_PSPEC	0x0080	/* Interpret ambiguous specifiers as probes */
 #define	DTRACE_C_ETAGS	0x0100	/* Prefix error messages with error tags */
 #define	DTRACE_C_ARGREF	0x0200	/* Do not require all macro args to be used */
 #define	DTRACE_C_DEFARG	0x0800	/* Use 0/"" as value for unspecified args */
@@ -518,6 +519,10 @@ extern int dtrace_type_strcompile(dtrace_hdl_t *,
 
 extern int dtrace_type_fcompile(dtrace_hdl_t *,
     FILE *, dtrace_typeinfo_t *);
+
+extern struct dt_node *dt_compile_sugar(dtrace_hdl_t *,
+    struct dt_node *);
+
 
 /*
  * DTrace Probe Interface

--- a/usr/src/lib/libdtrace/common/dtrace.h
+++ b/usr/src/lib/libdtrace/common/dtrace.h
@@ -25,7 +25,7 @@
  */
 
 /*
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  */
 

--- a/usr/src/pkg/manifests/system-dtrace-tests.mf
+++ b/usr/src/pkg/manifests/system-dtrace-tests.mf
@@ -112,6 +112,7 @@ dir path=opt/SUNWdtrt/tst/common/stop
 dir path=opt/SUNWdtrt/tst/common/strlen
 dir path=opt/SUNWdtrt/tst/common/strtoll
 dir path=opt/SUNWdtrt/tst/common/struct
+dir path=opt/SUNWdtrt/tst/common/sugar
 dir path=opt/SUNWdtrt/tst/common/syscall
 dir path=opt/SUNWdtrt/tst/common/sysevent
 dir path=opt/SUNWdtrt/tst/common/tick-n
@@ -1818,6 +1819,13 @@ file path=opt/SUNWdtrt/tst/common/struct/tst.StructDataTypes.d mode=0444
 file path=opt/SUNWdtrt/tst/common/struct/tst.StructInside.d mode=0444
 file path=opt/SUNWdtrt/tst/common/struct/tst.clauselocal.d mode=0444
 file path=opt/SUNWdtrt/tst/common/struct/tst.clauselocal.d.out mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.else.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if2.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if_before_after.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if_nested.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if_trailing_semicolon.d mode=0444
+file path=opt/SUNWdtrt/tst/common/sugar/tst.if_trailing_semicolon2.d mode=0444
 file path=opt/SUNWdtrt/tst/common/syscall/tst.args.d mode=0444
 file path=opt/SUNWdtrt/tst/common/syscall/tst.args.exe mode=0555
 file path=opt/SUNWdtrt/tst/common/syscall/tst.openret.ksh mode=0444

--- a/usr/src/pkg/manifests/system-dtrace-tests.mf
+++ b/usr/src/pkg/manifests/system-dtrace-tests.mf
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/system/dtrace/tests@$(PKGVERS)


### PR DESCRIPTION
https://www.illumos.org/issues/7085

For those who don't like github, the code is also available here: http://cr.illumos.org/~webrev/mahrens/ifelse/

I ran the dtrace test suite (on OmniOS) and it has the same set of failures as trunk:

```
#   KIND       TEST                            DETAILS
0   cpc        tst.allcpus.ksh
1   dtraceUtil tst.ELFGenerationOut.d.ksh      dtrace: failed to link script /dev/stdin: failed to open d.out: Permission deni
2   dtraceUtil tst.ELFGenerationWithO.d.ksh    dtrace: failed to link script /dev/stdin: failed to open outputFile: Permission
3   ip         tst.ipv4localicmp.ksh
4   ip         tst.ipv4remoteicmp.ksh
5   ip         tst.ipv6remoteicmp.ksh          remote IPv6 host.
6   ip         tst.localtcpstate.ksh
7   ip         tst.remotetcpstate.ksh
8   java_api   tst.Bean.ksh                    failed to create TestBean.out
9   pid        tst.newprobes.ksh               dtrace: pid 114297 has exited
10  preprocessor err.ifdefnotendif.d
11  scripting  tst.egid.ksh                    Error in executing /var/tmp/stdin.127634.d
12  scripting  tst.euid.ksh                    Error in executing /var/tmp/stdin.127645
13  scripting  tst.gid.ksh                     Error in executing /var/tmp/stdin.127656
14  scripting  tst.projid.ksh                  Error in executing /var/tmp/stdin.127678
15  scripting  tst.sid.ksh                     Error in executing /var/tmp/stdin.127691
16  scripting  tst.taskid.ksh                  Error in executing /var/tmp/stdin.127708
17  scripting  tst.uid.ksh                     Error in executing /var/tmp/stdin.127721
18  ustack     tst.depth.ksh                   dtrace: failed to open output file 'out.138919': Permission denied
19  ustack     tst.spin.ksh                    dtrace: failed to open output file 'out.138923': Permission denied
```
