### PR TITLE
7262 remove seq from zfs_receive_010.ksh

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_010_pos.ksh
@@ -21,7 +21,7 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -138,7 +138,7 @@ $RM $mntpnt/h17
 $RM $mntpnt2/h*
 
 # Add empty objects to $fs to exercise dmu_traverse code
-for i in `seq 1 100`; do
+for i in {1..100}; do
 	log_must touch $mntpnt/uf$i
 done
 


### PR DESCRIPTION
Reviewed by: John Wren Kennedy <john.kennedy@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>

There's no good reason to use the GNU utility "seq" to do a simple for
loop in the ZFS test suite. This patch replaces "seq" with "{..}" in the
"zfs_receive_010_pos" test case.

Upstream Bugs: DLPX-41844