### PR TITLE
7238 zvol_swap/setup fails due to memory usage

### DIFF
--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -548,10 +548,6 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
 
-[/opt/zfs-tests/tests/functional/zvol/zvol_swap]
-tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
-
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']
 pre =

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_swap/setup.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,6 +34,9 @@
 . $STF_SUITE/tests/functional/zvol/zvol_swap/zvol_swap.cfg
 
 verify_runnable "global"
+
+# Restart fmd to lower the chances of swap -d failing with ENOMEM.
+log_must $SVCADM restart svc:/system/fmd:default
 
 for i in $SAVESWAPDEVS ; do
 	log_note "Executing: swap -d $i"


### PR DESCRIPTION
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Will Guyette <will.guyette@delphix.com>

Restart fmd to free up more memory for swap -d operation during
execution of zvol_swap/setup.

Upstream bug: QA-4325