### PR TITLE
ESC_ZFS_VDEV_REMOVE_AUX fallout

### DIFF
--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -5473,10 +5473,10 @@ spa_vdev_remove(spa_t *spa, uint64_t guid, boolean_t unspare)
 			    ZPOOL_CONFIG_SPARES, spares, nspares, nv);
 			spa_load_spares(spa);
 			spa->spa_spares.sav_sync = B_TRUE;
+			spa_event_notify(spa, vd, ESC_ZFS_VDEV_REMOVE_AUX);
 		} else {
 			error = SET_ERROR(EBUSY);
 		}
-		spa_event_notify(spa, vd, ESC_ZFS_VDEV_REMOVE_AUX);
 	} else if (spa->spa_l2cache.sav_vdevs != NULL &&
 	    nvlist_lookup_nvlist_array(spa->spa_l2cache.sav_config,
 	    ZPOOL_CONFIG_L2CACHE, &l2cache, &nl2cache) == 0 &&
@@ -5488,7 +5488,7 @@ spa_vdev_remove(spa_t *spa, uint64_t guid, boolean_t unspare)
 		    ZPOOL_CONFIG_L2CACHE, l2cache, nl2cache, nv);
 		spa_load_l2cache(spa);
 		spa->spa_l2cache.sav_sync = B_TRUE;
-		spa_event_notify(spa, vd, ESC_ZFS_VDEV_REMOVE_AUX);
+		spa_event_notify(spa, NULL, ESC_ZFS_VDEV_REMOVE_AUX);
 	} else if (vd != NULL && vd->vdev_islog) {
 		ASSERT(!locked);
 		ASSERT(vd == vd->vdev_top);


### PR DESCRIPTION
```
7115 6922 generates ESC_ZFS_VDEV_REMOVE_AUX a bit too often
7116 6922 could have been clearer about event vdev pointer
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Alan Somers <asomers@freebsd.org>
```