### PR TITLE
7257 zfs manpage user property length needs to be updated

### DIFF
--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -1629,9 +1629,8 @@ and so forth
 .Pc
 can be used to manipulate both native properties and user properties. Use the
 .Nm zfs Cm inherit
-command to clear a user property . If the property is not defined in any parent
-dataset, it is removed entirely. Property values are limited to 1024
-characters.
+command to clear a user property. If the property is not defined in any parent
+dataset, it is removed entirely. Property values are limited to 8192 bytes.
 .Ss ZFS Volumes as Swap or Dump Devices
 During an initial installation a swap device and dump device are created on ZFS
 volumes in the ZFS root pool. By default, the swap area size is based on 1/2 the


### PR DESCRIPTION
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>

The zfs.1m manpage says:

    User Properties
    ...
       Property values are limited to 1024 characters.

Since zpool version 16, this limit is actually 8192 characters.
Additionally, this limit is actually 8192 _bytes_, as it supports UTF-8.

This patch updates the manpage to reflect the increase in length, and
replaces "characters" with "bytes".

Upstream bugs: DLPX-36740