### PR TITLE
7236 libumem should be able to abort() when an allocation fails

### DIFF
--- a/usr/src/cmd/mdb/common/modules/libumem/umem.c
+++ b/usr/src/cmd/mdb/common/modules/libumem/umem.c
@@ -25,7 +25,7 @@
 
 /*
  * Copyright 2012 Joyent, Inc.  All rights reserved.
- * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
  */
 
 #include "umem.h"
@@ -336,6 +336,7 @@ umem_debug_flags_t umem_status_flags[] = {
 	{ "nosignal",	UMF_CHECKSIGNAL },
 	{ "firewall",	UMF_FIREWALL },
 	{ "lite",	UMF_LITE },
+	{ "checknull",	UMF_CHECKNULL },
 	{ NULL }
 };
 

--- a/usr/src/lib/libumem/common/envvar.c
+++ b/usr/src/lib/libumem/common/envvar.c
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2012 Joyent, Inc. All rights reserved.
+ * Copyright (c) 2015 by Delphix. All rights reserved.
  */
 
 #include <ctype.h>
@@ -225,6 +226,10 @@ static umem_env_item_t umem_debug_items[] = {
 	{ "allverbose",		"Private",	ITEM_FLAG,
 		"Enables writing all logged messages to stderr",
 		&umem_output,	2
+	},
+	{ "checknull",		"Private",	ITEM_FLAG,
+		"Abort if an allocation would return null",
+		&umem_flags,	UMF_CHECKNULL
 	},
 
 	{ NULL, "-- end of UMEM_DEBUG --",	ITEM_INVALID }

--- a/usr/src/lib/libumem/common/umem.c
+++ b/usr/src/lib/libumem/common/umem.c
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2014 Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2015 by Delphix. All rights reserved.
  */
 
 /*
@@ -1233,6 +1234,9 @@ umem_alloc_retry(umem_cache_t *cp, int umflag)
 		/*
 		 * Initialization failed.  Do normal failure processing.
 		 */
+	}
+	if (umem_flags & UMF_CHECKNULL) {
+		umem_err_recoverable("umem: out of heap space");
 	}
 	if (umflag & UMEM_NOFAIL) {
 		int def_result = UMEM_CALLBACK_EXIT(255);

--- a/usr/src/lib/libumem/common/umem_impl.h
+++ b/usr/src/lib/libumem/common/umem_impl.h
@@ -26,6 +26,7 @@
 
 /*
  * Copyright (c) 2012 Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2015 by Delphix. All rights reserved.
  */
 
 #ifndef _UMEM_IMPL_H
@@ -67,6 +68,8 @@ extern "C" {
 #define	UMF_HASH	0x00000200	/* cache has hash table */
 #define	UMF_RANDOMIZE	0x00000400	/* randomize other umem_flags */
 #define	UMF_PTC		0x00000800	/* cache has per-thread caching */
+
+#define	UMF_CHECKNULL	0x00001000	/* heap exhaustion checking */
 
 #define	UMF_BUFTAG	(UMF_DEADBEEF | UMF_REDZONE)
 #define	UMF_TOUCH	(UMF_BUFTAG | UMF_LITE | UMF_CONTENTS)


### PR DESCRIPTION
Reviewed by: Alex Reece <alex@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Basil Crow <basil.crow@delphix.com>

When libumem isn't able to satisfy an allocation request, it can be hard
to debug why that was true unless you manage to get a core dump or other
debug information from that exact instant so you can analyze the
contents of the heap. This adds that feature to libumem through a new
UMEM_DEBUG environment variable argument called "checknull".

Upstream bug: DLPX-37155