### PR TITLE
7231 nlockmgr failing to start up during bootup

### DIFF
--- a/usr/src/cmd/fs.d/nfs/svc/nlockmgr
+++ b/usr/src/cmd/fs.d/nfs/svc/nlockmgr
@@ -21,9 +21,9 @@
 #
 #
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2015 by Delphix. All rights reserved.
 # Use is subject to license terms.
 #
-#ident	"%Z%%M%	%I%	%E% SMI"
 
 #
 # Start the lockd service; we are serving NFS and we need to verify
@@ -60,5 +60,16 @@ then
 		echo "$0: WARNING svcadm refresh failed" 1>&2
 	fi
 fi
-   
+
+#
+# We have to wait for statd to finish starting up before lockd can
+# start running. If statd hangs after service startup (so SMF thinks
+# it's done) but before it registers an rpc address, we can end up
+# failing in the kernel when we attempt to contact it.
+#
+until /usr/bin/rpcinfo -T tcp 127.0.0.1 status >/dev/null 2>&1
+do
+	sleep 1
+done
+
 exec /usr/lib/nfs/lockd

--- a/usr/src/cmd/fs.d/nfs/svc/nlockmgr.xml
+++ b/usr/src/cmd/fs.d/nfs/svc/nlockmgr.xml
@@ -21,6 +21,7 @@
  CDDL HEADER END
 
 	Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+	Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 
 	NOTE:  This service manifest is not editable; its contents will
 	be overwritten by package or patch operations, including
@@ -71,7 +72,7 @@
 	    type='method'
 	    name='start'
 	    exec='/lib/svc/method/nlockmgr'
-	    timeout_seconds='60' />
+	    timeout_seconds='300' />
 
 	<exec_method
 	    type='method'


### PR DESCRIPTION
Reviewed by: Matt Amdur <matt.amdur@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Kyle Cackett <kyle.cackett@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

If statd tries to use an unreachable DNS server during boot, it can hang
while doing reverse DNS lookups. This can cause nlockmgr's start method
to time out, so we raised the default limit and added a loop to wait for
statd to advertise an rpc address.

Upstream bug: DLPX-24767