### PR TITLE
7232 add tunables to combat scheduling delay of kernel threads

### DIFF
--- a/usr/src/uts/common/disp/sysdc.c
+++ b/usr/src/uts/common/disp/sysdc.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  */
 
 /*
@@ -393,7 +393,7 @@ sysdc_initparam(void)
 	sysdc_minDC = 1;
 	sysdc_maxDC = SYSDC_DC_MAX;
 	sysdc_minpri = 0;
-	sysdc_maxpri = maxclsyspri;
+	sysdc_maxpri = maxclsyspri - 1;
 
 	/* break parameters */
 	if (sysdc_max_pset_DC > SYSDC_DC_MAX) {

--- a/usr/src/uts/common/os/kmem.c
+++ b/usr/src/uts/common/os/kmem.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1994, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  */
 
@@ -2185,11 +2186,19 @@ kmem_depot_ws_zero(kmem_cache_t *cp)
 }
 
 /*
+ * The number of bytes to reap before we call kpreempt(). The default (1MB)
+ * causes us to preempt reaping up to hundreds of times per second. Using a
+ * larger value (1GB) causes this to have virtually no effect.
+ */
+size_t kmem_reap_preempt_bytes = 1024 * 1024;
+
+/*
  * Reap all magazines that have fallen out of the depot's working set.
  */
 static void
 kmem_depot_ws_reap(kmem_cache_t *cp)
 {
+	size_t bytes = 0;
 	long reap;
 	kmem_magazine_t *mp;
 
@@ -2197,12 +2206,26 @@ kmem_depot_ws_reap(kmem_cache_t *cp)
 	    taskq_member(kmem_taskq, curthread));
 
 	reap = MIN(cp->cache_full.ml_reaplimit, cp->cache_full.ml_min);
-	while (reap-- && (mp = kmem_depot_alloc(cp, &cp->cache_full)) != NULL)
+	while (reap-- &&
+	    (mp = kmem_depot_alloc(cp, &cp->cache_full)) != NULL) {
 		kmem_magazine_destroy(cp, mp, cp->cache_magtype->mt_magsize);
+		bytes += cp->cache_magtype->mt_magsize * cp->cache_bufsize;
+		if (bytes > kmem_reap_preempt_bytes) {
+			kpreempt(KPREEMPT_SYNC);
+			bytes = 0;
+		}
+	}
 
 	reap = MIN(cp->cache_empty.ml_reaplimit, cp->cache_empty.ml_min);
-	while (reap-- && (mp = kmem_depot_alloc(cp, &cp->cache_empty)) != NULL)
+	while (reap-- &&
+	    (mp = kmem_depot_alloc(cp, &cp->cache_empty)) != NULL) {
 		kmem_magazine_destroy(cp, mp, 0);
+		bytes += cp->cache_magtype->mt_magsize * cp->cache_bufsize;
+		if (bytes > kmem_reap_preempt_bytes) {
+			kpreempt(KPREEMPT_SYNC);
+			bytes = 0;
+		}
+	}
 }
 
 static void


### PR DESCRIPTION
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>

Some threads need to be scheduled promptly, for example after receiving
an interrupt, however even if they are running with the highest priority
(pri=99), they can't get on CPU until another thread is voluntarily
descheduled. This is made even worse by having some long-running pri=99
threads.

The solution has several parts:
1. reducing ZIO threads to pri=98
2. shrinking the vmem hashtable only if it is 8x as large as necessary
3. force kmem_depo_ws_reap() to be voluntarily descheduled

Upstream bugs: DLPX-36188, DLPX-37976, DLPX-45382
Diff by @ahrens