### PR TITLE
7163 ztest failures due to excess error injection

### DIFF
--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -4792,7 +4792,7 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 	char path0[MAXPATHLEN];
 	char pathrand[MAXPATHLEN];
 	size_t fsize;
-	int bshift = SPA_MAXBLOCKSHIFT + 2;	/* don't scrog all labels */
+	int bshift = SPA_MAXBLOCKSHIFT + 2;
 	int iters = 1000;
 	int maxfaults;
 	int mirror_save;
@@ -4982,7 +4982,29 @@ ztest_fault_inject(ztest_ds_t *zd, uint64_t id)
 		    (leaves << bshift) + (leaf << bshift) +
 		    (ztest_random(1ULL << (bshift - 1)) & -8ULL);
 
-		if (offset >= fsize)
+		/*
+		 * Only allow damage to the labels at one end of the vdev.
+		 *
+		 * If all labels are damaged, the device will be totally
+		 * inaccessible, which will result in loss of data,
+		 * because we also damage (parts of) the other side of
+		 * the mirror/raidz.
+		 *
+		 * Additionally, we will always have both an even and an
+		 * odd label, so that we can handle crashes in the
+		 * middle of vdev_config_sync().
+		 */
+		if ((leaf & 1) == 0 && offset < VDEV_LABEL_START_SIZE)
+			continue;
+
+		/*
+		 * The two end labels are stored at the "end" of the disk, but
+		 * the end of the disk (vdev_psize) is aligned to
+		 * sizeof (vdev_label_t).
+		 */
+		uint64_t psize = P2ALIGN(fsize, sizeof (vdev_label_t));
+		if ((leaf & 1) == 1 &&
+		    offset + sizeof (bad) > psize - VDEV_LABEL_END_SIZE)
 			continue;
 
 		VERIFY(mutex_lock(&ztest_vdev_lock) == 0);


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com
Reviewed by: Paul Dagnelie pcd@delphix.com

ztest sometimes experiences on-disk corruption in the form of
unrecoverable i/o errors (ECKSUM).  This can manifest in several
different ways.

The problem is that all 4 labels of one of the disks are corrupt with
1990c0ffeedecade.  This is a form of error injection that ztest does
when it is testing mirrors or raid-z, but it isn't intended to corrupt
all 4 labels.

Why did zdb pour c0ffee over all 4 labels? Let’s look at
ztest_fault_inject():

```
int bshift = SPA_MAXBLOCKSHIFT + 2; /* don't scrog all labels */
    ...
    offset = ztest_random(fsize / (leaves << bshift)) *
        (leaves << bshift) + (leaf << bshift) +
        (ztest_random(1ULL << (bshift - 1)) & -8ULL);
```

The comment implies that this value of bshift will keep us from
overwriting all the labels. This was true when the max block size was
128KB, but is no longer true now that the max block size is 16MB. See
the comment near the bottom of ztest_fault_inject() for an explanation
of what regions are eligible for corruption. Here are examples with
2-way mirroring:

Note: sizeof (vdev_label_t) is 256KB

  with leaves=2, MAXBLOCKSIZE=128KB:
  chunk size = 2 \* 128KB \* 4 = 1MB
  divide into 4 regions of 256KB each:
  0-256K: inject leaf 0 [covers label 0]
  256-512K: DMZ - no injection [covers label 1]
  512-768K: inject leaf 1
  768-1024K: DMZ - no injection

  with leaves=2, MAXBLICKSIZE=16MB:
  chunk size = 2 \* 16MB \* 4 = 128MB
  divide into 4 regions of 32MB each:
  0-32MB: inject leaf 0 [covers labels 0 and 1]
  32-64MB: DMZ - no injection
  64-96MB: inject leaf 1
  96-128MB: DMZ - no injection

This bug was introduced by the fix for "6451 ztest fails due to checksum
errors", which changed bshift from using SPA_OLD_MAXBLOCKSHIFT (128KB)
to SPA_MAXBLOCKSHIFT (16MB), to fix a different "too much injection"
problem.

The fix is to use a different method to ensure that we don’t caffeinate
all 4 labels with 0x1990c0ffeedecade.

Upstream bugs: DLPX-45278
