### PR TITLE
7278 tuning zfs_arc_max does not impact arc_c_min

### DIFF
--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -5606,8 +5606,10 @@ arc_init(void)
 	 * Allow the tunables to override our calculations if they are
 	 * reasonable (ie. over 64MB)
 	 */
-	if (zfs_arc_max > 64 << 20 && zfs_arc_max < allmem)
+	if (zfs_arc_max > 64 << 20 && zfs_arc_max < allmem) {
 		arc_c_max = zfs_arc_max;
+		arc_c_min = MIN(arc_c_min, arc_c_max);
+	}
 	if (zfs_arc_min > 64 << 20 && zfs_arc_min <= arc_c_max)
 		arc_c_min = zfs_arc_min;
 


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Paul Dagnelie <paul.dagnelie@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>

When changing zfs_arc_max (e.g. as zdb does), it may be set to less
than the default arc_c_min. arc_c_min should decrease to not be more than
arc_c_max, but it doesn't; therefore tuning of arc_c_max is ineffective.

Upstream Bugs: DLPX-43438