### PR TITLE
7149 move libzpool's taskq library into libcmdutils

### DIFF
--- a/exception_lists/packaging
+++ b/exception_lists/packaging
@@ -455,6 +455,7 @@ lib/llib-lcmdutils.ln
 lib/amd64/llib-lcmdutils.ln		i386
 lib/sparcv9/llib-lcmdutils.ln		sparc
 usr/include/libcmdutils.h
+usr/include/taskq.h
 usr/lib/libcmdutils.so
 usr/lib/amd64/libcmdutils.so		i386
 usr/lib/sparcv9/libcmdutils.so		sparc

--- a/usr/src/lib/libcmdutils/Makefile
+++ b/usr/src/lib/libcmdutils/Makefile
@@ -22,7 +22,7 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 
 include ../Makefile.lib
@@ -37,7 +37,7 @@ install :=	TARGET= install
 lint :=		TARGET= lint
 
 # definitions for install_h target
-HDRS=		libcmdutils.h
+HDRS=		libcmdutils.h taskq.h
 ROOTHDRDIR=	$(ROOT)/usr/include
 ROOTHDRS=	$(HDRS:%=$(ROOTHDRDIR)/%)
 CHECKHDRS=	$(HDRS:%.h=%.check)

--- a/usr/src/lib/libcmdutils/Makefile.com
+++ b/usr/src/lib/libcmdutils/Makefile.com
@@ -21,12 +21,13 @@
 #
 # Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013 RackTop Systems.
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
 #
 
 LIBRARY=	libcmdutils.a
 VERS=		.1
 CMD_OBJS=	avltree.o sysattrs.o writefile.o process_xattrs.o uid.o gid.o \
-		custr.o
+		custr.o taskq.o
 COM_OBJS=	list.o
 OBJECTS=	$(CMD_OBJS) $(COM_OBJS)
 
@@ -35,7 +36,7 @@ include ../../Makefile.rootfs
 
 LIBS =		$(DYNLIB) $(LINTLIB)
 
-LDLIBS +=	-lc -lavl -lnvpair
+LDLIBS +=	-lc -lavl -lnvpair -lumem
 
 SRCDIR =	../common
 

--- a/usr/src/lib/libcmdutils/common/llib-lcmdutils
+++ b/usr/src/lib/libcmdutils/common/llib-lcmdutils
@@ -25,10 +25,12 @@
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
 
 #include <sys/avl.h>
 #include <sys/types.h>
 #include <stdlib.h>
 #include <libcmdutils.h>
+#include <taskq.h>

--- a/usr/src/lib/libcmdutils/common/mapfile-vers
+++ b/usr/src/lib/libcmdutils/common/mapfile-vers
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013 RackTop Systems.
+# Copyright (c) 2014 by Delphix. All rights reserved.
 #
 
 #
@@ -72,9 +73,18 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	list_remove_head;
 	list_remove_tail;
 	list_tail;
+	taskq_create;
+	taskq_dispatch;
+	taskq_dispatch_ent;
+	taskq_destroy;
+	taskq_wait;
+	taskq_member;
 	tnode_compare;
 	sysattr_type;
 	sysattr_support;
+	system_taskq;
+	system_taskq_init;
+	system_taskq_fini;
 	writefile;
 	get_attrdirs;
 	mv_xattrs;

--- a/usr/src/lib/libcmdutils/taskq.h
+++ b/usr/src/lib/libcmdutils/taskq.h
@@ -1,0 +1,79 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ */
+
+#ifndef	_TASKQ_H
+#define	_TASKQ_H
+
+#include <stdint.h>
+#include <umem.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef struct taskq taskq_t;
+typedef uintptr_t taskqid_t;
+typedef void (task_func_t)(void *);
+
+typedef struct taskq_ent {
+	struct taskq_ent	*tqent_next;
+	struct taskq_ent	*tqent_prev;
+	task_func_t		*tqent_func;
+	void			*tqent_arg;
+	uintptr_t		tqent_flags;
+} taskq_ent_t;
+
+#define	TQENT_FLAG_PREALLOC	0x1	/* taskq_dispatch_ent used */
+
+#define	TASKQ_PREPOPULATE	0x0001
+#define	TASKQ_CPR_SAFE		0x0002	/* Use CPR safe protocol */
+#define	TASKQ_DYNAMIC		0x0004	/* Use dynamic thread scheduling */
+#define	TASKQ_THREADS_CPU_PCT	0x0008	/* Scale # threads by # cpus */
+#define	TASKQ_DC_BATCH		0x0010	/* Mark threads as batch */
+
+#define	TQ_SLEEP	UMEM_NOFAIL	/* Can block for memory */
+#define	TQ_NOSLEEP	UMEM_DEFAULT	/* cannot block for memory; may fail */
+#define	TQ_NOQUEUE	0x02		/* Do not enqueue if can't dispatch */
+#define	TQ_FRONT	0x08		/* Queue in front */
+
+extern taskq_t *system_taskq;
+
+extern taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
+extern taskqid_t taskq_dispatch(taskq_t *, task_func_t, void *, uint_t);
+extern void	taskq_dispatch_ent(taskq_t *, task_func_t, void *, uint_t,
+    taskq_ent_t *);
+extern void	taskq_destroy(taskq_t *);
+extern void	taskq_wait(taskq_t *);
+extern int	taskq_member(taskq_t *, void *);
+extern void	system_taskq_init(void);
+extern void	system_taskq_fini(void);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _TASKQ_H */

--- a/usr/src/lib/libzpool/Makefile.com
+++ b/usr/src/lib/libzpool/Makefile.com
@@ -20,7 +20,7 @@
 #
 #
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 #
 
 LIBRARY= libzpool.a
@@ -28,7 +28,7 @@ VERS= .1
 
 # include the list of ZFS sources
 include ../../../uts/common/Makefile.files
-KERNEL_OBJS = kernel.o taskq.o util.o
+KERNEL_OBJS = kernel.o util.o
 DTRACE_OBJS = zfs.o
 
 OBJECTS=$(ZFS_COMMON_OBJS) $(ZFS_SHARED_OBJS) $(KERNEL_OBJS)

--- a/usr/src/lib/libzpool/common/sys/zfs_context.h
+++ b/usr/src/lib/libzpool/common/sys/zfs_context.h
@@ -62,6 +62,7 @@ extern "C" {
 #include <time.h>
 #include <procfs.h>
 #include <pthread.h>
+#include <taskq.h>
 #include <sys/debug.h>
 #include <libsysevent.h>
 #include <sys/note.h>
@@ -347,51 +348,6 @@ typedef enum kmem_cbrc {
 	KMEM_CBRC_DONT_KNOW
 } kmem_cbrc_t;
 
-/*
- * Task queues
- */
-typedef struct taskq taskq_t;
-typedef uintptr_t taskqid_t;
-typedef void (task_func_t)(void *);
-
-typedef struct taskq_ent {
-	struct taskq_ent	*tqent_next;
-	struct taskq_ent	*tqent_prev;
-	task_func_t		*tqent_func;
-	void			*tqent_arg;
-	uintptr_t		tqent_flags;
-} taskq_ent_t;
-
-#define	TQENT_FLAG_PREALLOC	0x1	/* taskq_dispatch_ent used */
-
-#define	TASKQ_PREPOPULATE	0x0001
-#define	TASKQ_CPR_SAFE		0x0002	/* Use CPR safe protocol */
-#define	TASKQ_DYNAMIC		0x0004	/* Use dynamic thread scheduling */
-#define	TASKQ_THREADS_CPU_PCT	0x0008	/* Scale # threads by # cpus */
-#define	TASKQ_DC_BATCH		0x0010	/* Mark threads as batch */
-
-#define	TQ_SLEEP	KM_SLEEP	/* Can block for memory */
-#define	TQ_NOSLEEP	KM_NOSLEEP	/* cannot block for memory; may fail */
-#define	TQ_NOQUEUE	0x02		/* Do not enqueue if can't dispatch */
-#define	TQ_FRONT	0x08		/* Queue in front */
-
-
-extern taskq_t *system_taskq;
-
-extern taskq_t	*taskq_create(const char *, int, pri_t, int, int, uint_t);
-#define	taskq_create_proc(a, b, c, d, e, p, f) \
-	    (taskq_create(a, b, c, d, e, f))
-#define	taskq_create_sysdc(a, b, d, e, p, dc, f) \
-	    (taskq_create(a, b, maxclsyspri, d, e, f))
-extern taskqid_t taskq_dispatch(taskq_t *, task_func_t, void *, uint_t);
-extern void	taskq_dispatch_ent(taskq_t *, task_func_t, void *, uint_t,
-    taskq_ent_t *);
-extern void	taskq_destroy(taskq_t *);
-extern void	taskq_wait(taskq_t *);
-extern int	taskq_member(taskq_t *, void *);
-extern void	system_taskq_init(void);
-extern void	system_taskq_fini(void);
-
 #define	XVA_MAPSIZE	3
 #define	XVA_MAGIC	0x78766174
 
@@ -569,6 +525,14 @@ typedef struct callb_cpr {
 
 extern char *kmem_asprintf(const char *fmt, ...);
 #define	strfree(str) kmem_free((str), strlen(str) + 1)
+
+/*
+ * Task queues
+ */
+#define	taskq_create_proc(a, b, c, d, e, p, f) \
+	    (taskq_create(a, b, c, d, e, f))
+#define	taskq_create_sysdc(a, b, d, e, p, dc, f) \
+	    (taskq_create(a, b, maxclsyspri, d, e, f))
 
 /*
  * Hostname information


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

To better facilitate multi-threaded tools and libraries, it would be useful to
move the taskq implementation out of libzpool and into a more generic location
(which is currently deemed to be libcmdutils). The libzpool library can be
reworked to be a consumer of this new taskq library, and other tools/libraries
could then be made to use this library as well.

Upstream bug: DLPX-32469