### PR TITLE
7260 disable libdiskmgmt in zfstest unless it's required

### DIFF
--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -17,6 +17,7 @@
 # Copyright 2016 Nexenta Systems, Inc.
 #
 
+export NOINUSE_CHECK=1
 export STF_SUITE="/opt/zfs-tests"
 export STF_TOOLS="/opt/test-runner/stf"
 runner="/opt/test-runner/bin/run"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_005_pos.ksh
@@ -24,6 +24,11 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+
+#
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+#
+
 . $STF_SUITE/include/libtest.shlib
 . $STF_SUITE/tests/functional/cli_root/zpool_add/zpool_add.kshlib
 
@@ -71,10 +76,10 @@ log_must poolexists "$TESTPOOL"
 
 create_pool "$TESTPOOL1" "${disk}s${SLICE1}"
 log_must poolexists "$TESTPOOL1"
+
+unset NOINUSE_CHECK
 log_mustnot $ZPOOL add -f "$TESTPOOL" ${disk}s${SLICE1}
-
 log_mustnot $ZPOOL add -f "$TESTPOOL" $mnttab_dev
-
 log_mustnot $ZPOOL add -f "$TESTPOOL" $vfstab_dev
 
 log_must $ECHO "y" | $NEWFS /dev/dsk/$dump_dev > /dev/null 2>&1

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -83,6 +83,7 @@ log_must $MKFILE $SIZE /var/tmp/$FILEDISK0
 log_must $MKFILE $SIZE /var/tmp/$FILEDISK1
 log_must $MKFILE $SIZE /var/tmp/$FILEDISK2
 
+unset NOINUSE_CHECK
 log_must $ZPOOL export $TESTPOOL
 log_note "'zpool create' without '-f' will fail " \
 	"while device is belong to an exported pool."

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_008_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -128,6 +128,7 @@ destroy_pool $TESTPOOL
 log_must labelvtoc $disk
 log_must create_overlap_slice $disk
 
+unset NOINUSE_CHECK
 log_mustnot $ZPOOL create $TESTPOOL ${disk}s${SLICE0}
 log_must $ZPOOL create -f $TESTPOOL ${disk}s${SLICE0}
 destroy_pool $TESTPOOL

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_009_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_009_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -66,6 +66,7 @@ log_assert "Create a pool with same devices twice or create two pools with " \
 	"same devices, 'zpool create' should fail."
 log_onexit cleanup
 
+unset NOINUSE_CHECK
 typeset opt
 for opt in "" "mirror" "raidz" "raidz1"; do
 	typeset disk="$DISKS"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_011_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -105,6 +105,7 @@ set -A arg "$TESTPOOL $pooldev2" \
         "$TESTPOOL1 ${disk}s10" \
 	"$TESTPOOL1 spare $pooldev2"
 
+unset NOINUSE_CHECK
 typeset -i i=0
 while (( i < ${#arg[*]} )); do
         log_mustnot $ZPOOL create ${arg[i]}

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_015_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -63,9 +63,9 @@ function cleanup
 			destroy_pool $pool
 		fi
 	done
-
 }
 
+unset NOINUSE_CHECK
 if [[ -n $DISK ]]; then
         disk=$DISK
 else

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -79,6 +79,7 @@ dumpdev=`$DUMPADM | $GREP "Dump device" | $AWK '{print $3}'`
     log_untested "Dump device has not been been configured to $diskslice"
 
 log_note "Attempt to zpool the dump device"
+unset NOINUSE_CHECK
 log_mustnot $ZPOOL create $TESTPOOL "$diskslice"
 log_mustnot poolexists $TESTPOOL
 

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_003_pos.ksh
@@ -141,6 +141,7 @@ log_note "$UFSDUMP 0bf 512 $rawdisk0 $disk1"
 $UFSDUMP 0bf 512 $rawdisk0 $disk1 &
 PIDUFSDUMP=$!
 
+unset NOINUSE_CHECK
 log_note "Attempt to zpool the source device in use by ufsdump"
 log_mustnot $ZPOOL create $TESTPOOL1 "$disk1"
 log_mustnot poolexists $TESTPOOL1

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_005_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -76,6 +76,7 @@ set -A vdevs "" "mirror" "raidz" "raidz1" "raidz2"
 
 typeset -i i=0
 
+unset NOINUSE_CHECK
 while (( i < ${#vdevs[*]} )); do
 
 	for num in 0 1 2 3 ; do

--- a/usr/src/test/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inuse/inuse_006_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -79,6 +79,7 @@ typeset -i i=0
 
 PREVDUMPDEV=`$DUMPADM | $GREP "Dump device" | $AWK '{print $3}'`
 
+unset NOINUSE_CHECK
 while (( i < ${#vdevs[*]} )); do
 
 	for num in 0 1 2 3 ; do

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_003_neg.ksh
@@ -69,6 +69,7 @@ savedumpdev=$(get_dumpdevice)
 
 safe_dumpadm $voldev
 
+unset NOINUSE_CHECK
 $ECHO "y" | $NEWFS -v $voldev > /dev/null 2>&1
 if (( $? == 0 )) ; then
 	log_fail "newfs on dump zvol succeeded unexpectedly"


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

Most tests in the ZFS test suite do not require libdiskmgmt, so this
patch diables it by default, and tests the require it to be enabled
must explicitly enable it for that specific test using:

    unset NOINUSE_CHECK

We've measured the entire ZFS test suite to run about 35% faster when
using this change.

Upstream Bugs: QA-6191, QA-880