### PR TITLE
7147 ztest: ztest_ddt_repair fails with ztest_pattern_match assertion

### DIFF
--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -5045,9 +5045,14 @@ ztest_ddt_repair(ztest_ds_t *zd, uint64_t id)
 		return;
 	}
 
+	dmu_objset_stats_t dds;
+	dsl_pool_config_enter(dmu_objset_pool(os), FTAG);
+	dmu_objset_fast_stat(os, &dds);
+	dsl_pool_config_exit(dmu_objset_pool(os), FTAG);
+
 	object = od[0].od_object;
 	blocksize = od[0].od_blocksize;
-	pattern = zs->zs_guid ^ dmu_objset_fsid_guid(os);
+	pattern = zs->zs_guid ^ dds.dds_guid;
 
 	ASSERT(object != 0);
 
@@ -5643,9 +5648,13 @@ ztest_run(ztest_shared_t *zs)
 	metaslab_preload_limit = ztest_random(20) + 1;
 	ztest_spa = spa;
 
+	dmu_objset_stats_t dds;
 	VERIFY0(dmu_objset_own(ztest_opts.zo_pool,
 	    DMU_OST_ANY, B_TRUE, FTAG, &os));
-	zs->zs_guid = dmu_objset_fsid_guid(os);
+	dsl_pool_config_enter(dmu_objset_pool(os), FTAG);
+	dmu_objset_fast_stat(os, &dds);
+	dsl_pool_config_exit(dmu_objset_pool(os), FTAG);
+	zs->zs_guid = dds.dds_guid;
 	dmu_objset_disown(os, FTAG);
 
 	spa->spa_dedup_ditto = 2 * ZIO_DEDUPDITTO_MIN;


### PR DESCRIPTION
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Prakash Surya prakash.surya@delphix.com

It's possible for a dataset to find that its ds_fsid_guid is still in
use and so it must pick a new one. This breaks the ztest_ddt_repair()
test since it's expecting the ds_fsid_guid to be the same throughout the
lifetime of the dataset. We can find an already in-use ds_fsid_guid if
the dataset is being destroyed but has not yet been processed by the
dbu_evict_taskq. To resolve this we will use the ds_guid which should
never change to create the pattern used by ztest_ddt_repair().

upstream bugs: DLPX-39989
