### PR TITLE
6363 Add UNMAP/TRIM functionality to ZFS and Illumos

### DIFF
--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -25,7 +25,7 @@
  * Copyright (c) 2012 by Frederik Wessels. All rights reserved.
  * Copyright (c) 2013 by Prasad Joshi (sTec). All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  */
 
 #include <assert.h>
@@ -81,6 +81,7 @@ static int zpool_do_replace(int, char **);
 static int zpool_do_split(int, char **);
 
 static int zpool_do_scrub(int, char **);
+static int zpool_do_trim(int, char **);
 
 static int zpool_do_import(int, char **);
 static int zpool_do_export(int, char **);
@@ -129,6 +130,7 @@ typedef enum {
 	HELP_REPLACE,
 	HELP_REMOVE,
 	HELP_SCRUB,
+	HELP_TRIM,
 	HELP_STATUS,
 	HELP_UPGRADE,
 	HELP_GET,
@@ -178,6 +180,8 @@ static zpool_command_t command_table[] = {
 	{ "split",	zpool_do_split,		HELP_SPLIT		},
 	{ NULL },
 	{ "scrub",	zpool_do_scrub,		HELP_SCRUB		},
+	{ NULL },
+	{ "trim",	zpool_do_trim,		HELP_TRIM		},
 	{ NULL },
 	{ "import",	zpool_do_import,	HELP_IMPORT		},
 	{ "export",	zpool_do_export,	HELP_EXPORT		},
@@ -250,6 +254,8 @@ get_usage(zpool_help_t idx)
 		return (gettext("\treopen <pool>\n"));
 	case HELP_SCRUB:
 		return (gettext("\tscrub [-s] <pool> ...\n"));
+	case HELP_TRIM:
+		return (gettext("\ttrim [-s|-r <rate>] <pool> ...\n"));
 	case HELP_STATUS:
 		return (gettext("\tstatus [-vx] [-T d|u] [pool] ... [interval "
 		    "[count]]\n"));
@@ -3822,6 +3828,31 @@ scrub_callback(zpool_handle_t *zhp, void *data)
 	return (err != 0);
 }
 
+typedef struct trim_cbdata {
+	boolean_t	cb_start;
+	uint64_t	cb_rate;
+} trim_cbdata_t;
+
+int
+trim_callback(zpool_handle_t *zhp, void *data)
+{
+	trim_cbdata_t *cb = data;
+	int err;
+
+	/*
+	 * Ignore faulted pools.
+	 */
+	if (zpool_get_state(zhp) == POOL_STATE_UNAVAIL) {
+		(void) fprintf(stderr, gettext("cannot trim '%s': pool is "
+		    "currently unavailable\n"), zpool_get_name(zhp));
+		return (1);
+	}
+
+	err = zpool_trim(zhp, cb->cb_start, cb->cb_rate);
+
+	return (err != 0);
+}
+
 /*
  * zpool scrub [-s] <pool> ...
  *
@@ -3859,6 +3890,52 @@ zpool_do_scrub(int argc, char **argv)
 	}
 
 	return (for_each_pool(argc, argv, B_TRUE, NULL, scrub_callback, &cb));
+}
+
+/*
+ * zpool trim [-s|-r <rate>] <pool> ...
+ *
+ *	-s		Stop. Stops any in-progress trim.
+ *	-r <rate>	Sets the TRIM rate.
+ */
+int
+zpool_do_trim(int argc, char **argv)
+{
+	int c;
+	trim_cbdata_t cb;
+
+	cb.cb_start = B_TRUE;
+	cb.cb_rate = 0;
+
+	/* check options */
+	while ((c = getopt(argc, argv, "sr:")) != -1) {
+		switch (c) {
+		case 's':
+			cb.cb_start = B_FALSE;
+			break;
+		case 'r':
+			if (zfs_nicestrtonum(NULL, optarg, &cb.cb_rate) == -1) {
+				(void) fprintf(stderr,
+				    gettext("invalid value for rate\n"));
+				usage(B_FALSE);
+			}
+			break;
+		case '?':
+			(void) fprintf(stderr, gettext("invalid option '%c'\n"),
+			    optopt);
+			usage(B_FALSE);
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (argc < 1) {
+		(void) fprintf(stderr, gettext("missing pool name argument\n"));
+		usage(B_FALSE);
+	}
+
+	return (for_each_pool(argc, argv, B_TRUE, NULL, trim_callback, &cb));
 }
 
 typedef struct status_cbdata {
@@ -3983,6 +4060,59 @@ print_scan_status(pool_scan_stat_t *ps)
 }
 
 static void
+print_trim_status(uint64_t trim_prog, uint64_t total_size, uint64_t rate,
+    uint64_t start_time_u64, uint64_t end_time_u64)
+{
+	time_t start_time = start_time_u64, end_time = end_time_u64;
+	char *buf;
+
+	assert(trim_prog <= total_size);
+	if (trim_prog != 0 && trim_prog != total_size) {
+		buf = ctime(&start_time);
+		buf[strlen(buf) - 1] = '\0';	/* strip trailing newline */
+		if (rate != 0) {
+			char rate_str[32];
+			zfs_nicenum(rate, rate_str, sizeof (rate_str));
+			(void) printf("  trim: %.02f%%\tstarted: %s\t"
+			    "(rate: %s/s)\n", (((double)trim_prog) /
+			    total_size) * 100, buf, rate_str);
+		} else {
+			(void) printf("  trim: %.02f%%\tstarted: %s\t"
+			    "(rate: max)\n", (((double)trim_prog) /
+			    total_size) * 100, buf);
+		}
+	} else {
+		if (start_time != 0) {
+			/*
+			 * Non-zero start time means we were run at some point
+			 * in the past.
+			 */
+			if (end_time != 0) {
+				/* Non-zero end time means we completed */
+				time_t diff = end_time - start_time;
+				int hrs, mins;
+
+				buf = ctime(&end_time);
+				buf[strlen(buf) - 1] = '\0';
+				hrs = diff / 3600;
+				mins = (diff % 3600) / 60;
+				(void) printf(gettext("  trim: completed on %s "
+				    "(after %dh%dm)\n"), buf, hrs, mins);
+			} else {
+				buf = ctime(&start_time);
+				buf[strlen(buf) - 1] = '\0';
+				/* Zero end time means we were interrupted */
+				(void) printf(gettext("  trim: interrupted\t"
+				    "(started %s)\n"), buf);
+			}
+		} else {
+			/* trim was never run */
+			(void) printf(gettext("  trim: none requested\n"));
+		}
+	}
+}
+
+static void
 print_error_log(zpool_handle_t *zhp)
 {
 	nvlist_t *nverrlist = NULL;
@@ -4091,6 +4221,43 @@ print_dedup_stats(nvlist_t *config)
 	verify(nvlist_lookup_uint64_array(config, ZPOOL_CONFIG_DDT_HISTOGRAM,
 	    (uint64_t **)&ddh, &c) == 0);
 	zpool_dump_ddt(dds, ddh);
+}
+
+/*
+ * Calculates the total space available on log devices on the pool.
+ * For whatever reason, this is not counted in the root vdev's space stats.
+ */
+static uint64_t
+zpool_slog_space(nvlist_t *nvroot)
+{
+	nvlist_t **newchild;
+	uint_t c, children;
+	uint64_t space = 0;
+
+	verify(nvlist_lookup_nvlist_array(nvroot, ZPOOL_CONFIG_CHILDREN,
+	    &newchild, &children) == 0);
+
+	for (c = 0; c < children; c++) {
+		uint64_t islog = B_FALSE;
+		vdev_stat_t *vs;
+		uint_t n;
+		uint_t n_subchildren = 1;
+		nvlist_t **subchild;
+
+		(void) nvlist_lookup_uint64(newchild[c], ZPOOL_CONFIG_IS_LOG,
+		    &islog);
+		if (!islog)
+			continue;
+		verify(nvlist_lookup_uint64_array(newchild[c],
+		    ZPOOL_CONFIG_VDEV_STATS, (uint64_t **)&vs, &n) == 0);
+
+		/* vdev can be non-leaf, so multiply by number of children */
+		(void) nvlist_lookup_nvlist_array(newchild[c],
+		    ZPOOL_CONFIG_CHILDREN, &subchild, &n_subchildren);
+		space += n_subchildren * vs->vs_space;
+	}
+
+	return (space);
 }
 
 /*
@@ -4355,10 +4522,29 @@ status_callback(zpool_handle_t *zhp, void *data)
 		nvlist_t **spares, **l2cache;
 		uint_t nspares, nl2cache;
 		pool_scan_stat_t *ps = NULL;
+		uint64_t trim_prog, trim_rate, trim_start_time, trim_stop_time;
 
 		(void) nvlist_lookup_uint64_array(nvroot,
 		    ZPOOL_CONFIG_SCAN_STATS, (uint64_t **)&ps, &c);
 		print_scan_status(ps);
+
+		/* Grab trim stats if the pool supports it */
+		if (nvlist_lookup_uint64(config, ZPOOL_CONFIG_TRIM_PROG,
+		    &trim_prog) == 0 &&
+		    nvlist_lookup_uint64(config, ZPOOL_CONFIG_TRIM_RATE,
+		    &trim_rate) == 0 &&
+		    nvlist_lookup_uint64(config, ZPOOL_CONFIG_TRIM_START_TIME,
+		    &trim_start_time) == 0 &&
+		    nvlist_lookup_uint64(config, ZPOOL_CONFIG_TRIM_STOP_TIME,
+		    &trim_stop_time) == 0) {
+			/*
+			 * For whatever reason, root vdev_stats_t don't
+			 * include log devices.
+			 */
+			print_trim_status(trim_prog, vs->vs_space +
+			    zpool_slog_space(nvroot), trim_rate,
+			    trim_start_time, trim_stop_time);
+		}
 
 		namewidth = max_width(zhp, nvroot, 0, 0);
 		if (namewidth < 10)

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -48,6 +48,7 @@
 #include <zfs_prop.h>
 #include <sys/fs/zfs.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include <libzfs.h>
 
@@ -4066,7 +4067,6 @@ print_trim_status(uint64_t trim_prog, uint64_t total_size, uint64_t rate,
 	time_t start_time = start_time_u64, end_time = end_time_u64;
 	char *buf;
 
-	assert(trim_prog <= total_size);
 	if (trim_prog != 0 && trim_prog != total_size) {
 		buf = ctime(&start_time);
 		buf[strlen(buf) - 1] = '\0';	/* strip trailing newline */
@@ -4074,12 +4074,12 @@ print_trim_status(uint64_t trim_prog, uint64_t total_size, uint64_t rate,
 			char rate_str[32];
 			zfs_nicenum(rate, rate_str, sizeof (rate_str));
 			(void) printf("  trim: %.02f%%\tstarted: %s\t"
-			    "(rate: %s/s)\n", (((double)trim_prog) /
-			    total_size) * 100, buf, rate_str);
+			    "(rate: %s/s)\n", MIN((((double)trim_prog) /
+			    total_size) * 100, 100), buf, rate_str);
 		} else {
 			(void) printf("  trim: %.02f%%\tstarted: %s\t"
-			    "(rate: max)\n", (((double)trim_prog) /
-			    total_size) * 100, buf);
+			    "(rate: max)\n", MIN((((double)trim_prog) /
+			    total_size) * 100, 100), buf);
 		}
 	} else {
 		if (start_time != 0) {
@@ -4541,9 +4541,9 @@ status_callback(zpool_handle_t *zhp, void *data)
 			 * For whatever reason, root vdev_stats_t don't
 			 * include log devices.
 			 */
-			print_trim_status(trim_prog, vs->vs_space +
-			    zpool_slog_space(nvroot), trim_rate,
-			    trim_start_time, trim_stop_time);
+			print_trim_status(trim_prog, (vs->vs_space -
+			    vs->vs_alloc) + zpool_slog_space(nvroot),
+			    trim_rate, trim_start_time, trim_stop_time);
 		}
 
 		namewidth = max_width(zhp, nvroot, 0, 0);

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -3897,7 +3897,8 @@ zpool_do_scrub(int argc, char **argv)
  * zpool trim [-s|-r <rate>] <pool> ...
  *
  *	-s		Stop. Stops any in-progress trim.
- *	-r <rate>	Sets the TRIM rate.
+ *	-r <rate>	Sets the TRIM rate in bytes (per second). Supports
+ *			adding a multiplier suffix such as 'k' or 'm'.
  */
 int
 zpool_do_trim(int argc, char **argv)
@@ -4074,11 +4075,11 @@ print_trim_status(uint64_t trim_prog, uint64_t total_size, uint64_t rate,
 			char rate_str[32];
 			zfs_nicenum(rate, rate_str, sizeof (rate_str));
 			(void) printf("  trim: %.02f%%\tstarted: %s\t"
-			    "(rate: %s/s)\n", MIN((((double)trim_prog) /
+			    "(rate limit: %s/s)\n", MIN((((double)trim_prog) /
 			    total_size) * 100, 100), buf, rate_str);
 		} else {
 			(void) printf("  trim: %.02f%%\tstarted: %s\t"
-			    "(rate: max)\n", MIN((((double)trim_prog) /
+			    "(rate limit: none)\n", MIN((((double)trim_prog) /
 			    total_size) * 100, 100), buf);
 		}
 	} else {

--- a/usr/src/common/zfs/zpool_prop.c
+++ b/usr/src/common/zfs/zpool_prop.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  */
@@ -124,6 +124,12 @@ zpool_prop_init(void)
 	zprop_register_index(ZPOOL_PROP_FAILUREMODE, "failmode",
 	    ZIO_FAILURE_MODE_WAIT, PROP_DEFAULT, ZFS_TYPE_POOL,
 	    "wait | continue | panic", "FAILMODE", failuremode_table);
+	zprop_register_index(ZPOOL_PROP_FORCETRIM, "forcetrim",
+	    SPA_FORCE_TRIM_OFF, PROP_DEFAULT, ZFS_TYPE_POOL,
+	    "on | off", "FORCETRIM", boolean_table);
+	zprop_register_index(ZPOOL_PROP_AUTOTRIM, "autotrim",
+	    SPA_AUTO_TRIM_OFF, PROP_DEFAULT, ZFS_TYPE_POOL,
+	    "on | off", "AUTOTRIM", boolean_table);
 
 	/* hidden properties */
 	zprop_register_hidden(ZPOOL_PROP_NAME, "name", PROP_TYPE_STRING,

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -26,7 +26,7 @@
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  * Copyright (c) 2013 Steven Hartland. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  */
 
 #ifndef	_LIBZFS_H
@@ -240,6 +240,7 @@ typedef struct splitflags {
  * Functions to manipulate pool and vdev state
  */
 extern int zpool_scan(zpool_handle_t *, pool_scan_func_t);
+extern int zpool_trim(zpool_handle_t *, boolean_t start, uint64_t rate);
 extern int zpool_clear(zpool_handle_t *, const char *, nvlist_t *);
 extern int zpool_reguid(zpool_handle_t *);
 extern int zpool_reopen(zpool_handle_t *);

--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  */
 
@@ -1882,6 +1882,29 @@ zpool_scan(zpool_handle_t *zhp, pool_scan_func_t func)
 	} else {
 		return (zpool_standard_error(hdl, errno, msg));
 	}
+}
+
+/*
+ * Trim the pool.
+ */
+int
+zpool_trim(zpool_handle_t *zhp, boolean_t start, uint64_t rate)
+{
+	zfs_cmd_t zc = { 0 };
+	char msg[1024];
+	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	trim_cmd_info_t tci = { .tci_start = start, .tci_rate = rate };
+
+	(void) strlcpy(zc.zc_name, zhp->zpool_name, sizeof (zc.zc_name));
+	zc.zc_cookie = (uintptr_t)&tci;
+
+	if (zfs_ioctl(hdl, ZFS_IOC_POOL_TRIM, &zc) == 0)
+		return (0);
+
+	(void) snprintf(msg, sizeof (msg),
+	    dgettext(TEXT_DOMAIN, "cannot trim %s"), zc.zc_name);
+
+	return (zpool_standard_error(hdl, errno, msg));
 }
 
 /*

--- a/usr/src/lib/libzfs/common/libzfs_util.c
+++ b/usr/src/lib/libzfs/common/libzfs_util.c
@@ -24,6 +24,7 @@
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 /*
@@ -1065,8 +1066,9 @@ str2shift(libzfs_handle_t *hdl, const char *buf)
 			break;
 	}
 	if (i == strlen(ends)) {
-		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-		    "invalid numeric suffix '%s'"), buf);
+		if (hdl)
+			zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+			    "invalid numeric suffix '%s'"), buf);
 		return (-1);
 	}
 
@@ -1078,8 +1080,9 @@ str2shift(libzfs_handle_t *hdl, const char *buf)
 	    toupper(buf[0]) != 'B'))
 		return (10*i);
 
-	zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
-	    "invalid numeric suffix '%s'"), buf);
+	if (hdl)
+		zfs_error_aux(hdl, dgettext(TEXT_DOMAIN,
+		    "invalid numeric suffix '%s'"), buf);
 	return (-1);
 }
 

--- a/usr/src/lib/libzfs/common/mapfile-vers
+++ b/usr/src/lib/libzfs/common/mapfile-vers
@@ -22,7 +22,7 @@
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2011, 2014 by Delphix. All rights reserved.
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2017 Nexenta Systems, Inc.
 #
 
 #
@@ -240,6 +240,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zpool_set_prop;
 	zpool_skip_pool;
 	zpool_state_to_name;
+	zpool_trim;
 	zpool_unmount_datasets;
 	zpool_upgrade;
 	zpool_vdev_attach;

--- a/usr/src/lib/libzpool/Makefile.com
+++ b/usr/src/lib/libzpool/Makefile.com
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+# Copyright 2017 Nexenta Systems, Inc. All rights reserved.
 #
 
 LIBRARY= libzpool.a
@@ -28,7 +29,7 @@ VERS= .1
 
 # include the list of ZFS sources
 include ../../../uts/common/Makefile.files
-KERNEL_OBJS = kernel.o taskq.o util.o
+KERNEL_OBJS = kernel.o taskq.o util.o dkioc_free_util.o
 DTRACE_OBJS = zfs.o
 
 OBJECTS=$(ZFS_COMMON_OBJS) $(ZFS_SHARED_OBJS) $(KERNEL_OBJS)
@@ -99,3 +100,7 @@ pics/%.o: ../common/%.d $(PICS)
 
 ../common/%.h: ../common/%.d
 	$(DTRACE) -xnolibs -h -s $< -o $@
+
+pics/%.o: ../../../uts/common/os/%.c
+	$(COMPILE.c) -o $@ $<
+	$(POST_PROCESS_O)

--- a/usr/src/lib/libzpool/common/kernel.c
+++ b/usr/src/lib/libzpool/common/kernel.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <assert.h>
@@ -886,6 +887,14 @@ ddi_strtoull(const char *str, char **nptr, int base, u_longlong_t *result)
 	*result = strtoull(str, &end, base);
 	if (*result == 0)
 		return (errno);
+	return (0);
+}
+
+/* ARGSUSED */
+int
+ddi_copyin(const void *buf, void *driverbuf, size_t cn, int flags)
+{
+	bcopy(buf, driverbuf, cn);
 	return (0);
 }
 

--- a/usr/src/lib/libzpool/common/sys/zfs_context.h
+++ b/usr/src/lib/libzpool/common/sys/zfs_context.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  */
@@ -480,6 +480,8 @@ extern int fop_getattr(vnode_t *vp, vattr_t *vap);
 #define	VOP_GETATTR(vp, vap, fl, cr, ct)  fop_getattr((vp), (vap));
 
 #define	VOP_FSYNC(vp, f, cr, ct)	fsync((vp)->v_fd)
+#define	VOP_SPACE(vp, cmd, flck, fl, off, cr, ct) \
+	fcntl((vp)->v_fd, cmd, (flck), sizeof (*(flck)))
 
 #define	VN_RELE(vp)	vn_close(vp)
 
@@ -531,6 +533,8 @@ extern void delay(clock_t ticks);
 
 #define	ptob(x)		((x) * PAGESIZE)
 
+#define	FKIOCTL		1
+
 extern uint64_t physmem;
 
 extern int highbit64(uint64_t i);
@@ -581,6 +585,8 @@ extern int ddi_strtoul(const char *str, char **nptr, int base,
 
 extern int ddi_strtoull(const char *str, char **nptr, int base,
     u_longlong_t *result);
+
+extern int ddi_copyin(const void *buf, void *driverbuf, size_t cn, int flags);
 
 /* ZFS Boot Related stuff. */
 

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (c) 2007, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2013 by Delphix. All rights reserved.
-.\" Copyright 2016 Nexenta Systems, Inc.
+.\" Copyright 2017 Nexenta Systems, Inc.
 .\"
 .Dd March 30, 2016
 .Dt ZPOOL 1M
@@ -137,6 +137,10 @@
 .Nm
 .Cm scrub
 .Op Fl s
+.Ar pool Ns ...
+.Nm
+.Cm trim
+.Op Fl r Ar rate | Fl s
 .Ar pool Ns ...
 .Nm
 .Cm set
@@ -595,6 +599,42 @@ blocked.
 .It Sy panic
 Prints out a message to the console and generates a system crash dump.
 .El
+.It Sy autotrim Ns = Ns Sy on Ns | Ns Sy off
+When set to
+.Sy on Ns , while deleting data, ZFS will inform the underlying vdevs of any
+blocks that have been marked as freed. This allows thinly provisioned vdevs to
+reclaim unused blocks. Currently, this feature supports sending SCSI UNMAP
+commands to SCSI and SAS disk vdevs, SATA TRIM commands to SATA disk vdevs, and
+using file hole punching on file-backed vdevs. The default setting for this
+property is
+.Sy off .
+.Pp
+Please note that automatic trimming of data blocks can put significant stress
+on the underlying storage devices if they do not handle these commands in a
+background, low-priority manner. In that case, it may be possible to achieve
+most of the benefits of trimming free space on the pool by running a manual
+trim every once in a while during a maintenance window using the
+.Nm zpool Cm trim
+command.
+.Pp
+Automatic trim does not reclaim blocks after a delete immediately. Instead,
+it waits approximately 32-64 TXGs (or as defined by the
+.Nm zfs_txgs_per_trim
+tunable) to allow for more efficient aggregation of smaller portions of free
+space into fewer larger regions, as well as to allow for longer pool
+corruption recovery via
+.Nm zpool Cm import Fl F .
+.It Sy forcetrim Ns = Ns Sy on Ns | Ns Sy off
+Controls whether device support is taken into consideration when issuing
+TRIM commands to the underlying vdevs of the pool. Normally, both automatic
+trim and manual trim only issue TRIM commands if a vdev indicates support
+for it. Setting the
+.Sy forcetrim
+property to
+.Sy on
+will force ZFS to issue TRIMs even if it thinks a device does not support it.
+The default is
+.Sy off .
 .It Sy feature@ Ns Ar feature_name Ns = Ns Sy enabled
 The value of this property is the current state of
 .Ar feature_name .
@@ -1339,6 +1379,72 @@ does not allow a scrub to be started until the resilver completes.
 .Bl -tag -width Ds
 .It Fl s
 Stop scrubbing.
+.El
+.It Xo
+.Nm
+.Cm trim
+.Op Fl r Ar rate | Fl s
+.Ar pool Ns ...
+.Xc
+Initiates a manual TRIM operation on all of the free space of a pool.
+This informs the underlying storage devices of all of the blocks that
+the pool no longer considers allocated, thus allowing thinly provisioned
+storage devices to reclaim them. Please note that this collects all
+space marked as "freed" in the pool immediately and doesn't wait the
+.Nm zfs_txgs_per_trim
+delay as automatic TRIM does. Hence, this can limit pool corruption recovery
+options during and immediately following the manual TRIM to 1-2 TXGs into the
+past (instead of the standard 32-64 of automatic TRIM). This approach,
+however, allows you to recover the maximum amount of free space from the pool
+immediately without having to wait.
+.Pp
+Also note that a manual TRIM operation can be initiated irrespective of
+the
+.Sy autotrim
+zpool property setting. It does, however, respect the
+.Sy forcetrim
+zpool property.
+.Pp
+A manual TRIM operation does not conflict with an ongoing scrub, but it can
+put significant I/O stress on the underlying vdevs. A resilver, however,
+automatically stops a manual TRIM operation. You can manually reinitiate the
+TRIM operation after the resilver has started, by simply reissuing the
+.Nm zpool Cm trim
+command.
+.Pp
+Adding a vdev during TRIM is supported, although the progression display in
+.Nm zpool Cm status
+might not be entirely accurate in that case (TRIM will complete before
+reaching 100%). Removing or detaching a vdev will prematurely terminate
+a manual TRIM operation.
+.Bl -tag -width Ds
+.It Fl r Ar rate
+Controls the speed at which the TRIM operation progresses. Without this
+option, TRIM is executed in parallel on all top-level vdevs as quickly
+as possible. This option allows you to control how fast (in bytes per
+second) the TRIM is executed. This rate is applied on a per-vdev basis,
+i.e. every top-level vdev in the pool tries to match this speed. The rate
+argument supports common multiplier suffixes such as `k' for kilobytes,
+`m' for megabytes and `g' for gigabytes per second.
+.Pp
+Due to limitations in how the algorithm is designed, TRIMs are executed
+in whole-metaslab increments. Each top-level vdev contains approximately
+200 metaslabs, so a rate-limited TRIM progresses in steps. It TRIMs
+one metaslab completely and then waits for a while so that over the
+whole device, the speed averages out.
+.Pp
+When a manual TRIM operation is already in progress, this option
+changes its rate. To change a rate-limited TRIM to an unlimited one,
+simply execute the
+.Nm zpool Cm trim
+command without a
+.Fl r
+option.
+.El
+.Bl -tag -width Ds
+.It Fl s
+Stop trimming. If a manual TRIM operation is not ongoing at the moment,
+this does nothing and the command returns success.
 .El
 .It Xo
 .Nm

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -618,11 +618,9 @@ trim every once in a while during a maintenance window using the
 command.
 .Pp
 Automatic trim does not reclaim blocks after a delete immediately. Instead,
-it waits approximately 32-64 TXGs (or as defined by the
-.Nm zfs_txgs_per_trim
-tunable) to allow for more efficient aggregation of smaller portions of free
-space into fewer larger regions, as well as to allow for longer pool
-corruption recovery via
+it waits approximately 32-64 TXGs to allow for more efficient aggregation of
+smaller portions of free space into fewer larger regions, as well as to allow
+for longer pool corruption recovery via
 .Nm zpool Cm import Fl F .
 .It Sy forcetrim Ns = Ns Sy on Ns | Ns Sy off
 Controls whether device support is taken into consideration when issuing
@@ -1390,9 +1388,8 @@ Initiates a manual TRIM operation on all of the free space of a pool.
 This informs the underlying storage devices of all of the blocks that
 the pool no longer considers allocated, thus allowing thinly provisioned
 storage devices to reclaim them. Please note that this collects all
-space marked as "freed" in the pool immediately and doesn't wait the
-.Nm zfs_txgs_per_trim
-delay as automatic TRIM does. Hence, this can limit pool corruption recovery
+space marked as "freed" in the pool immediately and doesn't wait to age out
+blocks as automatic TRIM does. Hence, this can limit pool corruption recovery
 options during and immediately following the manual TRIM to 1-2 TXGs into the
 past (instead of the standard 32-64 of automatic TRIM). This approach,
 however, allows you to recover the maximum amount of free space from the pool
@@ -1426,12 +1423,6 @@ second) the TRIM is executed. This rate is applied on a per-vdev basis,
 i.e. every top-level vdev in the pool tries to match this speed. The rate
 argument supports common multiplier suffixes such as `k' for kilobytes,
 `m' for megabytes and `g' for gigabytes per second.
-.Pp
-Due to limitations in how the algorithm is designed, TRIMs are executed
-in whole-metaslab increments. Each top-level vdev contains approximately
-200 metaslabs, so a rate-limited TRIM progresses in steps. It TRIMs
-one metaslab completely and then waits for a while so that over the
-whole device, the speed averages out.
 .Pp
 When a manual TRIM operation is already in progress, this option
 changes its rate. To change a rate-limited TRIM to an unlimited one,

--- a/usr/src/pkg/manifests/system-header.mf
+++ b/usr/src/pkg/manifests/system-header.mf
@@ -24,7 +24,7 @@
 # Copyright (c) 2012 by Delphix. All rights reserved.
 # Copyright 2013 Saso Kiselkov. All rights reserved.
 # Copyright 2014 Garrett D'Amore <garrett@damore.org>
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2017 Nexenta Systems, Inc.
 # Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 #
 
@@ -919,6 +919,7 @@ file path=usr/include/sys/dirent.h
 file path=usr/include/sys/disp.h
 file path=usr/include/sys/dkbad.h
 file path=usr/include/sys/dkio.h
+file path=usr/include/sys/dkioc_free_util.h
 file path=usr/include/sys/dklabel.h
 $(sparc_ONLY)file path=usr/include/sys/dkmpio.h
 $(i386_ONLY)file path=usr/include/sys/dktp/altsctr.h

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -12,7 +12,7 @@
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2017 Nexenta Systems, Inc.
 #
 
 set name=pkg.fmri value=pkg:/system/test/zfstest@$(PKGVERS)
@@ -134,6 +134,7 @@ dir path=opt/zfs-tests/tests/functional/snapshot
 dir path=opt/zfs-tests/tests/functional/snapused
 dir path=opt/zfs-tests/tests/functional/sparse
 dir path=opt/zfs-tests/tests/functional/threadsappend
+dir path=opt/zfs-tests/tests/functional/trim
 dir path=opt/zfs-tests/tests/functional/truncate
 dir path=opt/zfs-tests/tests/functional/userquota
 dir path=opt/zfs-tests/tests/functional/utils_test
@@ -2165,6 +2166,12 @@ file path=opt/zfs-tests/tests/functional/threadsappend/setup mode=0555
 file path=opt/zfs-tests/tests/functional/threadsappend/threadsappend mode=0555
 file path=opt/zfs-tests/tests/functional/threadsappend/threadsappend_001_pos \
     mode=0555
+file path=opt/zfs-tests/tests/functional/trim/autotrim_001_pos mode=0555
+file path=opt/zfs-tests/tests/functional/trim/cleanup mode=0555
+file path=opt/zfs-tests/tests/functional/trim/manualtrim_001_pos mode=0555
+file path=opt/zfs-tests/tests/functional/trim/setup mode=0555
+file path=opt/zfs-tests/tests/functional/trim/trim.cfg mode=0444
+file path=opt/zfs-tests/tests/functional/trim/trim.kshlib mode=0444
 file path=opt/zfs-tests/tests/functional/truncate/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/truncate/setup mode=0555
 file path=opt/zfs-tests/tests/functional/truncate/truncate.cfg mode=0444

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -12,6 +12,7 @@
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright (c) 2017 Nexenta Systems, Inc. All rights reserved.
 #
 
 [DEFAULT]
@@ -521,6 +522,9 @@ tests = ['sparse_001_pos']
 
 [/opt/zfs-tests/tests/functional/threadsappend]
 tests = ['threadsappend_001_pos']
+
+[/opt/zfs-tests/tests/functional/trim]
+tests = ['autotrim_001_pos', 'manualtrim_001_pos']
 
 [/opt/zfs-tests/tests/functional/truncate]
 tests = ['truncate_001_pos', 'truncate_002_pos']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -12,6 +12,7 @@
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2017 Nexenta Systems, Inc. All rights reserved.
 #
 
 [DEFAULT]
@@ -517,6 +518,9 @@ tests = ['sparse_001_pos']
 
 [/opt/zfs-tests/tests/functional/threadsappend]
 tests = ['threadsappend_001_pos']
+
+[/opt/zfs-tests/tests/functional/trim]
+tests = ['autotrim_001_pos', 'manualtrim_001_pos']
 
 [/opt/zfs-tests/tests/functional/truncate]
 tests = ['truncate_001_pos', 'truncate_002_pos']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -12,6 +12,7 @@
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2017 Nexenta Systems, Inc. All rights reserved.
 #
 
 [DEFAULT]
@@ -517,6 +518,9 @@ tests = ['sparse_001_pos']
 
 [/opt/zfs-tests/tests/functional/threadsappend]
 tests = ['threadsappend_001_pos']
+
+[/opt/zfs-tests/tests/functional/trim]
+tests = ['autotrim_001_pos', 'manualtrim_001_pos']
 
 [/opt/zfs-tests/tests/functional/truncate]
 tests = ['truncate_001_pos', 'truncate_002_pos']

--- a/usr/src/test/zfs-tests/tests/functional/trim/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/trim/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 Nexenta Systems, Inc. All rights reserved.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/trim
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/trim/autotrim_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/trim/autotrim_001_pos.ksh
@@ -1,0 +1,125 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
+# Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/trim/trim.cfg
+. $STF_SUITE/tests/functional/trim/trim.kshlib
+
+set_tunable64 zfs_trim_min_ext_sz 0
+set_tunable32 zfs_txgs_per_trim 2
+
+function txgs
+{
+	typeset x
+
+	# Run some txgs in order to let autotrim do its work.
+	#
+	for x in 1 2 3; do
+		log_must $ZFS snapshot $TRIMPOOL@snap
+		log_must $ZFS destroy  $TRIMPOOL@snap
+		log_must $ZFS snapshot $TRIMPOOL@snap
+		log_must $ZFS destroy  $TRIMPOOL@snap
+		# We need to introduce some delay to get the queued trim zios
+		# to run through and actaully affect the host FS
+		sync
+		sleep 1
+	done
+}
+
+#
+# Let's try this on real disks first and do some scrubbing to check for
+# data integrity.
+#
+for z in 1 2 3; do
+	if [ $(echo "$TRIM_POOL_DISKS" | tr ' ' '\n' | grep -v '^$' | wc -l) \
+	    -le $z ]; then
+		continue
+	fi
+	log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL raidz$z \
+	    $TRIM_POOL_DISKS
+	log_must $ZPOOL set autotrim=on $TRIMPOOL
+	log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+	    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	for x in 1 2 3; do
+		log_must $FILE_WRITE -o create \
+		    -f "/$TRIMPOOL/${TESTFILE}-keep$x" \
+		    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	done
+	log_must rm "/$TRIMPOOL/$TESTFILE"
+	txgs
+	checkpool $TRIMPOOL
+	log_must $ZPOOL destroy $TRIMPOOL
+done
+
+#
+# Check various pool geometries: Create the pool, fill it, remove the test file,
+# run some txgs, export the pool and verify that the vdevs shrunk.
+#
+
+#
+# raidz
+#
+for z in 1 2 3; do
+	setupvdevs
+	log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL raidz$z $VDEVS
+	log_must $ZPOOL set autotrim=on $TRIMPOOL
+	log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+	    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	log_must rm "/$TRIMPOOL/$TESTFILE"
+	txgs
+	log_must $ZPOOL export $TRIMPOOL
+	checkvdevs
+done
+
+#
+# mirror
+#
+setupvdevs
+log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL mirror $MIRROR_VDEVS_1 \
+    mirror $MIRROR_VDEVS_2
+log_must $ZPOOL set autotrim=on $TRIMPOOL
+log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+log_must rm "/$TRIMPOOL/$TESTFILE"
+txgs
+log_must $ZPOOL export $TRIMPOOL
+checkvdevs
+
+#
+# stripe
+#
+setupvdevs
+log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL $STRIPE_VDEVS
+log_must $ZPOOL set autotrim=on $TRIMPOOL
+log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+log_must rm "/$TRIMPOOL/$TESTFILE"
+txgs
+log_must $ZPOOL export $TRIMPOOL
+checkvdevs
+
+log_pass TRIM successfully shrunk vdevs

--- a/usr/src/test/zfs-tests/tests/functional/trim/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/trim/cleanup.ksh
@@ -1,3 +1,4 @@
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -20,20 +21,16 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
 # Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
 #
 
-# Set the expected properties of zpool
-typeset -a properties=("size" "capacity" "altroot" "health" "guid" "version"
-    "bootfs" "delegation" "autoreplace" "cachefile" "dedupditto" "dedupratio"
-    "free" "allocated" "readonly" "comment" "expandsize" "freeing" "failmode"
-    "listsnapshots" "autoexpand" "forcetrim" "autotrim" "feature@async_destroy"
-    "feature@empty_bpobj" "feature@lz4_compress" "feature@multi_vdev_crash_dump"
-    "feature@spacemap_histogram" "feature@enabled_txg" "feature@hole_birth"
-    "feature@extensible_dataset" "feature@bookmarks")
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/trim/trim.cfg
+. $STF_SUITE/tests/functional/trim/trim.kshlib
+
+if [ -n "$HOST_POOL_NAME" ]; then
+	log_must $ZPOOL destroy "$HOST_POOL_NAME"
+fi
+
+log_pass TRIM cleanup succeeded

--- a/usr/src/test/zfs-tests/tests/functional/trim/manualtrim_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/trim/manualtrim_001_pos.ksh
@@ -1,0 +1,165 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
+# Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/trim/trim.cfg
+. $STF_SUITE/tests/functional/trim/trim.kshlib
+
+set_tunable64 zfs_trim_min_ext_sz 0
+
+function dotrim
+{
+	typeset interrupt="$1"
+	typeset scrub="$2"
+	typeset poolvdevdir="$3"
+	typeset done_status
+
+	# Run manual trim for at most 30 seconds
+	typeset stop_time=$(( $(date +%s) + 30 ))
+
+	log_must rm "/$TRIMPOOL/$TESTFILE"
+	log_must $ZPOOL export $TRIMPOOL
+	if [ -n "$poolvdevdir" ]; then
+		log_must $ZPOOL import -d $poolvdevdir $TRIMPOOL
+	else
+		log_must $ZPOOL import $TRIMPOOL
+	fi
+	if [ -z "$interrupt" ]; then
+		log_must $ZPOOL trim $TRIMPOOL
+		sleep 1
+		done_status="completed"
+	else
+		# Run trim at the minimal rate to guarantee that it has
+		# to be interrupted.
+		log_must $ZPOOL trim -r 1 $TRIMPOOL
+		sleep 1
+		log_must $ZPOOL trim -s $TRIMPOOL
+		done_status="interrupted"
+	fi
+	while true; do
+		typeset st=$($ZPOOL status $TRIMPOOL | awk '/trim:/{print $2}')
+		if [ -z "$st" ]; then
+			log_fail "Pool reported '' trim status. Is TRIM" \
+			    "supported on this box??"
+		elif [[ "$st" = "completed" ]]; then
+			[ -n "$interrupt" ] && log_fail "TRIM completed," \
+			    "but we wanted it to be interrupted."
+			break
+		elif [[ "$st" = "interrupted" ]]; then
+			[ -z "$interrupt" ] && log_fail "TRIM interrupted," \
+			    "but we wanted it to complete."
+			break
+		elif [ "$(date +%s)" -ge $stop_time ]; then
+			# Constrain the run time of trim so as not to overstep
+			# the test time limit
+			log_note "Exceeded trim time limit of 30s, stopping..."
+			log_must $ZPOOL trim -s $TRIMPOOL
+			break
+		fi
+		log_note "Waiting for TRIM status to change from \"$st\" to" \
+		    "\"$done_status\""
+		sleep 1
+	done
+	[ -n "$scrub" ] && checkpool $TRIMPOOL
+	log_must $ZPOOL destroy $TRIMPOOL
+	for i in {1..3}; do
+		log_must sync
+		log_must sleep 1
+	done
+}
+
+#
+# Let's try this on real disks first and do some scrubbing to check for
+# data integrity.
+#
+for z in 1 2 3; do
+	if [ $(echo "$TRIM_POOL_DISKS" | tr ' ' '\n' | grep -v '^$' | wc -l) \
+	    -le $z ]; then
+		continue
+	fi
+	log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL raidz$z \
+	    $TRIM_POOL_DISKS
+	log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+	    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	for x in 1 2; do
+		log_must $FILE_WRITE -o create \
+		    -f "/$TRIMPOOL/${TESTFILE}-keep$x" \
+		    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	done
+	dotrim '' '1'
+done
+
+#
+# Check various pool geometries: Create the pool, fill it, remove the test file,
+# perform a manual trim, export the pool and verify that the vdevs shrunk.
+#
+
+#
+# raidz
+#
+for z in 1 2 3; do
+	setupvdevs
+	log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL raidz$z $VDEVS
+	log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+	    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+	dotrim '' '' $VDEVDIR
+	checkvdevs
+done
+
+#
+# mirror
+#
+setupvdevs
+log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL mirror $MIRROR_VDEVS_1 \
+    mirror $MIRROR_VDEVS_2
+log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+dotrim '' '' $VDEVDIR
+checkvdevs
+
+#
+# stripe
+#
+setupvdevs
+log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL $STRIPE_VDEVS
+log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+dotrim '' '' $VDEVDIR
+checkvdevs
+
+#
+# trimus interruptus
+#
+setupvdevs
+log_must $ZPOOL create -o cachefile=none -f $TRIMPOOL $STRIPE_VDEVS
+log_must $FILE_WRITE -o create -f "/$TRIMPOOL/$TESTFILE" \
+    -b $BLOCKSIZE -c $NUM_WRITES -d R -w
+dotrim "1" '' $VDEVDIR
+# Don't check vdev size, since we interrupted trim
+log_must rm $VDEVS
+
+log_pass Manual TRIM successfully shrunk vdevs

--- a/usr/src/test/zfs-tests/tests/functional/trim/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/trim/setup.ksh
@@ -1,3 +1,4 @@
+#!/bin/ksh -p
 #
 # CDDL HEADER START
 #
@@ -20,20 +21,18 @@
 #
 
 #
-# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
-# Use is subject to license terms.
-#
-
-#
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
 # Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
 #
 
-# Set the expected properties of zpool
-typeset -a properties=("size" "capacity" "altroot" "health" "guid" "version"
-    "bootfs" "delegation" "autoreplace" "cachefile" "dedupditto" "dedupratio"
-    "free" "allocated" "readonly" "comment" "expandsize" "freeing" "failmode"
-    "listsnapshots" "autoexpand" "forcetrim" "autotrim" "feature@async_destroy"
-    "feature@empty_bpobj" "feature@lz4_compress" "feature@multi_vdev_crash_dump"
-    "feature@spacemap_histogram" "feature@enabled_txg" "feature@hole_birth"
-    "feature@extensible_dataset" "feature@bookmarks")
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/trim/trim.cfg
+. $STF_SUITE/tests/functional/trim/trim.kshlib
+
+if [ -n "$HOST_POOL_NAME" ]; then
+	log_note "Creating TRIM host pool to control recordsize"
+	log_must $ZPOOL create -o cachefile=none -O recordsize=4k \
+	    -O mountpoint="$VDEVDIR" "$HOST_POOL_NAME" "$HOST_POOL_DISK"
+fi
+
+log_pass TRIM setup succeeded

--- a/usr/src/test/zfs-tests/tests/functional/trim/trim.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/trim/trim.cfg
@@ -1,0 +1,89 @@
+#!/bin/ksh -p
+#
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
+# Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
+#
+
+#
+# Parameters
+#
+TRIMPOOL="trimpool.$$"
+case "$(uname)" in
+Linux)
+	VDEVDIR="/tmp"
+	VDEVS="/tmp/trim1.dev /tmp/trim2.dev /tmp/trim3.dev /tmp/trim4.dev \
+	    /tmp/trim5.dev"
+
+	HOST_POOL_NAME=''
+	HOST_POOL_DISK=''
+	TRIM_POOL_DISKS="$DISKS"
+	;;
+SunOS)
+	# On Illumos, we can't just shove the files into /tmp, because tmpfs
+	# doesn't support hole punching. UFS doesn't support it either. ZFS
+	# does, but it won't reduce space usage unless the amount of space
+	# freed covers at least a full host FS block (128k in most cases),
+	# which can mess with our space accouting.
+	# To work around these limitations, we simply use the first disk in
+	# $DISKS to hold a host pool with recordsize=4k, so we can guarantee
+	# file hole punching of a usable granularity for our needs.
+	HOST_POOL_NAME="trimhost"
+	HOST_POOL_DISK=$(echo "$DISKS" | awk '{print $1}')
+	TRIM_POOL_DISKS="$(echo "$DISKS" | tr ' ' '\n' | grep -v '^$' | \
+	    tail +2 | tr '\n' ' ')"
+
+	VDEVDIR="/$HOST_POOL_NAME"
+	VDEVS="$VDEVDIR/trim1.dev $VDEVDIR/trim2.dev $VDEVDIR/trim3.dev \
+	    $VDEVDIR/trim4.dev $VDEVDIR/trim5.dev"
+	;;
+esac
+
+# These test limits are algorithm-sensitive, so whenever you adjust the
+# way TRIM processes extents and filters them, be sure to adjust these
+# accordingly to get all tests to pass.
+VDEV_SIZE=256m
+TESTFILE=testfile
+SHRUNK_SIZE_MB=20
+
+NUM_WRITES=2048
+BLOCKSIZE=65536
+
+#
+# Computed values and parameters
+#
+function get_mirror_vdevs
+{
+	set -- $VDEVS
+	MIRROR_VDEVS_1="$1 $2"
+	MIRROR_VDEVS_2="$3 $4"
+}
+get_mirror_vdevs
+
+function get_stripe_vdevs
+{
+	set -- $VDEVS
+	STRIPE_VDEVS="$1 $2 $3 $4"
+}
+get_stripe_vdevs

--- a/usr/src/test/zfs-tests/tests/functional/trim/trim.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/trim/trim.kshlib
@@ -1,0 +1,110 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Tim Chase. All rights reserved.
+# Copyright (c) 2017 by Nexenta Systems, Inc. All rights reserved.
+#
+
+# Adaptation from older zfs-tests
+if [ -z "$ZPOOL" ]; then
+	ZPOOL=zpool
+fi
+if [ -z "$ZFS" ]; then
+	ZFS=zfs
+fi
+if [ -z "$FILE_WRITE" ]; then
+	FILE_WRITE=file_write
+fi
+
+function set_tunable64
+{
+	set_tunable_impl "$1" "$2" Z
+}
+
+function set_tunable32
+{
+	set_tunable_impl "$1" "$2" W
+}
+
+function set_tunable_impl
+{
+	typeset tunable="$1"
+	typeset value="$2"
+	typeset mdb_cmd="$3"
+
+	[[ -z "$tunable" ]] && return 1
+	[[ -z "$value" ]] && return 1
+	[[ -z "$mdb_cmd" ]] && return 1
+
+	case "$(uname)" in
+	Linux)
+		typeset zfs_tunables="/sys/module/zfs/parameters"
+		[[ -f "$zfs_tunables/$tunable" ]] || return 1
+		echo -n "$value" > "$zfs_tunables/$tunable"
+		return "$?"
+		;;
+	SunOS)
+		echo "${tunable}/${mdb_cmd}0t${value}" | mdb -kw
+		return "$?"
+		;;
+	esac
+}
+
+function setupvdevs
+{
+	log_must rm -f $VDEVS
+	log_must truncate -s $VDEV_SIZE $VDEVS
+}
+
+function getsizemb
+{
+	case "$(uname)" in
+	Linux)
+		typeset rval
+		rval=$(du --block-size 1048576 -s "$1" | awk '{print $1}')
+		echo -n "$rval"
+		;;
+	SunOS)
+		du -m "$1" | awk '{print $1}'
+		;;
+	esac
+}
+
+function checkvdevs
+{
+	typeset vd sz
+
+	for vd in $VDEVS; do
+		sz=$(getsizemb $vd)
+		log_note Size of $vd is $sz MB
+		log_must test $sz -le $SHRUNK_SIZE_MB
+	done
+	# If all checks succeeded, remove the vdevs to clean up
+	log_must rm $VDEVS
+}
+
+function checkpool
+{
+	typeset pool="$1"
+
+	log_must $ZPOOL scrub $pool
+	while true; do
+		typeset st=$($ZPOOL status $pool | awk '/scan:/{print $3}')
+		if [[ "$st" == "repaired" ]] || [[ "$st" == "canceled" ]]; then
+			break
+		fi
+		log_note "Waiting for scrub to complete on $pool"
+		sleep 1
+	done
+	log_must $ZPOOL status -x $TRIMPOOL
+}

--- a/usr/src/uts/common/Makefile.files
+++ b/usr/src/uts/common/Makefile.files
@@ -23,7 +23,7 @@
 # Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2011, 2014 by Delphix. All rights reserved.
 # Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
-# Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+# Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2016 Garrett D'Amore <garrett@damore.org>
 # Copyright 2016 Joyent, Inc.
 # Copyright 2016 OmniTI Computer Consulting, Inc.  All rights reserved.
@@ -160,6 +160,7 @@ GENUNIX_OBJS +=	\
 		devid_smp.o	\
 		devpolicy.o	\
 		disp_lock.o	\
+		dkioc_free_util.o \
 		dnlc.o		\
 		driver.o	\
 		dumpsubr.o	\

--- a/usr/src/uts/common/fs/zfs/dsl_scan.c
+++ b/usr/src/uts/common/fs/zfs/dsl_scan.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Gary Mills
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/dsl_scan.h>
@@ -1679,6 +1680,9 @@ dsl_scan_sync(dsl_pool_t *dp, dmu_tx_t *tx)
 void
 dsl_resilver_restart(dsl_pool_t *dp, uint64_t txg)
 {
+	/* Stop any ongoing TRIMs */
+	spa_man_trim_stop(dp->dp_spa);
+
 	if (txg == 0) {
 		dmu_tx_t *tx;
 		tx = dmu_tx_create_dd(dp->dp_mos_dir);

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -200,33 +200,6 @@ static void metaslab_set_fragmentation(metaslab_t *);
 kmem_cache_t *metaslab_alloc_trace_cache;
 
 /*
- * How many TXG's worth of updates should be aggregated per TRIM/UNMAP
- * issued to the underlying vdev. We keep two range trees of extents
- * (called "trim sets") to be trimmed per metaslab, the `current' and
- * the `previous' TS. New free's are added to the current TS. Then,
- * once `zfs_txgs_per_trim' transactions have elapsed, the `current'
- * TS becomes the `previous' TS and a new, blank TS is created to be
- * the new `current', which will then start accumulating any new frees.
- * Once another zfs_txgs_per_trim TXGs have passed, the previous TS's
- * extents are trimmed, the TS is destroyed and the current TS again
- * becomes the previous TS.
- * This serves to fulfill two functions: aggregate many small frees
- * into fewer larger trim operations (which should help with devices
- * which do not take so kindly to them) and to allow for disaster
- * recovery (extents won't get trimmed immediately, but instead only
- * after passing this rather long timeout, thus preserving
- * 'zfs import -F' functionality).
- * The exact default value of this tunable is a tradeoff between:
- * 1) Keeping the trim commands reasonably small.
- * 2) Keeping the ability to rollback back for as many txgs as possible.
- * 3) Waiting around too long that the user starts to get uneasy about not
- *	seeing any space being freed after they remove some files.
- * The default value of 32 is the maximum number of uberblocks in a vdev
- * label, assuming a 4k physical sector size (which seems to be the almost
- * universal smallest sector size used in SSDs).
- */
-unsigned int zfs_txgs_per_trim = 32;
-/*
  * Maximum number of bytes we'll put into a single zio_trim. This is for
  * vdev queue processing purposes and also because some devices advertise
  * they can handle a lot more LBAs per command than they can handle
@@ -236,13 +209,11 @@ uint64_t zfs_max_bytes_per_trim = 128 << 20;
 
 static void metaslab_trim_remove(void *arg, uint64_t offset, uint64_t size);
 static void metaslab_trim_add(void *arg, uint64_t offset, uint64_t size);
+static uint64_t metaslab_trimming_space(const metaslab_t *msp);
 
 static zio_t *metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim);
 
-static metaslab_trimset_t *metaslab_new_trimset(uint64_t txg, kmutex_t *lock);
-static void metaslab_free_trimset(metaslab_trimset_t *ts);
-static boolean_t metaslab_check_trim_conflict(metaslab_t *msp,
-    uint64_t *offset, uint64_t size, uint64_t align, uint64_t limit);
+static void metaslab_free_trimset(range_tree_t *ts);
 
 /*
  * ==========================================================================
@@ -523,7 +494,8 @@ metaslab_verify_space(metaslab_t *msp, uint64_t txg)
 	}
 
 	msp_free_space = range_tree_space(msp->ms_tree) + allocated +
-	    msp->ms_deferspace + range_tree_space(msp->ms_freedtree);
+	    msp->ms_deferspace + range_tree_space(msp->ms_freedtree) +
+	    metaslab_trimming_space(msp);
 
 	VERIFY3U(sm_free_space, ==, msp_free_space);
 }
@@ -1147,20 +1119,16 @@ metaslab_block_find(avl_tree_t *t, uint64_t start, uint64_t size)
  * tree looking for a block that matches the specified criteria.
  */
 static uint64_t
-metaslab_block_picker(metaslab_t *msp, avl_tree_t *t, uint64_t *cursor,
-    uint64_t size, uint64_t align)
+metaslab_block_picker(avl_tree_t *t, uint64_t *cursor, uint64_t size)
 {
 	range_seg_t *rs = metaslab_block_find(t, *cursor, size);
 
-	for (; rs != NULL; rs = AVL_NEXT(t, rs)) {
-		uint64_t offset = P2ROUNDUP(rs->rs_start, align);
-
-		if (offset + size <= rs->rs_end &&
-		    !metaslab_check_trim_conflict(msp, &offset, size, align,
-		    rs->rs_end)) {
-			*cursor = offset + size;
-			return (offset);
+	while (rs != NULL) {
+		if (rs->rs_start + size <= rs->rs_end) {
+			*cursor = rs->rs_start + size;
+			return (rs->rs_start);
 		}
+		rs = AVL_NEXT(t, rs);
 	}
 
 	/*
@@ -1171,34 +1139,8 @@ metaslab_block_picker(metaslab_t *msp, avl_tree_t *t, uint64_t *cursor,
 		return (-1ULL);
 
 	*cursor = 0;
-	return (metaslab_block_picker(msp, t, cursor, size, align));
+	return (metaslab_block_picker(t, cursor, size));
 }
-
-/*
- * ==========================================================================
- * The first-fit block allocator
- * ==========================================================================
- */
-static uint64_t
-metaslab_ff_alloc(metaslab_t *msp, uint64_t size)
-{
-	/*
-	 * Find the largest power of 2 block size that evenly divides the
-	 * requested size. This is used to try to allocate blocks with similar
-	 * alignment from the same area of the metaslab (i.e. same cursor
-	 * bucket) but it does not guarantee that other allocations sizes
-	 * may exist in the same region.
-	 */
-	uint64_t align = size & -size;
-	uint64_t *cursor = &msp->ms_lbas[highbit64(align) - 1];
-	avl_tree_t *t = &msp->ms_tree->rt_root;
-
-	return (metaslab_block_picker(msp, t, cursor, size, align));
-}
-
-static metaslab_ops_t metaslab_ff_ops = {
-	metaslab_ff_alloc
-};
 
 /*
  * ==========================================================================
@@ -1241,7 +1183,7 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 		*cursor = 0;
 	}
 
-	return (metaslab_block_picker(msp, t, cursor, size, 1ULL));
+	return (metaslab_block_picker(t, cursor, size));
 }
 
 static metaslab_ops_t metaslab_df_ops = {
@@ -1275,16 +1217,11 @@ metaslab_cf_alloc(metaslab_t *msp, uint64_t size)
 		range_seg_t *rs;
 
 		rs = avl_last(&msp->ms_size_tree);
-		for (; rs != NULL && rs->rs_end - rs->rs_start >= size;
-		    rs = AVL_PREV(&msp->ms_size_tree, rs)) {
-			if (!metaslab_check_trim_conflict(msp, cursor, size,
-			    1, *cursor_end)) {
-				/* segment appears to be acceptable */
-				break;
-			}
-		}
 		if (rs == NULL || (rs->rs_end - rs->rs_start) < size)
 			return (-1ULL);
+
+		*cursor = rs->rs_start;
+		*cursor_end = rs->rs_end;
 	}
 
 	offset = *cursor;
@@ -1321,8 +1258,6 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 	uint64_t hbit = highbit64(size);
 	uint64_t *cursor = &msp->ms_lbas[hbit - 1];
 	uint64_t max_size = metaslab_block_maxsize(msp);
-	/* mutable copy for adjustment by metaslab_check_trim_conflict */
-	uint64_t adjustable_start;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(avl_numnodes(t), ==, avl_numnodes(&msp->ms_size_tree));
@@ -1334,12 +1269,7 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 	rsearch.rs_end = *cursor + size;
 
 	rs = avl_find(t, &rsearch, &where);
-	if (rs != NULL)
-		adjustable_start = rs->rs_start;
-	if (rs == NULL || rs->rs_end - adjustable_start < size ||
-	    metaslab_check_trim_conflict(msp, &adjustable_start, size, 1,
-	    rs->rs_end)) {
-		/* segment not usable, try the largest remaining one */
+	if (rs == NULL || (rs->rs_end - rs->rs_start) < size) {
 		t = &msp->ms_size_tree;
 
 		rsearch.rs_start = 0;
@@ -1349,17 +1279,13 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 		if (rs == NULL)
 			rs = avl_nearest(t, where, AVL_AFTER);
 		ASSERT(rs != NULL);
-		adjustable_start = rs->rs_start;
-		if (rs->rs_end - adjustable_start < size ||
-		    metaslab_check_trim_conflict(msp, &adjustable_start,
-		    size, 1, rs->rs_end)) {
-			/* even largest remaining segment not usable */
-			return (-1ULL);
-		}
 	}
 
-	*cursor = adjustable_start + size;
-	return (*cursor);
+	if ((rs->rs_end - rs->rs_start) >= size) {
+		*cursor = rs->rs_start + size;
+		return (rs->rs_start);
+	}
+	return (-1ULL);
 }
 
 static metaslab_ops_t metaslab_ndf_ops = {
@@ -1423,6 +1349,14 @@ metaslab_load(metaslab_t *msp)
 			range_tree_walk(msp->ms_defertree[t],
 			    metaslab_trim_remove, msp);
 		}
+		/*
+		 * If there's a trim ongoing, punch out the holes that will
+		 * be filled back in in metaslab_trim_done.
+		 */
+		if (msp->ms_trimming_ts != NULL) {
+			range_tree_walk(msp->ms_trimming_ts, range_tree_remove,
+			    msp->ms_tree);
+		}
 		msp->ms_max_size = metaslab_block_maxsize(msp);
 	}
 	cv_broadcast(&msp->ms_load_cv);
@@ -1473,7 +1407,7 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object, uint64_t txg,
 		ASSERT(ms->ms_sm != NULL);
 	}
 
-	ms->ms_cur_ts = metaslab_new_trimset(0, &ms->ms_lock);
+	ms->ms_cur_ts = range_tree_create(NULL, NULL, &ms->ms_lock);
 
 	/*
 	 * We create the main range tree here, but we don't create the
@@ -2152,6 +2086,10 @@ metaslab_should_condense(metaslab_t *msp)
 	segsz = entries * sizeof (uint64_t);
 
 	optimal_size = sizeof (uint64_t) * avl_numnodes(&msp->ms_tree->rt_root);
+	if (msp->ms_trimming_ts != NULL) {
+		optimal_size += sizeof (uint64_t) *
+		    avl_numnodes(&msp->ms_trimming_ts->rt_root);
+	}
 	object_size = space_map_length(msp->ms_sm);
 
 	dmu_object_info_from_db(sm->sm_dbuf, &doi);
@@ -2183,7 +2121,9 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	    "spa %s, smp size %llu, segments %lu, forcing condense=%s", txg,
 	    msp->ms_id, msp, msp->ms_group->mg_vd->vdev_id,
 	    msp->ms_group->mg_vd->vdev_spa->spa_name,
-	    space_map_length(msp->ms_sm), avl_numnodes(&msp->ms_tree->rt_root),
+	    space_map_length(msp->ms_sm), avl_numnodes(&msp->ms_tree->rt_root) +
+	    (msp->ms_trimming_ts != NULL ?
+	    avl_numnodes(&msp->ms_trimming_ts->rt_root) : 0),
 	    msp->ms_condense_wanted ? "TRUE" : "FALSE");
 
 	msp->ms_condense_wanted = B_FALSE;
@@ -2244,7 +2184,21 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	range_tree_vacate(condense_tree, NULL, NULL);
 	range_tree_destroy(condense_tree);
 
-	space_map_write(sm, msp->ms_tree, SM_FREE, tx);
+	if (msp->ms_trimming_ts == NULL) {
+		space_map_write(sm, msp->ms_tree, SM_FREE, tx);
+	} else {
+		/*
+		 * While trimming, the stuff being trimmed isn't in ms_tree,
+		 * but we still want our persistent state to reflect that. So
+		 * we construct a temporary union of the two trees.
+		 */
+		range_tree_t *rt = range_tree_create(NULL, NULL, &msp->ms_lock);
+		range_tree_walk(msp->ms_tree, range_tree_add, rt);
+		range_tree_walk(msp->ms_trimming_ts, range_tree_add, rt);
+		space_map_write(sm, rt, SM_FREE, tx);
+		range_tree_vacate(rt, NULL, NULL);
+		range_tree_destroy(rt);
+	}
 	msp->ms_condensing = B_FALSE;
 	cv_broadcast(&msp->ms_condensing_cv);
 }
@@ -2343,6 +2297,12 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 		 */
 		space_map_histogram_clear(msp->ms_sm);
 		space_map_histogram_add(msp->ms_sm, msp->ms_tree, tx);
+
+		if (msp->ms_trimming_ts != NULL) {
+			/* Stuff currently being trimmed is also free. */
+			space_map_histogram_add(msp->ms_sm,
+			    msp->ms_trimming_ts, tx);
+		}
 
 		/*
 		 * Since we've cleared the histogram we need to add back
@@ -2946,11 +2906,9 @@ next:
 		 * We have just failed an allocation attempt, check
 		 * that metaslab_should_allocate() agrees. Otherwise,
 		 * we may end up in an infinite loop retrying the same
-		 * metaslab. Keep in mind, it might have happened due
-		 * to an ongoing trim.
+		 * metaslab.
 		 */
-		ASSERT(!metaslab_should_allocate(msp, asize) ||
-		    msp->ms_trimming_ts != NULL);
+		ASSERT(!metaslab_should_allocate(msp, asize));
 		mutex_exit(&msp->ms_lock);
 	}
 	mutex_exit(&msp->ms_lock);
@@ -3255,12 +3213,16 @@ metaslab_free_dva(spa_t *spa, const dva_t *dva, uint64_t txg, boolean_t now)
 		VERIFY(!msp->ms_condensing);
 		VERIFY3U(offset, >=, msp->ms_start);
 		VERIFY3U(offset + size, <=, msp->ms_start + msp->ms_size);
-		VERIFY3U(range_tree_space(msp->ms_tree) + size, <=,
-		    msp->ms_size);
+		VERIFY3U(range_tree_space(msp->ms_tree) + size +
+		    metaslab_trimming_space(msp), <=, msp->ms_size);
 		VERIFY0(P2PHASE(offset, 1ULL << vd->vdev_ashift));
 		VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
 		VERIFY(!range_tree_contains(msp->ms_alloctree[txg & TXG_MASK],
 		    offset, size));
+		if (msp->ms_trimming_ts != NULL) {
+			VERIFY(!range_tree_contains(msp->ms_trimming_ts,
+			    offset, size));
+		}
 		range_tree_add(msp->ms_tree, offset, size);
 		msp->ms_max_size = metaslab_block_maxsize(msp);
 		if (spa_get_auto_trim(spa) == SPA_AUTO_TRIM_ON &&
@@ -3503,16 +3465,18 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 		mutex_enter(&msp->ms_lock);
 		if (msp->ms_loaded) {
 			range_tree_verify(msp->ms_tree, offset, size);
+			if (msp->ms_trimming_ts) {
+				range_tree_verify(msp->ms_trimming_ts,
+				    offset, size);
+			}
 #ifdef	DEBUG
-			VERIFY3P(&msp->ms_lock, ==,
-			    msp->ms_cur_ts->ts_tree->rt_lock);
-			range_tree_verify(msp->ms_cur_ts->ts_tree,
-			    offset, size);
+			VERIFY3P(&msp->ms_lock, ==, msp->ms_cur_ts->rt_lock);
+			range_tree_verify(msp->ms_cur_ts, offset, size);
 			if (msp->ms_prev_ts != NULL) {
 				VERIFY3P(&msp->ms_lock, ==,
-				    msp->ms_prev_ts->ts_tree->rt_lock);
-				range_tree_verify(msp->ms_prev_ts->ts_tree,
-				    offset, size);
+				    msp->ms_prev_ts->rt_lock);
+				range_tree_verify(msp->ms_prev_ts, offset,
+				    size);
 			}
 #endif
 		}
@@ -3572,7 +3536,7 @@ metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
 	 * from the last cursor position, but not more than the trim run
 	 * limit.
 	 */
-	range_tree_vacate(msp->ms_cur_ts->ts_tree, NULL, NULL);
+	range_tree_vacate(msp->ms_cur_ts, NULL, NULL);
 
 	rsearch.rs_start = cur;
 	rsearch.rs_end = cur + SPA_MINBLOCKSIZE;
@@ -3604,7 +3568,7 @@ metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
 	if (trimmed_space != 0) {
 		/* Force this trim to take place ASAP. */
 		msp->ms_prev_ts = msp->ms_cur_ts;
-		msp->ms_cur_ts = metaslab_new_trimset(0, &msp->ms_lock);
+		msp->ms_cur_ts = range_tree_create(NULL, NULL, &msp->ms_lock);
 		trim_io = metaslab_exec_trim(msp, B_FALSE);
 		ASSERT(trim_io != NULL);
 
@@ -3635,11 +3599,11 @@ metaslab_trim_remove(void *arg, uint64_t offset, uint64_t size)
 {
 	metaslab_t *msp = arg;
 
-	range_tree_clear(msp->ms_cur_ts->ts_tree, offset, size);
+	range_tree_clear(msp->ms_cur_ts, offset, size);
 	if (msp->ms_prev_ts != NULL)
-		range_tree_clear(msp->ms_prev_ts->ts_tree, offset, size);
+		range_tree_clear(msp->ms_prev_ts, offset, size);
 	ASSERT(msp->ms_trimming_ts == NULL ||
-	    !range_tree_contains(msp->ms_trimming_ts->ts_tree, offset, size));
+	    !range_tree_contains(msp->ms_trimming_ts, offset, size));
 }
 
 /*
@@ -3654,16 +3618,25 @@ metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT(msp->ms_cur_ts != NULL);
-	range_tree_add(msp->ms_cur_ts->ts_tree, offset, size);
-	if (msp->ms_prev_ts != NULL) {
-		ASSERT(!range_tree_contains_part(msp->ms_prev_ts->ts_tree,
-		    offset, size));
-	}
+	range_tree_add(msp->ms_cur_ts, offset, size);
+	ASSERT(msp->ms_prev_ts == NULL ||
+	    !range_tree_contains_part(msp->ms_prev_ts, offset, size));
 }
 
 /*
- * Does a metaslab's automatic trim operation processing. This function
- * issues trims in intervals as dictated by the zfs_txgs_per_trim tunable.
+ * Returns the amount of space currently being trimmed.
+ */
+static uint64_t
+metaslab_trimming_space(const metaslab_t *msp)
+{
+	ASSERT(MUTEX_HELD(&msp->ms_lock));
+	if (msp->ms_trimming_ts == NULL)
+		return (0);
+	return (range_tree_space(msp->ms_trimming_ts));
+}
+
+/*
+ * Does a metaslab's automatic trim operation processing.
  * If the previous trimset has not yet finished trimming, this function
  * decides what to do based on `preserve_spilled'. If preserve_spilled is
  * false, the next trimset which would have been issued is simply dropped to
@@ -3671,78 +3644,55 @@ metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
  * trimset.
  */
 void
-metaslab_auto_trim(metaslab_t *msp, uint64_t txg, boolean_t preserve_spilled)
+metaslab_auto_trim(metaslab_t *msp, boolean_t preserve_spilled)
 {
-	/* for atomicity */
-	uint64_t txgs_per_trim = zfs_txgs_per_trim;
-
 	ASSERT(!MUTEX_HELD(&msp->ms_lock));
 	mutex_enter(&msp->ms_lock);
 
 	/*
-	 * Since we typically have hundreds of metaslabs per vdev, but we only
-	 * trim them once every zfs_txgs_per_trim txgs, it'd be best if we
-	 * could sequence the TRIM commands from all metaslabs so that they
-	 * don't all always pound the device in the same txg. We do so by
-	 * artificially inflating the birth txg of the first trim set by a
-	 * sequence number derived from the metaslab's starting offset
-	 * (modulo zfs_txgs_per_trim). Thus, for the default 200 metaslabs and
-	 * 32 txgs per trim, we'll only be trimming ~6.25 metaslabs per txg.
-	 *
-	 * If we detect that the txg has advanced too far ahead of ts_birth,
-	 * it means our birth txg is out of lockstep. Recompute it by
-	 * rounding down to the nearest zfs_txgs_per_trim multiple and adding
-	 * our metaslab id modulo zfs_txgs_per_trim.
+	 * Always swap out the current and previous trimsets. Normally this
+	 * should be done at intervals of zfs_txgs_per_trim. The code which
+	 * controls this is in vdev_auto_trim.
 	 */
-	if (txg > msp->ms_cur_ts->ts_birth + txgs_per_trim) {
-		msp->ms_cur_ts->ts_birth = (txg / txgs_per_trim) *
-		    txgs_per_trim + (msp->ms_id % txgs_per_trim);
-	}
-
-	/* Time to swap out the current and previous trimsets */
-	if (txg == msp->ms_cur_ts->ts_birth + txgs_per_trim) {
-		if (msp->ms_prev_ts != NULL) {
-			if (msp->ms_trimming_ts != NULL) {
-				spa_t *spa = msp->ms_group->mg_class->mc_spa;
-				/*
-				 * The previous trim run is still ongoing, so
-				 * the device is reacting slowly to our trim
-				 * requests. Drop this trimset, so as not to
-				 * back the device up with trim requests.
-				 */
-				if (preserve_spilled) {
-					DTRACE_PROBE1(preserve__spilled,
-					    metaslab_t *, msp);
-					range_tree_vacate(
-					    msp->ms_prev_ts->ts_tree,
-					    range_tree_add,
-					    msp->ms_cur_ts->ts_tree);
-				} else {
-					DTRACE_PROBE1(drop__spilled,
-					    metaslab_t *, msp);
-					spa_trimstats_auto_slow_incr(spa);
-				}
-				metaslab_free_trimset(msp->ms_prev_ts);
-			} else if (msp->ms_group->mg_vd->vdev_man_trimming) {
-				/*
-				 * If a manual trim is ongoing, we want to
-				 * inhibit autotrim temporarily so it doesn't
-				 * slow down the manual trim.
-				 */
-				metaslab_free_trimset(msp->ms_prev_ts);
+	if (msp->ms_prev_ts != NULL) {
+		if (msp->ms_trimming_ts != NULL) {
+			spa_t *spa = msp->ms_group->mg_class->mc_spa;
+			/*
+			 * The previous trim run is still ongoing, so the
+			 * device is reacting slowly to trims. Consider
+			 * dropping this trimset, so as not to back the
+			 * device up.
+			 */
+			if (preserve_spilled) {
+				DTRACE_PROBE1(preserve__spilled,
+				    metaslab_t *, msp);
+				range_tree_vacate(msp->ms_prev_ts,
+				    range_tree_add, msp->ms_cur_ts);
 			} else {
-				/*
-				 * Trim out aged extents on the vdevs - these
-				 * are safe to be destroyed now. We'll keep
-				 * the trimset around to deny allocations from
-				 * these regions while the trims are ongoing.
-				 */
-				zio_nowait(metaslab_exec_trim(msp, B_TRUE));
+				DTRACE_PROBE1(drop__spilled, metaslab_t *, msp);
+				spa_trimstats_auto_slow_incr(spa);
 			}
+			metaslab_free_trimset(msp->ms_prev_ts);
+		} else if (msp->ms_group->mg_vd->vdev_man_trimming) {
+			/*
+			 * If a manual trim is ongoing, we want to inhibit
+			 * autotrim temporarily so it doesn't slow down the
+			 * manual trim.
+			 */
+			metaslab_free_trimset(msp->ms_prev_ts);
+		} else {
+			/*
+			 * Trim out aged extents on the vdevs - these are safe
+			 * to be destroyed now. We'll keep the trimset around
+			 * to deny allocations from these regions while the
+			 * trims are ongoing.
+			 */
+			zio_nowait(metaslab_exec_trim(msp, B_TRUE));
 		}
-		msp->ms_prev_ts = msp->ms_cur_ts;
-		msp->ms_cur_ts = metaslab_new_trimset(txg, &msp->ms_lock);
 	}
+	msp->ms_prev_ts = msp->ms_cur_ts;
+	msp->ms_cur_ts = range_tree_create(NULL, NULL, &msp->ms_lock);
+
 	mutex_exit(&msp->ms_lock);
 }
 
@@ -3756,15 +3706,15 @@ metaslab_auto_trim(metaslab_t *msp, uint64_t txg, boolean_t preserve_spilled)
  * get it "close enough".
  */
 static uint64_t
-metaslab_trimset_mem_used(metaslab_trimset_t *ts)
+metaslab_trimset_mem_used(range_tree_t *ts)
 {
 	uint64_t result = 0;
 
-	result += avl_numnodes(&ts->ts_tree->rt_root) * (sizeof (range_seg_t) +
+	result += avl_numnodes(&ts->rt_root) * (sizeof (range_seg_t) +
 	    sizeof (dkioc_free_list_ext_t));
-	result += ((range_tree_space(ts->ts_tree) / zfs_max_bytes_per_trim) +
-	    1) * sizeof (zio_t);
-	result += sizeof (range_tree_t) + sizeof (metaslab_trimset_t);
+	result += ((range_tree_space(ts) / zfs_max_bytes_per_trim) + 1) *
+	    sizeof (zio_t);
+	result += sizeof (range_tree_t);
 
 	return (result);
 }
@@ -3799,6 +3749,10 @@ metaslab_trim_done(zio_t *zio)
 	held = MUTEX_HELD(&msp->ms_lock);
 	if (!held)
 		mutex_enter(&msp->ms_lock);
+	if (msp->ms_loaded) {
+		range_tree_walk(msp->ms_trimming_ts, range_tree_add,
+		    msp->ms_tree);
+	}
 	metaslab_free_trimset(msp->ms_trimming_ts);
 	msp->ms_trimming_ts = NULL;
 	cv_broadcast(&msp->ms_trim_cv);
@@ -3844,24 +3798,33 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 		cv_wait(&msp->ms_trim_cv, &msp->ms_lock);
 	msp->ms_trimming_ts = msp->ms_prev_ts;
 	msp->ms_prev_ts = NULL;
-	trim_tree = msp->ms_trimming_ts->ts_tree;
-#ifdef	DEBUG
+	trim_tree = msp->ms_trimming_ts;
+
 	if (msp->ms_loaded) {
 		for (range_seg_t *rs = avl_first(&trim_tree->rt_root);
 		    rs != NULL; rs = AVL_NEXT(&trim_tree->rt_root, rs)) {
+#ifdef	DEBUG
 			if (!range_tree_contains_part(msp->ms_tree,
 			    rs->rs_start, rs->rs_end - rs->rs_start)) {
 				panic("trimming allocated region; rs=%p",
 				    (void*)rs);
 			}
+#endif	/* DEBUG */
+			/*
+			 * To avoid allocating from the range of extents we're
+			 * currently destroying, temporarily remove them from
+			 * the tree of free space. They'll then be added back
+			 * in in metaslab_trim_done.
+			 */
+			range_tree_remove(msp->ms_tree, rs->rs_start,
+			    rs->rs_end - rs->rs_start);
 		}
 	}
-#endif
 
 	/* Nothing to trim */
 	if (range_tree_space(trim_tree) == 0) {
 		metaslab_free_trimset(msp->ms_trimming_ts);
-		msp->ms_trimming_ts = 0;
+		msp->ms_trimming_ts = NULL;
 		return (zio_null(NULL, spa, NULL, NULL, NULL, 0));
 	}
 
@@ -3913,65 +3876,11 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 }
 
 /*
- * Allocates and initializes a new trimset structure. The `txg' argument
- * indicates when this trimset was born and `lock' indicates the lock to
- * link to the range tree.
- */
-static metaslab_trimset_t *
-metaslab_new_trimset(uint64_t txg, kmutex_t *lock)
-{
-	metaslab_trimset_t *ts;
-
-	ts = kmem_zalloc(sizeof (*ts), KM_SLEEP);
-	ts->ts_birth = txg;
-	ts->ts_tree = range_tree_create(NULL, NULL, lock);
-
-	return (ts);
-}
-
-/*
- * Destroys and frees a trim set previously allocated by metaslab_new_trimset.
+ * Destroys and frees a trim set.
  */
 static void
-metaslab_free_trimset(metaslab_trimset_t *ts)
+metaslab_free_trimset(range_tree_t *ts)
 {
-	range_tree_vacate(ts->ts_tree, NULL, NULL);
-	range_tree_destroy(ts->ts_tree);
-	kmem_free(ts, sizeof (*ts));
-}
-
-/*
- * Checks whether an allocation conflicts with an ongoing trim operation in
- * the given metaslab. This function takes a segment starting at `*offset'
- * of `size' and checks whether it hits any region in the metaslab currently
- * being trimmed. If yes, it tries to adjust the allocation to the end of
- * the region being trimmed (P2ROUNDUP aligned by `align'), but only up to
- * `limit' (no part of the allocation is allowed to go past this point).
- *
- * Returns B_FALSE if either the original allocation wasn't in conflict, or
- * the conflict could be resolved by adjusting the value stored in `offset'
- * such that the whole allocation still fits below `limit'. Returns B_TRUE
- * if the allocation conflict couldn't be resolved.
- */
-static boolean_t metaslab_check_trim_conflict(metaslab_t *msp,
-    uint64_t *offset, uint64_t size, uint64_t align, uint64_t limit)
-{
-	uint64_t new_offset;
-
-	ASSERT3U(*offset + size, <=, limit);
-	ASSERT(MUTEX_HELD(&msp->ms_lock));
-
-	if (msp->ms_trimming_ts == NULL)
-		/* no trim conflict, original offset is OK */
-		return (B_FALSE);
-
-	new_offset = P2ROUNDUP(range_tree_find_gap(msp->ms_trimming_ts->ts_tree,
-	    *offset, size), align);
-	if (new_offset + size > limit)
-		/* trim conflict and adjustment not possible */
-		return (B_TRUE);
-
-	/* trim conflict, but adjusted offset still within limit */
-	*offset = new_offset;
-	return (B_FALSE);
+	range_tree_vacate(ts, NULL, NULL);
+	range_tree_destroy(ts);
 }

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -2184,21 +2184,10 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 	range_tree_vacate(condense_tree, NULL, NULL);
 	range_tree_destroy(condense_tree);
 
-	if (msp->ms_trimming_ts == NULL) {
-		space_map_write(sm, msp->ms_tree, SM_FREE, tx);
-	} else {
-		/*
-		 * While trimming, the stuff being trimmed isn't in ms_tree,
-		 * but we still want our persistent state to reflect that. So
-		 * we construct a temporary union of the two trees.
-		 */
-		range_tree_t *rt = range_tree_create(NULL, NULL, &msp->ms_lock);
-		range_tree_walk(msp->ms_tree, range_tree_add, rt);
-		range_tree_walk(msp->ms_trimming_ts, range_tree_add, rt);
-		space_map_write(sm, rt, SM_FREE, tx);
-		range_tree_vacate(rt, NULL, NULL);
-		range_tree_destroy(rt);
-	}
+	space_map_write(sm, msp->ms_tree, SM_FREE, tx);
+	if (msp->ms_trimming_ts != NULL)
+		space_map_write(sm, msp->ms_trimming_ts, SM_FREE, tx);
+
 	msp->ms_condensing = B_FALSE;
 	cv_broadcast(&msp->ms_condensing_cv);
 }
@@ -3463,24 +3452,14 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 		metaslab_t *msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
 
 		mutex_enter(&msp->ms_lock);
-		if (msp->ms_loaded) {
+		if (msp->ms_loaded)
 			range_tree_verify(msp->ms_tree, offset, size);
-			if (msp->ms_trimming_ts) {
-				range_tree_verify(msp->ms_trimming_ts,
-				    offset, size);
-			}
-#ifdef	DEBUG
-			VERIFY3P(&msp->ms_lock, ==, msp->ms_cur_ts->rt_lock);
-			range_tree_verify(msp->ms_cur_ts, offset, size);
-			if (msp->ms_prev_ts != NULL) {
-				VERIFY3P(&msp->ms_lock, ==,
-				    msp->ms_prev_ts->rt_lock);
-				range_tree_verify(msp->ms_prev_ts, offset,
-				    size);
-			}
-#endif
-		}
-
+		if (msp->ms_trimming_ts)
+			range_tree_verify(msp->ms_trimming_ts, offset, size);
+		ASSERT(msp->ms_cur_ts != NULL);
+		range_tree_verify(msp->ms_cur_ts, offset, size);
+		if (msp->ms_prev_ts != NULL)
+			range_tree_verify(msp->ms_prev_ts, offset, size);
 		range_tree_verify(msp->ms_freeingtree, offset, size);
 		range_tree_verify(msp->ms_freedtree, offset, size);
 		for (int j = 0; j < TXG_DEFER_SIZE; j++)
@@ -3491,17 +3470,32 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 }
 
 /*
- * Trims all free space in the metaslab. Returns the root TRIM zio (that the
- * caller should zio_wait() for) and the amount of space in the metaslab that
- * has been scheduled for trimming in the `delta' return argument.
+ * This is used to trim all free space in a metaslab. The caller must
+ * initially set 'cursor' to the start offset of the metaslab. This function
+ * then walks the free space starting at or after this cursor and composes a
+ * TRIM zio for it. The function limits the number of bytes placed into the
+ * TRIM zio to at most zfs_max_bytes_per_trim. If the limit was hit before
+ * trimming all free space in the metaslab, the 'cursor' is updated to the
+ * last place we left off. The caller should keep calling this function in
+ * a loop as long as there is more space to trim. The function returns a TRIM
+ * zio that the caller should zio_wait for. If there is no more free space to
+ * trim in this metaslab, the function returns NULL instead. The 'delta'
+ * return argument contains the number of bytes scheduled for trimming in the
+ * returned TRIM zio.
+ * During execution, this function needs to load the metaslab. 'was_loaded'
+ * is an external state variable that is used to determine if the metaslab
+ * load was initiated by us and therefore whether we should unload the
+ * metaslab once we're done.
  */
 zio_t *
 metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
     boolean_t *was_loaded)
 {
-	uint64_t cur = *cursor, trimmed_space = 0;
+	uint64_t cur = *cursor;
+	uint64_t trimmed_space = 0;
 	zio_t *trim_io = NULL;
-	range_seg_t rsearch, *rs;
+	range_seg_t rsearch;
+	range_seg_t *rs;
 	avl_index_t where;
 	const uint64_t max_bytes = zfs_max_bytes_per_trim;
 
@@ -3532,11 +3526,16 @@ metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
 	}
 
 	/*
-	 * Flush out any scheduled extents and add everything in ms_tree
-	 * from the last cursor position, but not more than the trim run
-	 * limit.
+	 * Drop any scheduled extents and add everything in ms_tree from
+	 * the last cursor position, but not more than the trim run limit.
 	 */
 	range_tree_vacate(msp->ms_cur_ts, NULL, NULL);
+
+	/* Clear out ms_prev_ts, since we'll be trimming everything. */
+	if (msp->ms_prev_ts != NULL) {
+		metaslab_free_trimset(msp->ms_prev_ts);
+		msp->ms_prev_ts = NULL;
+	}
 
 	rsearch.rs_start = cur;
 	rsearch.rs_end = cur + SPA_MINBLOCKSIZE;
@@ -3545,12 +3544,6 @@ metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
 		rs = avl_nearest(&msp->ms_tree->rt_root, where, AVL_AFTER);
 		if (rs != NULL)
 			cur = rs->rs_start;
-	}
-
-	/* Clear out ms_prev_ts, since we'll be trimming everything. */
-	if (msp->ms_prev_ts != NULL) {
-		metaslab_free_trimset(msp->ms_prev_ts);
-		msp->ms_prev_ts = NULL;
 	}
 
 	while (rs != NULL && trimmed_space < max_bytes) {
@@ -3621,6 +3614,11 @@ metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
 	range_tree_add(msp->ms_cur_ts, offset, size);
 	ASSERT(msp->ms_prev_ts == NULL ||
 	    !range_tree_contains_part(msp->ms_prev_ts, offset, size));
+	/*
+	 * This might have been called from the manual trim code path
+	 * while an autotrim is demolishing this extent, so we can't
+	 * ASSERT against ms_trimming_ts here.
+	 */
 }
 
 /*
@@ -3826,6 +3824,18 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 		metaslab_free_trimset(msp->ms_trimming_ts);
 		msp->ms_trimming_ts = NULL;
 		return (zio_null(NULL, spa, NULL, NULL, NULL, 0));
+	}
+
+	if (msp->ms_loaded) {
+		/*
+		 * Recompute of the metaslab's weight & resort it. This is only
+		 * done when we're loaded, because then the trim_tree will have
+		 * affected ms_tree and its histogram. We cannot adjust the
+		 * histogram for the on-disk spacemap, however, because we
+		 * don't know which buckets to alter with what we have in
+		 * trim_tree.
+		 */
+		metaslab_group_sort(msp->ms_group, msp, metaslab_weight(msp));
 	}
 
 	if (auto_trim) {

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -3636,6 +3636,8 @@ static void
 metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
 {
 	metaslab_t *msp = arg;
+
+	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT(msp->ms_cur_ts != NULL);
 	range_tree_add(msp->ms_cur_ts->ts_tree, offset, size);
 	if (msp->ms_prev_ts != NULL) {
@@ -3939,6 +3941,7 @@ static boolean_t metaslab_check_trim_conflict(metaslab_t *msp,
 	uint64_t new_offset;
 
 	ASSERT3U(*offset + size, <=, limit);
+	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
 	if (msp->ms_trimming_ts == NULL)
 		/* no trim conflict, original offset is OK */

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -2270,7 +2270,7 @@ metaslab_sync(metaslab_t *msp, uint64_t txg)
 	metaslab_group_histogram_remove(mg, msp);
 
 	if (msp->ms_loaded && spa_sync_pass(spa) == 1 &&
-	    metaslab_should_condense(msp)) {
+	    metaslab_should_condense(msp) && msp->ms_trimming_ts == NULL) {
 		metaslab_condense(msp, txg, tx);
 	} else {
 		space_map_write(msp->ms_sm, alloctree, SM_ALLOC, tx);
@@ -3505,9 +3505,6 @@ metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
 
 	mutex_enter(&msp->ms_lock);
 
-	while (msp->ms_condensing)
-		cv_wait(&msp->ms_condensing_cv, &msp->ms_lock);
-
 	while (msp->ms_loading)
 		metaslab_load_wait(msp);
 	/*
@@ -3747,6 +3744,7 @@ metaslab_trim_done(zio_t *zio)
 	held = MUTEX_HELD(&msp->ms_lock);
 	if (!held)
 		mutex_enter(&msp->ms_lock);
+	VERIFY(!msp->ms_condensing);
 	if (msp->ms_loaded) {
 		range_tree_walk(msp->ms_trimming_ts, range_tree_add,
 		    msp->ms_tree);
@@ -3788,12 +3786,35 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 	const enum zio_flag trim_flags = ZIO_FLAG_CANFAIL |
 	    ZIO_FLAG_DONT_PROPAGATE | ZIO_FLAG_DONT_RETRY |
 	    ZIO_FLAG_CONFIG_WRITER;
+	zio_t *zio = NULL;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 
+	/*
+	 * TRIM and condense are mutually exclusive, because during TRIM
+	 * we're manipulating ms_tree to remove the extents that we're
+	 * currently trimming. Metaslab condensing takes priority.
+	 */
+	while (msp->ms_condensing)
+		cv_wait(&msp->ms_condensing_cv, &msp->ms_lock);
+
 	/* wait for a preceding trim to finish */
-	while (msp->ms_trimming_ts != NULL)
+	while (msp->ms_trimming_ts != NULL && !vdev_trim_should_stop(vd))
 		cv_wait(&msp->ms_trim_cv, &msp->ms_lock);
+
+	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
+
+	/*
+	 * If a management operation is about to happen, we need to stop
+	 * pushing new trims into the pipeline.
+	 */
+	if (vdev_trim_should_stop(vd)) {
+		metaslab_free_trimset(msp->ms_prev_ts);
+		msp->ms_prev_ts = NULL;
+		zio = zio_null(NULL, spa, NULL, NULL, NULL, 0);
+		goto out;
+	}
+
 	msp->ms_trimming_ts = msp->ms_prev_ts;
 	msp->ms_prev_ts = NULL;
 	trim_tree = msp->ms_trimming_ts;
@@ -3823,7 +3844,8 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 	if (range_tree_space(trim_tree) == 0) {
 		metaslab_free_trimset(msp->ms_trimming_ts);
 		msp->ms_trimming_ts = NULL;
-		return (zio_null(NULL, spa, NULL, NULL, NULL, 0));
+		zio = zio_null(NULL, spa, NULL, NULL, NULL, 0);
+		goto out;
 	}
 
 	if (msp->ms_loaded) {
@@ -3843,8 +3865,8 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 		range_seg_t *rs;
 		range_tree_t *sub_trim_tree = range_tree_create(NULL, NULL,
 		    &msp->ms_lock);
-		zio_t *pio = zio_null(NULL, spa, vd, metaslab_trim_done, msp,
-		    0);
+
+		zio = zio_null(NULL, spa, vd, metaslab_trim_done, msp, 0);
 
 		rs = avl_first(&trim_tree->rt_root);
 		if (rs != NULL)
@@ -3864,7 +3886,7 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 			ASSERT3U(range_tree_space(sub_trim_tree), <=,
 			    max_bytes);
 			if (range_tree_space(sub_trim_tree) == max_bytes) {
-				zio_nowait(zio_trim_tree(pio, spa, vd,
+				zio_nowait(zio_trim_tree(zio, spa, vd,
 				    sub_trim_tree, auto_trim, NULL, NULL,
 				    trim_flags, msp));
 				range_tree_vacate(sub_trim_tree, NULL, NULL);
@@ -3872,17 +3894,20 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 			start = end;
 		}
 		if (range_tree_space(sub_trim_tree) != 0) {
-			zio_nowait(zio_trim_tree(pio, spa, vd, sub_trim_tree,
+			zio_nowait(zio_trim_tree(zio, spa, vd, sub_trim_tree,
 			    auto_trim, NULL, NULL, trim_flags, msp));
 			range_tree_vacate(sub_trim_tree, NULL, NULL);
 		}
 		range_tree_destroy(sub_trim_tree);
-
-		return (pio);
 	} else {
-		return (zio_trim_tree(NULL, spa, vd, trim_tree, auto_trim,
-		    metaslab_trim_done, msp, trim_flags, msp));
+		zio = zio_trim_tree(NULL, spa, vd, trim_tree, auto_trim,
+		    metaslab_trim_done, msp, trim_flags, msp);
 	}
+
+	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+
+out:
+	return (zio);
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -216,6 +216,14 @@ kmem_cache_t *metaslab_alloc_trace_cache;
  * recovery (extents won't get trimmed immediately, but instead only
  * after passing this rather long timeout, thus preserving
  * 'zfs import -F' functionality).
+ * The exact default value of this tunable is a tradeoff between:
+ * 1) Keeping the trim commands reasonably small.
+ * 2) Keeping the ability to rollback back for as many txgs as possible.
+ * 3) Waiting around too long that the user starts to get uneasy about not
+ *	seeing any space being freed after they remove some files.
+ * The default value of 32 is the maximum number of uberblocks in a vdev
+ * label, assuming a 4k physical sector size (which seems to be the almost
+ * universal smallest sector size used in SSDs).
  */
 unsigned int zfs_txgs_per_trim = 32;
 /*
@@ -2479,8 +2487,13 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * the defer_tree.
 	 */
 	if (spa_get_auto_trim(spa) == SPA_AUTO_TRIM_ON &&
-	    !vd->vdev_man_trimming)
+	    !vd->vdev_man_trimming) {
 		range_tree_walk(*defer_tree, metaslab_trim_add, msp);
+		if (!defer_allowed) {
+			range_tree_walk(msp->ms_freedtree, metaslab_trim_add,
+			    msp);
+		}
+	}
 	range_tree_vacate(*defer_tree,
 	    msp->ms_loaded ? range_tree_add : NULL, msp->ms_tree);
 	if (defer_allowed) {
@@ -3625,6 +3638,8 @@ metaslab_trim_remove(void *arg, uint64_t offset, uint64_t size)
 	range_tree_clear(msp->ms_cur_ts->ts_tree, offset, size);
 	if (msp->ms_prev_ts != NULL)
 		range_tree_clear(msp->ms_prev_ts->ts_tree, offset, size);
+	ASSERT(msp->ms_trimming_ts == NULL ||
+	    !range_tree_contains(msp->ms_trimming_ts->ts_tree, offset, size));
 }
 
 /*
@@ -3647,8 +3662,7 @@ metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
 }
 
 /*
- * Does a metaslab's automatic trim operation processing. This must be
- * called from metaslab_sync, with the txg number of the txg. This function
+ * Does a metaslab's automatic trim operation processing. This function
  * issues trims in intervals as dictated by the zfs_txgs_per_trim tunable.
  * If the previous trimset has not yet finished trimming, this function
  * decides what to do based on `preserve_spilled'. If preserve_spilled is
@@ -3799,9 +3813,13 @@ metaslab_trim_done(zio_t *zio)
  * until that trim completes.
  * The `auto_trim' argument signals whether the trim is being invoked on
  * behalf of auto or manual trim. The differences are:
- * 1) For auto trim the trimset is split up into zios of no more than
- *	zfs_max_bytes_per_trim bytes. Manual trim already does this
- *	earlier, so the whole trimset is issued in a single zio.
+ * 1) For auto trim the trimset is split up into subtrees, each containing no
+ *	more than zfs_max_bytes_per_trim total bytes. Each subtree is then
+ *	trimmed in one zio. This is done to limit the number of LBAs per
+ *	trim command, as many devices perform suboptimally with large trim
+ *	commands, even if they indicate support for them. Manual trim already
+ *	applies this limit earlier by limiting the trimset size, so the
+ *	whole trimset can be issued in a single zio.
  * 2) The zio(s) generated are tagged with either ZIO_PRIORITY_AUTO_TRIM or
  *	ZIO_PRIORITY_MAN_TRIM to allow differentiating them further down
  *	the pipeline (see zio_priority_t in sys/zio_priority.h).

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -3802,8 +3802,6 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 	while (msp->ms_trimming_ts != NULL && !vdev_trim_should_stop(vd))
 		cv_wait(&msp->ms_trim_cv, &msp->ms_lock);
 
-	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
-
 	/*
 	 * If a management operation is about to happen, we need to stop
 	 * pushing new trims into the pipeline.
@@ -3811,9 +3809,10 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 	if (vdev_trim_should_stop(vd)) {
 		metaslab_free_trimset(msp->ms_prev_ts);
 		msp->ms_prev_ts = NULL;
-		zio = zio_null(NULL, spa, NULL, NULL, NULL, 0);
-		goto out;
+		return (zio_null(NULL, spa, NULL, NULL, NULL, 0));
 	}
+
+	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
 
 	msp->ms_trimming_ts = msp->ms_prev_ts;
 	msp->ms_prev_ts = NULL;
@@ -3904,9 +3903,9 @@ metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
 		    metaslab_trim_done, msp, trim_flags, msp);
 	}
 
+out:
 	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 
-out:
 	return (zio);
 }
 

--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -197,6 +198,43 @@ static uint64_t metaslab_weight(metaslab_t *);
 static void metaslab_set_fragmentation(metaslab_t *);
 
 kmem_cache_t *metaslab_alloc_trace_cache;
+
+/*
+ * How many TXG's worth of updates should be aggregated per TRIM/UNMAP
+ * issued to the underlying vdev. We keep two range trees of extents
+ * (called "trim sets") to be trimmed per metaslab, the `current' and
+ * the `previous' TS. New free's are added to the current TS. Then,
+ * once `zfs_txgs_per_trim' transactions have elapsed, the `current'
+ * TS becomes the `previous' TS and a new, blank TS is created to be
+ * the new `current', which will then start accumulating any new frees.
+ * Once another zfs_txgs_per_trim TXGs have passed, the previous TS's
+ * extents are trimmed, the TS is destroyed and the current TS again
+ * becomes the previous TS.
+ * This serves to fulfill two functions: aggregate many small frees
+ * into fewer larger trim operations (which should help with devices
+ * which do not take so kindly to them) and to allow for disaster
+ * recovery (extents won't get trimmed immediately, but instead only
+ * after passing this rather long timeout, thus preserving
+ * 'zfs import -F' functionality).
+ */
+unsigned int zfs_txgs_per_trim = 32;
+/*
+ * Maximum number of bytes we'll put into a single zio_trim. This is for
+ * vdev queue processing purposes and also because some devices advertise
+ * they can handle a lot more LBAs per command than they can handle
+ * efficiently.
+ */
+uint64_t zfs_max_bytes_per_trim = 128 << 20;
+
+static void metaslab_trim_remove(void *arg, uint64_t offset, uint64_t size);
+static void metaslab_trim_add(void *arg, uint64_t offset, uint64_t size);
+
+static zio_t *metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim);
+
+static metaslab_trimset_t *metaslab_new_trimset(uint64_t txg, kmutex_t *lock);
+static void metaslab_free_trimset(metaslab_trimset_t *ts);
+static boolean_t metaslab_check_trim_conflict(metaslab_t *msp,
+    uint64_t *offset, uint64_t size, uint64_t align, uint64_t limit);
 
 /*
  * ==========================================================================
@@ -1101,19 +1139,20 @@ metaslab_block_find(avl_tree_t *t, uint64_t start, uint64_t size)
  * tree looking for a block that matches the specified criteria.
  */
 static uint64_t
-metaslab_block_picker(avl_tree_t *t, uint64_t *cursor, uint64_t size,
-    uint64_t align)
+metaslab_block_picker(metaslab_t *msp, avl_tree_t *t, uint64_t *cursor,
+    uint64_t size, uint64_t align)
 {
 	range_seg_t *rs = metaslab_block_find(t, *cursor, size);
 
-	while (rs != NULL) {
+	for (; rs != NULL; rs = AVL_NEXT(t, rs)) {
 		uint64_t offset = P2ROUNDUP(rs->rs_start, align);
 
-		if (offset + size <= rs->rs_end) {
+		if (offset + size <= rs->rs_end &&
+		    !metaslab_check_trim_conflict(msp, &offset, size, align,
+		    rs->rs_end)) {
 			*cursor = offset + size;
 			return (offset);
 		}
-		rs = AVL_NEXT(t, rs);
 	}
 
 	/*
@@ -1124,7 +1163,7 @@ metaslab_block_picker(avl_tree_t *t, uint64_t *cursor, uint64_t size,
 		return (-1ULL);
 
 	*cursor = 0;
-	return (metaslab_block_picker(t, cursor, size, align));
+	return (metaslab_block_picker(msp, t, cursor, size, align));
 }
 
 /*
@@ -1146,7 +1185,7 @@ metaslab_ff_alloc(metaslab_t *msp, uint64_t size)
 	uint64_t *cursor = &msp->ms_lbas[highbit64(align) - 1];
 	avl_tree_t *t = &msp->ms_tree->rt_root;
 
-	return (metaslab_block_picker(t, cursor, size, align));
+	return (metaslab_block_picker(msp, t, cursor, size, align));
 }
 
 static metaslab_ops_t metaslab_ff_ops = {
@@ -1194,7 +1233,7 @@ metaslab_df_alloc(metaslab_t *msp, uint64_t size)
 		*cursor = 0;
 	}
 
-	return (metaslab_block_picker(t, cursor, size, 1ULL));
+	return (metaslab_block_picker(msp, t, cursor, size, 1ULL));
 }
 
 static metaslab_ops_t metaslab_df_ops = {
@@ -1228,11 +1267,16 @@ metaslab_cf_alloc(metaslab_t *msp, uint64_t size)
 		range_seg_t *rs;
 
 		rs = avl_last(&msp->ms_size_tree);
+		for (; rs != NULL && rs->rs_end - rs->rs_start >= size;
+		    rs = AVL_PREV(&msp->ms_size_tree, rs)) {
+			if (!metaslab_check_trim_conflict(msp, cursor, size,
+			    1, *cursor_end)) {
+				/* segment appears to be acceptable */
+				break;
+			}
+		}
 		if (rs == NULL || (rs->rs_end - rs->rs_start) < size)
 			return (-1ULL);
-
-		*cursor = rs->rs_start;
-		*cursor_end = rs->rs_end;
 	}
 
 	offset = *cursor;
@@ -1269,6 +1313,8 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 	uint64_t hbit = highbit64(size);
 	uint64_t *cursor = &msp->ms_lbas[hbit - 1];
 	uint64_t max_size = metaslab_block_maxsize(msp);
+	/* mutable copy for adjustment by metaslab_check_trim_conflict */
+	uint64_t adjustable_start;
 
 	ASSERT(MUTEX_HELD(&msp->ms_lock));
 	ASSERT3U(avl_numnodes(t), ==, avl_numnodes(&msp->ms_size_tree));
@@ -1280,7 +1326,12 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 	rsearch.rs_end = *cursor + size;
 
 	rs = avl_find(t, &rsearch, &where);
-	if (rs == NULL || (rs->rs_end - rs->rs_start) < size) {
+	if (rs != NULL)
+		adjustable_start = rs->rs_start;
+	if (rs == NULL || rs->rs_end - adjustable_start < size ||
+	    metaslab_check_trim_conflict(msp, &adjustable_start, size, 1,
+	    rs->rs_end)) {
+		/* segment not usable, try the largest remaining one */
 		t = &msp->ms_size_tree;
 
 		rsearch.rs_start = 0;
@@ -1290,13 +1341,17 @@ metaslab_ndf_alloc(metaslab_t *msp, uint64_t size)
 		if (rs == NULL)
 			rs = avl_nearest(t, where, AVL_AFTER);
 		ASSERT(rs != NULL);
+		adjustable_start = rs->rs_start;
+		if (rs->rs_end - adjustable_start < size ||
+		    metaslab_check_trim_conflict(msp, &adjustable_start,
+		    size, 1, rs->rs_end)) {
+			/* even largest remaining segment not usable */
+			return (-1ULL);
+		}
 	}
 
-	if ((rs->rs_end - rs->rs_start) >= size) {
-		*cursor = rs->rs_start + size;
-		return (rs->rs_start);
-	}
-	return (-1ULL);
+	*cursor = adjustable_start + size;
+	return (*cursor);
 }
 
 static metaslab_ops_t metaslab_ndf_ops = {
@@ -1357,6 +1412,8 @@ metaslab_load(metaslab_t *msp)
 		for (int t = 0; t < TXG_DEFER_SIZE; t++) {
 			range_tree_walk(msp->ms_defertree[t],
 			    range_tree_remove, msp->ms_tree);
+			range_tree_walk(msp->ms_defertree[t],
+			    metaslab_trim_remove, msp);
 		}
 		msp->ms_max_size = metaslab_block_maxsize(msp);
 	}
@@ -1386,6 +1443,8 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object, uint64_t txg,
 	ms = kmem_zalloc(sizeof (metaslab_t), KM_SLEEP);
 	mutex_init(&ms->ms_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&ms->ms_load_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&ms->ms_trim_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&ms->ms_condensing_cv, NULL, CV_DEFAULT, NULL);
 	ms->ms_id = id;
 	ms->ms_start = id << vd->vdev_ms_shift;
 	ms->ms_size = 1ULL << vd->vdev_ms_shift;
@@ -1405,6 +1464,8 @@ metaslab_init(metaslab_group_t *mg, uint64_t id, uint64_t object, uint64_t txg,
 
 		ASSERT(ms->ms_sm != NULL);
 	}
+
+	ms->ms_cur_ts = metaslab_new_trimset(0, &ms->ms_lock);
 
 	/*
 	 * We create the main range tree here, but we don't create the
@@ -1456,6 +1517,12 @@ metaslab_fini(metaslab_t *msp)
 {
 	metaslab_group_t *mg = msp->ms_group;
 
+	/* Wait for trimming to finish */
+	mutex_enter(&msp->ms_lock);
+	while (msp->ms_trimming_ts != NULL)
+		cv_wait(&msp->ms_trim_cv, &msp->ms_lock);
+	mutex_exit(&msp->ms_lock);
+
 	metaslab_group_remove(mg, msp);
 
 	mutex_enter(&msp->ms_lock);
@@ -1477,10 +1544,17 @@ metaslab_fini(metaslab_t *msp)
 		range_tree_destroy(msp->ms_defertree[t]);
 	}
 
+	metaslab_free_trimset(msp->ms_cur_ts);
+	if (msp->ms_prev_ts)
+		metaslab_free_trimset(msp->ms_prev_ts);
+	ASSERT3P(msp->ms_trimming_ts, ==, NULL);
+
 	ASSERT0(msp->ms_deferspace);
 
 	mutex_exit(&msp->ms_lock);
 	cv_destroy(&msp->ms_load_cv);
+	cv_destroy(&msp->ms_trim_cv);
+	cv_destroy(&msp->ms_condensing_cv);
 	mutex_destroy(&msp->ms_lock);
 
 	kmem_free(msp, sizeof (metaslab_t));
@@ -2164,6 +2238,7 @@ metaslab_condense(metaslab_t *msp, uint64_t txg, dmu_tx_t *tx)
 
 	space_map_write(sm, msp->ms_tree, SM_FREE, tx);
 	msp->ms_condensing = B_FALSE;
+	cv_broadcast(&msp->ms_condensing_cv);
 }
 
 /*
@@ -2403,6 +2478,9 @@ metaslab_sync_done(metaslab_t *msp, uint64_t txg)
 	 * defer_tree -- this is safe to do because we've just emptied out
 	 * the defer_tree.
 	 */
+	if (spa_get_auto_trim(spa) == SPA_AUTO_TRIM_ON &&
+	    !vd->vdev_man_trimming)
+		range_tree_walk(*defer_tree, metaslab_trim_add, msp);
 	range_tree_vacate(*defer_tree,
 	    msp->ms_loaded ? range_tree_add : NULL, msp->ms_tree);
 	if (defer_allowed) {
@@ -2652,6 +2730,7 @@ metaslab_block_alloc(metaslab_t *msp, uint64_t size, uint64_t txg)
 		VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
 		VERIFY3U(range_tree_space(rt) - size, <=, msp->ms_size);
 		range_tree_remove(rt, start, size);
+		metaslab_trim_remove(msp, start, size);
 
 		if (range_tree_space(msp->ms_alloctree[txg & TXG_MASK]) == 0)
 			vdev_dirty(mg->mg_vd, VDD_METASLAB, msp, txg);
@@ -2854,9 +2933,11 @@ next:
 		 * We have just failed an allocation attempt, check
 		 * that metaslab_should_allocate() agrees. Otherwise,
 		 * we may end up in an infinite loop retrying the same
-		 * metaslab.
+		 * metaslab. Keep in mind, it might have happened due
+		 * to an ongoing trim.
 		 */
-		ASSERT(!metaslab_should_allocate(msp, asize));
+		ASSERT(!metaslab_should_allocate(msp, asize) ||
+		    msp->ms_trimming_ts != NULL);
 		mutex_exit(&msp->ms_lock);
 	}
 	mutex_exit(&msp->ms_lock);
@@ -3165,8 +3246,13 @@ metaslab_free_dva(spa_t *spa, const dva_t *dva, uint64_t txg, boolean_t now)
 		    msp->ms_size);
 		VERIFY0(P2PHASE(offset, 1ULL << vd->vdev_ashift));
 		VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
+		VERIFY(!range_tree_contains(msp->ms_alloctree[txg & TXG_MASK],
+		    offset, size));
 		range_tree_add(msp->ms_tree, offset, size);
 		msp->ms_max_size = metaslab_block_maxsize(msp);
+		if (spa_get_auto_trim(spa) == SPA_AUTO_TRIM_ON &&
+		    !vd->vdev_man_trimming)
+			metaslab_trim_add(msp, offset, size);
 	} else {
 		VERIFY3U(txg, ==, spa->spa_syncing_txg);
 		if (range_tree_space(msp->ms_freeingtree) == 0)
@@ -3222,6 +3308,7 @@ metaslab_claim_dva(spa_t *spa, const dva_t *dva, uint64_t txg)
 	VERIFY0(P2PHASE(size, 1ULL << vd->vdev_ashift));
 	VERIFY3U(range_tree_space(msp->ms_tree) - size, <=, msp->ms_size);
 	range_tree_remove(msp->ms_tree, offset, size);
+	metaslab_trim_remove(msp, offset, size);
 
 	if (spa_writeable(spa)) {	/* don't dirty if we're zdb(1M) */
 		if (range_tree_space(msp->ms_alloctree[txg & TXG_MASK]) == 0)
@@ -3400,13 +3487,470 @@ metaslab_check_free(spa_t *spa, const blkptr_t *bp)
 		uint64_t size = DVA_GET_ASIZE(&bp->blk_dva[i]);
 		metaslab_t *msp = vd->vdev_ms[offset >> vd->vdev_ms_shift];
 
-		if (msp->ms_loaded)
+		mutex_enter(&msp->ms_lock);
+		if (msp->ms_loaded) {
 			range_tree_verify(msp->ms_tree, offset, size);
+#ifdef	DEBUG
+			VERIFY3P(&msp->ms_lock, ==,
+			    msp->ms_cur_ts->ts_tree->rt_lock);
+			range_tree_verify(msp->ms_cur_ts->ts_tree,
+			    offset, size);
+			if (msp->ms_prev_ts != NULL) {
+				VERIFY3P(&msp->ms_lock, ==,
+				    msp->ms_prev_ts->ts_tree->rt_lock);
+				range_tree_verify(msp->ms_prev_ts->ts_tree,
+				    offset, size);
+			}
+#endif
+		}
 
 		range_tree_verify(msp->ms_freeingtree, offset, size);
 		range_tree_verify(msp->ms_freedtree, offset, size);
 		for (int j = 0; j < TXG_DEFER_SIZE; j++)
 			range_tree_verify(msp->ms_defertree[j], offset, size);
+		mutex_exit(&msp->ms_lock);
 	}
 	spa_config_exit(spa, SCL_VDEV, FTAG);
+}
+
+/*
+ * Trims all free space in the metaslab. Returns the root TRIM zio (that the
+ * caller should zio_wait() for) and the amount of space in the metaslab that
+ * has been scheduled for trimming in the `delta' return argument.
+ */
+zio_t *
+metaslab_trim_all(metaslab_t *msp, uint64_t *cursor, uint64_t *delta,
+    boolean_t *was_loaded)
+{
+	uint64_t cur = *cursor, trimmed_space = 0;
+	zio_t *trim_io = NULL;
+	range_seg_t rsearch, *rs;
+	avl_index_t where;
+	const uint64_t max_bytes = zfs_max_bytes_per_trim;
+
+	ASSERT(!MUTEX_HELD(&msp->ms_group->mg_lock));
+	ASSERT3U(cur, >=, msp->ms_start);
+	ASSERT3U(cur, <=, msp->ms_start + msp->ms_size);
+
+	mutex_enter(&msp->ms_lock);
+
+	while (msp->ms_condensing)
+		cv_wait(&msp->ms_condensing_cv, &msp->ms_lock);
+
+	while (msp->ms_loading)
+		metaslab_load_wait(msp);
+	/*
+	 * On the initial call we memorize if we had to load the metaslab
+	 * for ourselves, so we can unload it when we're done.
+	 */
+	if (cur == msp->ms_start)
+		*was_loaded = msp->ms_loaded;
+	if (!msp->ms_loaded) {
+		if (metaslab_load(msp) != 0) {
+			/* Load failed, stop trimming this metaslab */
+			*cursor = msp->ms_start + msp->ms_size;
+			mutex_exit(&msp->ms_lock);
+			return (NULL);
+		}
+	}
+
+	/*
+	 * Flush out any scheduled extents and add everything in ms_tree
+	 * from the last cursor position, but not more than the trim run
+	 * limit.
+	 */
+	range_tree_vacate(msp->ms_cur_ts->ts_tree, NULL, NULL);
+
+	rsearch.rs_start = cur;
+	rsearch.rs_end = cur + SPA_MINBLOCKSIZE;
+	rs = avl_find(&msp->ms_tree->rt_root, &rsearch, &where);
+	if (rs == NULL) {
+		rs = avl_nearest(&msp->ms_tree->rt_root, where, AVL_AFTER);
+		if (rs != NULL)
+			cur = rs->rs_start;
+	}
+
+	/* Clear out ms_prev_ts, since we'll be trimming everything. */
+	if (msp->ms_prev_ts != NULL) {
+		metaslab_free_trimset(msp->ms_prev_ts);
+		msp->ms_prev_ts = NULL;
+	}
+
+	while (rs != NULL && trimmed_space < max_bytes) {
+		uint64_t end;
+		if (cur < rs->rs_start)
+			cur = rs->rs_start;
+		end = MIN(cur + (max_bytes - trimmed_space), rs->rs_end);
+		metaslab_trim_add(msp, cur, end - cur);
+		trimmed_space += (end - cur);
+		cur = end;
+		if (cur == rs->rs_end)
+			rs = AVL_NEXT(&msp->ms_tree->rt_root, rs);
+	}
+
+	if (trimmed_space != 0) {
+		/* Force this trim to take place ASAP. */
+		msp->ms_prev_ts = msp->ms_cur_ts;
+		msp->ms_cur_ts = metaslab_new_trimset(0, &msp->ms_lock);
+		trim_io = metaslab_exec_trim(msp, B_FALSE);
+		ASSERT(trim_io != NULL);
+
+		/*
+		 * Not at the end of this metaslab yet, have vdev_man_trim
+		 * come back around for another run.
+		 */
+		*cursor = cur;
+	} else {
+		*cursor = msp->ms_start + msp->ms_size;
+		if (!(*was_loaded) && !vdev_is_dirty(msp->ms_group->mg_vd,
+		    VDD_METASLAB, msp) && msp->ms_activation_weight == 0)
+			metaslab_unload(msp);
+	}
+
+	mutex_exit(&msp->ms_lock);
+	*delta = trimmed_space;
+
+	return (trim_io);
+}
+
+/*
+ * Notifies the trimsets in a metaslab that an extent has been allocated.
+ * This removes the segment from the queues of extents awaiting to be trimmed.
+ */
+static void
+metaslab_trim_remove(void *arg, uint64_t offset, uint64_t size)
+{
+	metaslab_t *msp = arg;
+
+	range_tree_clear(msp->ms_cur_ts->ts_tree, offset, size);
+	if (msp->ms_prev_ts != NULL)
+		range_tree_clear(msp->ms_prev_ts->ts_tree, offset, size);
+}
+
+/*
+ * Notifies the trimsets in a metaslab that an extent has been freed.
+ * This adds the segment to the currently open queue of extents awaiting
+ * to be trimmed.
+ */
+static void
+metaslab_trim_add(void *arg, uint64_t offset, uint64_t size)
+{
+	metaslab_t *msp = arg;
+	ASSERT(msp->ms_cur_ts != NULL);
+	range_tree_add(msp->ms_cur_ts->ts_tree, offset, size);
+	if (msp->ms_prev_ts != NULL) {
+		ASSERT(!range_tree_contains_part(msp->ms_prev_ts->ts_tree,
+		    offset, size));
+	}
+}
+
+/*
+ * Does a metaslab's automatic trim operation processing. This must be
+ * called from metaslab_sync, with the txg number of the txg. This function
+ * issues trims in intervals as dictated by the zfs_txgs_per_trim tunable.
+ * If the previous trimset has not yet finished trimming, this function
+ * decides what to do based on `preserve_spilled'. If preserve_spilled is
+ * false, the next trimset which would have been issued is simply dropped to
+ * limit memory usage. Otherwise it is preserved by adding it to the cur_ts
+ * trimset.
+ */
+void
+metaslab_auto_trim(metaslab_t *msp, uint64_t txg, boolean_t preserve_spilled)
+{
+	/* for atomicity */
+	uint64_t txgs_per_trim = zfs_txgs_per_trim;
+
+	ASSERT(!MUTEX_HELD(&msp->ms_lock));
+	mutex_enter(&msp->ms_lock);
+
+	/*
+	 * Since we typically have hundreds of metaslabs per vdev, but we only
+	 * trim them once every zfs_txgs_per_trim txgs, it'd be best if we
+	 * could sequence the TRIM commands from all metaslabs so that they
+	 * don't all always pound the device in the same txg. We do so by
+	 * artificially inflating the birth txg of the first trim set by a
+	 * sequence number derived from the metaslab's starting offset
+	 * (modulo zfs_txgs_per_trim). Thus, for the default 200 metaslabs and
+	 * 32 txgs per trim, we'll only be trimming ~6.25 metaslabs per txg.
+	 *
+	 * If we detect that the txg has advanced too far ahead of ts_birth,
+	 * it means our birth txg is out of lockstep. Recompute it by
+	 * rounding down to the nearest zfs_txgs_per_trim multiple and adding
+	 * our metaslab id modulo zfs_txgs_per_trim.
+	 */
+	if (txg > msp->ms_cur_ts->ts_birth + txgs_per_trim) {
+		msp->ms_cur_ts->ts_birth = (txg / txgs_per_trim) *
+		    txgs_per_trim + (msp->ms_id % txgs_per_trim);
+	}
+
+	/* Time to swap out the current and previous trimsets */
+	if (txg == msp->ms_cur_ts->ts_birth + txgs_per_trim) {
+		if (msp->ms_prev_ts != NULL) {
+			if (msp->ms_trimming_ts != NULL) {
+				spa_t *spa = msp->ms_group->mg_class->mc_spa;
+				/*
+				 * The previous trim run is still ongoing, so
+				 * the device is reacting slowly to our trim
+				 * requests. Drop this trimset, so as not to
+				 * back the device up with trim requests.
+				 */
+				if (preserve_spilled) {
+					DTRACE_PROBE1(preserve__spilled,
+					    metaslab_t *, msp);
+					range_tree_vacate(
+					    msp->ms_prev_ts->ts_tree,
+					    range_tree_add,
+					    msp->ms_cur_ts->ts_tree);
+				} else {
+					DTRACE_PROBE1(drop__spilled,
+					    metaslab_t *, msp);
+					spa_trimstats_auto_slow_incr(spa);
+				}
+				metaslab_free_trimset(msp->ms_prev_ts);
+			} else if (msp->ms_group->mg_vd->vdev_man_trimming) {
+				/*
+				 * If a manual trim is ongoing, we want to
+				 * inhibit autotrim temporarily so it doesn't
+				 * slow down the manual trim.
+				 */
+				metaslab_free_trimset(msp->ms_prev_ts);
+			} else {
+				/*
+				 * Trim out aged extents on the vdevs - these
+				 * are safe to be destroyed now. We'll keep
+				 * the trimset around to deny allocations from
+				 * these regions while the trims are ongoing.
+				 */
+				zio_nowait(metaslab_exec_trim(msp, B_TRUE));
+			}
+		}
+		msp->ms_prev_ts = msp->ms_cur_ts;
+		msp->ms_cur_ts = metaslab_new_trimset(txg, &msp->ms_lock);
+	}
+	mutex_exit(&msp->ms_lock);
+}
+
+/*
+ * Computes the amount of memory a trimset is expected to use if issued out
+ * to be trimmed. The calculation isn't 100% accurate, because we don't
+ * know how the trimset's extents might subdivide into smaller extents
+ * (dkioc_free_list_ext_t) that actually get passed to the zio, but luckily
+ * the extent structure is fairly small compared to the size of a zio_t, so
+ * it's less important that we get that absolutely correct. We just want to
+ * get it "close enough".
+ */
+static uint64_t
+metaslab_trimset_mem_used(metaslab_trimset_t *ts)
+{
+	uint64_t result = 0;
+
+	result += avl_numnodes(&ts->ts_tree->rt_root) * (sizeof (range_seg_t) +
+	    sizeof (dkioc_free_list_ext_t));
+	result += ((range_tree_space(ts->ts_tree) / zfs_max_bytes_per_trim) +
+	    1) * sizeof (zio_t);
+	result += sizeof (range_tree_t) + sizeof (metaslab_trimset_t);
+
+	return (result);
+}
+
+/*
+ * Computes the amount of memory used by the trimsets and queued trim zios of
+ * a metaslab.
+ */
+uint64_t
+metaslab_trim_mem_used(metaslab_t *msp)
+{
+	uint64_t result = 0;
+
+	ASSERT(!MUTEX_HELD(&msp->ms_lock));
+	mutex_enter(&msp->ms_lock);
+	result += metaslab_trimset_mem_used(msp->ms_cur_ts);
+	if (msp->ms_prev_ts != NULL)
+		result += metaslab_trimset_mem_used(msp->ms_prev_ts);
+	mutex_exit(&msp->ms_lock);
+
+	return (result);
+}
+
+static void
+metaslab_trim_done(zio_t *zio)
+{
+	metaslab_t *msp = zio->io_private;
+	boolean_t held;
+
+	ASSERT(msp != NULL);
+	ASSERT(msp->ms_trimming_ts != NULL);
+	held = MUTEX_HELD(&msp->ms_lock);
+	if (!held)
+		mutex_enter(&msp->ms_lock);
+	metaslab_free_trimset(msp->ms_trimming_ts);
+	msp->ms_trimming_ts = NULL;
+	cv_broadcast(&msp->ms_trim_cv);
+	if (!held)
+		mutex_exit(&msp->ms_lock);
+}
+
+/*
+ * Executes a zio_trim on a range tree holding freed extents in the metaslab.
+ * The set of extents is taken from the metaslab's ms_prev_ts. If there is
+ * another trim currently executing on that metaslab, this function blocks
+ * until that trim completes.
+ * The `auto_trim' argument signals whether the trim is being invoked on
+ * behalf of auto or manual trim. The differences are:
+ * 1) For auto trim the trimset is split up into zios of no more than
+ *	zfs_max_bytes_per_trim bytes. Manual trim already does this
+ *	earlier, so the whole trimset is issued in a single zio.
+ * 2) The zio(s) generated are tagged with either ZIO_PRIORITY_AUTO_TRIM or
+ *	ZIO_PRIORITY_MAN_TRIM to allow differentiating them further down
+ *	the pipeline (see zio_priority_t in sys/zio_priority.h).
+ * The function always returns a zio that the caller should zio_(no)wait.
+ */
+static zio_t *
+metaslab_exec_trim(metaslab_t *msp, boolean_t auto_trim)
+{
+	metaslab_group_t *mg = msp->ms_group;
+	spa_t *spa = mg->mg_class->mc_spa;
+	vdev_t *vd = mg->mg_vd;
+	range_tree_t *trim_tree;
+	const uint64_t max_bytes = zfs_max_bytes_per_trim;
+	const enum zio_flag trim_flags = ZIO_FLAG_CANFAIL |
+	    ZIO_FLAG_DONT_PROPAGATE | ZIO_FLAG_DONT_RETRY |
+	    ZIO_FLAG_CONFIG_WRITER;
+
+	ASSERT(MUTEX_HELD(&msp->ms_lock));
+
+	/* wait for a preceding trim to finish */
+	while (msp->ms_trimming_ts != NULL)
+		cv_wait(&msp->ms_trim_cv, &msp->ms_lock);
+	msp->ms_trimming_ts = msp->ms_prev_ts;
+	msp->ms_prev_ts = NULL;
+	trim_tree = msp->ms_trimming_ts->ts_tree;
+#ifdef	DEBUG
+	if (msp->ms_loaded) {
+		for (range_seg_t *rs = avl_first(&trim_tree->rt_root);
+		    rs != NULL; rs = AVL_NEXT(&trim_tree->rt_root, rs)) {
+			if (!range_tree_contains_part(msp->ms_tree,
+			    rs->rs_start, rs->rs_end - rs->rs_start)) {
+				panic("trimming allocated region; rs=%p",
+				    (void*)rs);
+			}
+		}
+	}
+#endif
+
+	/* Nothing to trim */
+	if (range_tree_space(trim_tree) == 0) {
+		metaslab_free_trimset(msp->ms_trimming_ts);
+		msp->ms_trimming_ts = 0;
+		return (zio_null(NULL, spa, NULL, NULL, NULL, 0));
+	}
+
+	if (auto_trim) {
+		uint64_t start = 0;
+		range_seg_t *rs;
+		range_tree_t *sub_trim_tree = range_tree_create(NULL, NULL,
+		    &msp->ms_lock);
+		zio_t *pio = zio_null(NULL, spa, vd, metaslab_trim_done, msp,
+		    0);
+
+		rs = avl_first(&trim_tree->rt_root);
+		if (rs != NULL)
+			start = rs->rs_start;
+		while (rs != NULL) {
+			uint64_t end = MIN(rs->rs_end, start + (max_bytes -
+			    range_tree_space(sub_trim_tree)));
+
+			ASSERT3U(start, <=, end);
+			if (start == end) {
+				rs = AVL_NEXT(&trim_tree->rt_root, rs);
+				if (rs != NULL)
+					start = rs->rs_start;
+				continue;
+			}
+			range_tree_add(sub_trim_tree, start, end - start);
+			ASSERT3U(range_tree_space(sub_trim_tree), <=,
+			    max_bytes);
+			if (range_tree_space(sub_trim_tree) == max_bytes) {
+				zio_nowait(zio_trim_tree(pio, spa, vd,
+				    sub_trim_tree, auto_trim, NULL, NULL,
+				    trim_flags, msp));
+				range_tree_vacate(sub_trim_tree, NULL, NULL);
+			}
+			start = end;
+		}
+		if (range_tree_space(sub_trim_tree) != 0) {
+			zio_nowait(zio_trim_tree(pio, spa, vd, sub_trim_tree,
+			    auto_trim, NULL, NULL, trim_flags, msp));
+			range_tree_vacate(sub_trim_tree, NULL, NULL);
+		}
+		range_tree_destroy(sub_trim_tree);
+
+		return (pio);
+	} else {
+		return (zio_trim_tree(NULL, spa, vd, trim_tree, auto_trim,
+		    metaslab_trim_done, msp, trim_flags, msp));
+	}
+}
+
+/*
+ * Allocates and initializes a new trimset structure. The `txg' argument
+ * indicates when this trimset was born and `lock' indicates the lock to
+ * link to the range tree.
+ */
+static metaslab_trimset_t *
+metaslab_new_trimset(uint64_t txg, kmutex_t *lock)
+{
+	metaslab_trimset_t *ts;
+
+	ts = kmem_zalloc(sizeof (*ts), KM_SLEEP);
+	ts->ts_birth = txg;
+	ts->ts_tree = range_tree_create(NULL, NULL, lock);
+
+	return (ts);
+}
+
+/*
+ * Destroys and frees a trim set previously allocated by metaslab_new_trimset.
+ */
+static void
+metaslab_free_trimset(metaslab_trimset_t *ts)
+{
+	range_tree_vacate(ts->ts_tree, NULL, NULL);
+	range_tree_destroy(ts->ts_tree);
+	kmem_free(ts, sizeof (*ts));
+}
+
+/*
+ * Checks whether an allocation conflicts with an ongoing trim operation in
+ * the given metaslab. This function takes a segment starting at `*offset'
+ * of `size' and checks whether it hits any region in the metaslab currently
+ * being trimmed. If yes, it tries to adjust the allocation to the end of
+ * the region being trimmed (P2ROUNDUP aligned by `align'), but only up to
+ * `limit' (no part of the allocation is allowed to go past this point).
+ *
+ * Returns B_FALSE if either the original allocation wasn't in conflict, or
+ * the conflict could be resolved by adjusting the value stored in `offset'
+ * such that the whole allocation still fits below `limit'. Returns B_TRUE
+ * if the allocation conflict couldn't be resolved.
+ */
+static boolean_t metaslab_check_trim_conflict(metaslab_t *msp,
+    uint64_t *offset, uint64_t size, uint64_t align, uint64_t limit)
+{
+	uint64_t new_offset;
+
+	ASSERT3U(*offset + size, <=, limit);
+
+	if (msp->ms_trimming_ts == NULL)
+		/* no trim conflict, original offset is OK */
+		return (B_FALSE);
+
+	new_offset = P2ROUNDUP(range_tree_find_gap(msp->ms_trimming_ts->ts_tree,
+	    *offset, size), align);
+	if (new_offset + size > limit)
+		/* trim conflict and adjustment not possible */
+		return (B_TRUE);
+
+	/* trim conflict, but adjusted offset still within limit */
+	*offset = new_offset;
+	return (B_FALSE);
 }

--- a/usr/src/uts/common/fs/zfs/range_tree.c
+++ b/usr/src/uts/common/fs/zfs/range_tree.c
@@ -325,23 +325,6 @@ range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size)
 	return (NULL);
 }
 
-/*
- * Given an extent start offset and size, will look through the provided
- * range tree and find a suitable start offset (starting at `start') such
- * that the requested extent _doesn't_ overlap with any range segment in
- * the range tree.
- */
-uint64_t
-range_tree_find_gap(range_tree_t *rt, uint64_t start, uint64_t size)
-{
-	range_seg_t *rs;
-
-	ASSERT(MUTEX_HELD(rt->rt_lock));
-	while ((rs = range_tree_find_impl(rt, start, size)) != NULL)
-		start = rs->rs_end;
-	return (start);
-}
-
 void
 range_tree_verify(range_tree_t *rt, uint64_t off, uint64_t size)
 {

--- a/usr/src/uts/common/fs/zfs/range_tree.c
+++ b/usr/src/uts/common/fs/zfs/range_tree.c
@@ -24,6 +24,7 @@
  */
 /*
  * Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -324,22 +325,44 @@ range_tree_find(range_tree_t *rt, uint64_t start, uint64_t size)
 	return (NULL);
 }
 
+/*
+ * Given an extent start offset and size, will look through the provided
+ * range tree and find a suitable start offset (starting at `start') such
+ * that the requested extent _doesn't_ overlap with any range segment in
+ * the range tree.
+ */
+uint64_t
+range_tree_find_gap(range_tree_t *rt, uint64_t start, uint64_t size)
+{
+	range_seg_t *rs;
+	while ((rs = range_tree_find_impl(rt, start, size)) != NULL)
+		start = rs->rs_end;
+	return (start);
+}
+
 void
 range_tree_verify(range_tree_t *rt, uint64_t off, uint64_t size)
 {
 	range_seg_t *rs;
 
-	mutex_enter(rt->rt_lock);
 	rs = range_tree_find(rt, off, size);
 	if (rs != NULL)
 		panic("freeing free block; rs=%p", (void *)rs);
-	mutex_exit(rt->rt_lock);
 }
 
 boolean_t
 range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size)
 {
 	return (range_tree_find(rt, start, size) != NULL);
+}
+
+/*
+ * Same as range_tree_contains, but locates even just a partial overlap.
+ */
+boolean_t
+range_tree_contains_part(range_tree_t *rt, uint64_t start, uint64_t size)
+{
+	return (range_tree_find_impl(rt, start, size) != NULL);
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/range_tree.c
+++ b/usr/src/uts/common/fs/zfs/range_tree.c
@@ -335,6 +335,8 @@ uint64_t
 range_tree_find_gap(range_tree_t *rt, uint64_t start, uint64_t size)
 {
 	range_seg_t *rs;
+
+	ASSERT(MUTEX_HELD(rt->rt_lock));
 	while ((rs = range_tree_find_impl(rt, start, size)) != NULL)
 		start = rs->rs_end;
 	return (start);
@@ -345,6 +347,7 @@ range_tree_verify(range_tree_t *rt, uint64_t off, uint64_t size)
 {
 	range_seg_t *rs;
 
+	ASSERT(MUTEX_HELD(rt->rt_lock));
 	rs = range_tree_find(rt, off, size);
 	if (rs != NULL)
 		panic("freeing free block; rs=%p", (void *)rs);

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
- * Copyright (c) 2015, Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -150,6 +150,10 @@ static int spa_load_impl(spa_t *spa, uint64_t, nvlist_t *config,
     spa_load_state_t state, spa_import_type_t type, boolean_t mosconfig,
     char **ereport);
 static void spa_vdev_resilver_done(spa_t *spa);
+static void spa_auto_trim(spa_t *spa, uint64_t txg);
+static void spa_vdev_man_trim_done(spa_t *spa);
+static void spa_vdev_auto_trim_done(spa_t *spa);
+static uint64_t spa_min_trim_rate(spa_t *spa);
 
 uint_t		zio_taskq_batch_pct = 75;	/* 1 thread per cpu in pset */
 id_t		zio_taskq_psrset_bind = PS_NONE;
@@ -466,6 +470,8 @@ spa_prop_validate(spa_t *spa, nvlist_t *props)
 		case ZPOOL_PROP_AUTOREPLACE:
 		case ZPOOL_PROP_LISTSNAPS:
 		case ZPOOL_PROP_AUTOEXPAND:
+		case ZPOOL_PROP_FORCETRIM:
+		case ZPOOL_PROP_AUTOTRIM:
 			error = nvpair_value_uint64(elem, &intval);
 			if (!error && intval > 1)
 				error = SET_ERROR(EINVAL);
@@ -1229,6 +1235,16 @@ spa_unload(spa_t *spa)
 	ASSERT(MUTEX_HELD(&spa_namespace_lock));
 
 	/*
+	 * Stop manual trim before stopping spa sync, because manual trim
+	 * needs to execute a synctask (trim timestamp sync) at the end.
+	 */
+	mutex_enter(&spa->spa_auto_trim_lock);
+	mutex_enter(&spa->spa_man_trim_lock);
+	spa_trim_stop_wait(spa);
+	mutex_exit(&spa->spa_man_trim_lock);
+	mutex_exit(&spa->spa_auto_trim_lock);
+
+	/*
 	 * Stop async tasks.
 	 */
 	spa_async_suspend(spa);
@@ -1240,6 +1256,14 @@ spa_unload(spa_t *spa)
 		txg_sync_stop(spa->spa_dsl_pool);
 		spa->spa_sync_on = B_FALSE;
 	}
+
+	/*
+	 * Stop autotrim tasks.
+	 */
+	mutex_enter(&spa->spa_auto_trim_lock);
+	if (spa->spa_auto_trim_taskq)
+		spa_auto_trim_taskq_destroy(spa);
+	mutex_exit(&spa->spa_auto_trim_lock);
 
 	/*
 	 * Even though vdev_free() also calls vdev_metaslab_fini, we need
@@ -2740,9 +2764,21 @@ spa_load_impl(spa_t *spa, uint64_t pool_guid, nvlist_t *config,
 		spa_prop_find(spa, ZPOOL_PROP_AUTOEXPAND, &spa->spa_autoexpand);
 		spa_prop_find(spa, ZPOOL_PROP_DEDUPDITTO,
 		    &spa->spa_dedup_ditto);
+		spa_prop_find(spa, ZPOOL_PROP_FORCETRIM, &spa->spa_force_trim);
+
+		mutex_enter(&spa->spa_auto_trim_lock);
+		spa_prop_find(spa, ZPOOL_PROP_AUTOTRIM, &spa->spa_auto_trim);
+		if (spa->spa_auto_trim == SPA_AUTO_TRIM_ON)
+			spa_auto_trim_taskq_create(spa);
+		mutex_exit(&spa->spa_auto_trim_lock);
 
 		spa->spa_autoreplace = (autoreplace != 0);
 	}
+
+	(void) spa_dir_prop(spa, DMU_POOL_TRIM_START_TIME,
+	    &spa->spa_man_trim_start_time);
+	(void) spa_dir_prop(spa, DMU_POOL_TRIM_STOP_TIME,
+	    &spa->spa_man_trim_stop_time);
 
 	/*
 	 * If the 'autoreplace' property is set, then post a resource notifying
@@ -3804,6 +3840,13 @@ spa_create(const char *pool, nvlist_t *nvroot, nvlist_t *props,
 	spa->spa_delegation = zpool_prop_default_numeric(ZPOOL_PROP_DELEGATION);
 	spa->spa_failmode = zpool_prop_default_numeric(ZPOOL_PROP_FAILUREMODE);
 	spa->spa_autoexpand = zpool_prop_default_numeric(ZPOOL_PROP_AUTOEXPAND);
+	spa->spa_force_trim = zpool_prop_default_numeric(ZPOOL_PROP_FORCETRIM);
+
+	mutex_enter(&spa->spa_auto_trim_lock);
+	spa->spa_auto_trim = zpool_prop_default_numeric(ZPOOL_PROP_AUTOTRIM);
+	if (spa->spa_auto_trim == SPA_AUTO_TRIM_ON)
+		spa_auto_trim_taskq_create(spa);
+	mutex_exit(&spa->spa_auto_trim_lock);
 
 	if (props != NULL) {
 		spa_configfile_set(spa, props, B_FALSE);
@@ -4686,6 +4729,8 @@ spa_vdev_attach(spa_t *spa, uint64_t guid, nvlist_t *nvroot, int replacing)
 	if (newvd->vdev_ashift > oldvd->vdev_top->vdev_ashift)
 		return (spa_vdev_exit(spa, newrootvd, txg, EDOM));
 
+	vdev_trim_stop_wait(oldvd->vdev_top);
+
 	/*
 	 * If this is an in-place replacement, update oldvd's path and devid
 	 * to make it distinguishable from newvd, and unopenable from now on.
@@ -4854,6 +4899,8 @@ spa_vdev_detach(spa_t *spa, uint64_t guid, uint64_t pguid, int replace_done)
 	 */
 	if (vdev_dtl_required(vd))
 		return (spa_vdev_exit(spa, NULL, txg, EBUSY));
+
+	vdev_trim_stop_wait(vd->vdev_top);
 
 	ASSERT(pvd->vdev_children >= 2);
 
@@ -5090,6 +5137,8 @@ spa_vdev_split_mirror(spa_t *spa, char *newname, nvlist_t *config,
 	if (nvlist_lookup_nvlist(nvl, ZPOOL_CONFIG_SPARES, &tmp) == 0 ||
 	    nvlist_lookup_nvlist(nvl, ZPOOL_CONFIG_L2CACHE, &tmp) == 0)
 		return (spa_vdev_exit(spa, NULL, txg, EINVAL));
+
+	vdev_trim_stop_wait(rvd);
 
 	vml = kmem_zalloc(children * sizeof (vdev_t *), KM_SLEEP);
 	glist = kmem_zalloc(children * sizeof (uint64_t), KM_SLEEP);
@@ -5519,6 +5568,8 @@ spa_vdev_remove(spa_t *spa, uint64_t guid, boolean_t unspare)
 		 */
 		metaslab_group_passivate(mg);
 
+		vdev_trim_stop_wait(vd);
+
 		/*
 		 * Wait for the youngest allocations and frees to sync,
 		 * and then wait for the deferral of those frees to finish.
@@ -5922,6 +5973,12 @@ spa_async_thread(spa_t *spa)
 	if (tasks & SPA_ASYNC_RESILVER)
 		dsl_resilver_restart(spa->spa_dsl_pool, 0);
 
+	if (tasks & SPA_ASYNC_MAN_TRIM_TASKQ_DESTROY) {
+		mutex_enter(&spa->spa_man_trim_lock);
+		spa_man_trim_taskq_destroy(spa);
+		mutex_exit(&spa->spa_man_trim_lock);
+	}
+
 	/*
 	 * Let the world know that we're done.
 	 */
@@ -5990,6 +6047,15 @@ spa_async_request(spa_t *spa, int task)
 	zfs_dbgmsg("spa=%s async request task=%u", spa->spa_name, task);
 	mutex_enter(&spa->spa_async_lock);
 	spa->spa_async_tasks |= task;
+	mutex_exit(&spa->spa_async_lock);
+}
+
+void
+spa_async_unrequest(spa_t *spa, int task)
+{
+	zfs_dbgmsg("spa=%s async unrequest task=%u", spa->spa_name, task);
+	mutex_enter(&spa->spa_async_lock);
+	spa->spa_async_tasks &= ~task;
 	mutex_exit(&spa->spa_async_lock);
 }
 
@@ -6399,6 +6465,21 @@ spa_sync_props(void *arg, dmu_tx_t *tx)
 			case ZPOOL_PROP_FAILUREMODE:
 				spa->spa_failmode = intval;
 				break;
+			case ZPOOL_PROP_FORCETRIM:
+				spa->spa_force_trim = intval;
+				break;
+			case ZPOOL_PROP_AUTOTRIM:
+				mutex_enter(&spa->spa_auto_trim_lock);
+				if (intval != spa->spa_auto_trim) {
+					spa->spa_auto_trim = intval;
+					if (intval != 0)
+						spa_auto_trim_taskq_create(spa);
+					else
+						spa_auto_trim_taskq_destroy(
+						    spa);
+				}
+				mutex_exit(&spa->spa_auto_trim_lock);
+				break;
 			case ZPOOL_PROP_AUTOEXPAND:
 				spa->spa_autoexpand = intval;
 				if (tx->tx_txg != TXG_INITIAL)
@@ -6522,6 +6603,9 @@ spa_sync(spa_t *spa, uint64_t txg)
 	mutex_enter(&spa->spa_alloc_lock);
 	VERIFY0(avl_numnodes(&spa->spa_alloc_tree));
 	mutex_exit(&spa->spa_alloc_lock);
+
+	if (spa->spa_auto_trim == SPA_AUTO_TRIM_ON)
+		spa_auto_trim(spa, txg);
 
 	/*
 	 * If there are any pending vdev state changes, convert them
@@ -7019,4 +7103,273 @@ void
 spa_event_notify(spa_t *spa, vdev_t *vd, const char *name)
 {
 	spa_event_post(spa_event_create(spa, vd, name));
+}
+
+/*
+ * Dispatches all auto-trim processing to all top-level vdevs. This is
+ * called from spa_sync once every txg.
+ */
+static void
+spa_auto_trim(spa_t *spa, uint64_t txg)
+{
+	ASSERT(spa_config_held(spa, SCL_CONFIG, RW_READER) == SCL_CONFIG);
+	ASSERT(!MUTEX_HELD(&spa->spa_auto_trim_lock));
+	ASSERT(spa->spa_auto_trim_taskq != NULL);
+
+	/*
+	 * Another pool management task might be currently prevented from
+	 * starting and the current txg sync was invoked on its behalf,
+	 * so be prepared to postpone autotrim processing.
+	 */
+	if (!mutex_tryenter(&spa->spa_auto_trim_lock))
+		return;
+	spa->spa_num_auto_trimming += spa->spa_root_vdev->vdev_children;
+	mutex_exit(&spa->spa_auto_trim_lock);
+
+	for (uint64_t i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
+		vdev_trim_info_t *vti = kmem_zalloc(sizeof (*vti), KM_SLEEP);
+		vti->vti_vdev = spa->spa_root_vdev->vdev_child[i];
+		vti->vti_txg = txg;
+		vti->vti_done_cb = (void (*)(void *))spa_vdev_auto_trim_done;
+		vti->vti_done_arg = spa;
+		(void) taskq_dispatch(spa->spa_auto_trim_taskq,
+		    (void (*)(void *))vdev_auto_trim, vti, TQ_SLEEP);
+	}
+}
+
+/*
+ * Performs the sync update of the MOS pool directory's trim start/stop values.
+ */
+static void
+spa_trim_update_time_sync(void *arg, dmu_tx_t *tx)
+{
+	spa_t *spa = arg;
+	VERIFY0(zap_update(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_TRIM_START_TIME, sizeof (uint64_t), 1,
+	    &spa->spa_man_trim_start_time, tx));
+	VERIFY0(zap_update(spa->spa_meta_objset, DMU_POOL_DIRECTORY_OBJECT,
+	    DMU_POOL_TRIM_STOP_TIME, sizeof (uint64_t), 1,
+	    &spa->spa_man_trim_stop_time, tx));
+}
+
+/*
+ * Updates the in-core and on-disk manual TRIM operation start/stop time.
+ * Passing UINT64_MAX for either start_time or stop_time means that no
+ * update to that value should be recorded.
+ */
+static dmu_tx_t *
+spa_trim_update_time(spa_t *spa, uint64_t start_time, uint64_t stop_time)
+{
+	int err;
+	dmu_tx_t *tx;
+
+	ASSERT(MUTEX_HELD(&spa->spa_man_trim_lock));
+	if (start_time != UINT64_MAX)
+		spa->spa_man_trim_start_time = start_time;
+	if (stop_time != UINT64_MAX)
+		spa->spa_man_trim_stop_time = stop_time;
+	tx = dmu_tx_create_dd(spa_get_dsl(spa)->dp_mos_dir);
+	err = dmu_tx_assign(tx, TXG_WAIT);
+	if (err) {
+		dmu_tx_abort(tx);
+		return (NULL);
+	}
+	dsl_sync_task_nowait(spa_get_dsl(spa), spa_trim_update_time_sync,
+	    spa, 1, ZFS_SPACE_CHECK_RESERVED, tx);
+
+	return (tx);
+}
+
+/*
+ * Initiates an manual TRIM of the whole pool. This kicks off individual
+ * TRIM tasks for each top-level vdev, which then pass over all of the free
+ * space in all of the vdev's metaslabs and issues TRIM commands for that
+ * space to the underlying vdevs.
+ */
+extern void
+spa_man_trim(spa_t *spa, uint64_t rate)
+{
+	dmu_tx_t *time_update_tx;
+
+	mutex_enter(&spa->spa_man_trim_lock);
+
+	if (rate != 0)
+		spa->spa_man_trim_rate = MAX(rate, spa_min_trim_rate(spa));
+	else
+		spa->spa_man_trim_rate = 0;
+
+	if (spa->spa_num_man_trimming) {
+		/*
+		 * TRIM is already ongoing. Wake up all sleeping vdev trim
+		 * threads because the trim rate might have changed above.
+		 */
+		cv_broadcast(&spa->spa_man_trim_update_cv);
+		mutex_exit(&spa->spa_man_trim_lock);
+		return;
+	}
+	spa_man_trim_taskq_create(spa);
+	spa->spa_man_trim_stop = B_FALSE;
+
+	spa_event_notify(spa, NULL, ESC_ZFS_TRIM_START);
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+	for (uint64_t i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
+		vdev_t *vd = spa->spa_root_vdev->vdev_child[i];
+		vdev_trim_info_t *vti = kmem_zalloc(sizeof (*vti), KM_SLEEP);
+		vti->vti_vdev = vd;
+		vti->vti_done_cb = (void (*)(void *))spa_vdev_man_trim_done;
+		vti->vti_done_arg = spa;
+		spa->spa_num_man_trimming++;
+
+		vd->vdev_trim_prog = 0;
+		(void) taskq_dispatch(spa->spa_man_trim_taskq,
+		    (void (*)(void *))vdev_man_trim, vti, TQ_SLEEP);
+	}
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
+	time_update_tx = spa_trim_update_time(spa, gethrestime_sec(), 0);
+	mutex_exit(&spa->spa_man_trim_lock);
+	/* mustn't hold spa_man_trim_lock to prevent deadlock /w syncing ctx */
+	if (time_update_tx != NULL)
+		dmu_tx_commit(time_update_tx);
+}
+
+/*
+ * Orders a manual TRIM operation to stop and returns immediately.
+ */
+extern void
+spa_man_trim_stop(spa_t *spa)
+{
+	boolean_t held = MUTEX_HELD(&spa->spa_man_trim_lock);
+	if (!held)
+		mutex_enter(&spa->spa_man_trim_lock);
+	spa->spa_man_trim_stop = B_TRUE;
+	cv_broadcast(&spa->spa_man_trim_update_cv);
+	if (!held)
+		mutex_exit(&spa->spa_man_trim_lock);
+}
+
+/*
+ * Orders a manual TRIM operation to stop and waits for both manual and
+ * automatic TRIM to complete. By holding both the spa_man_trim_lock and
+ * the spa_auto_trim_lock, the caller can guarantee that after this
+ * function returns, no new TRIM operations can be initiated in parallel.
+ */
+void
+spa_trim_stop_wait(spa_t *spa)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_man_trim_lock));
+	ASSERT(MUTEX_HELD(&spa->spa_auto_trim_lock));
+	spa->spa_man_trim_stop = B_TRUE;
+	cv_broadcast(&spa->spa_man_trim_update_cv);
+	while (spa->spa_num_man_trimming > 0)
+		cv_wait(&spa->spa_man_trim_done_cv, &spa->spa_man_trim_lock);
+	while (spa->spa_num_auto_trimming > 0)
+		cv_wait(&spa->spa_auto_trim_done_cv, &spa->spa_auto_trim_lock);
+}
+
+/*
+ * Returns manual TRIM progress. Progress is indicated by four return values:
+ * 1) prog: the number of bytes of space on the pool in total that manual
+ *	TRIM has already passed (regardless if the space is allocated or not).
+ *	Completion of the operation is indicated when either the returned value
+ *	is zero, or when the returned value is equal to the sum of the sizes of
+ *	all top-level vdevs.
+ * 2) rate: the trim rate in bytes per second. A value of zero indicates that
+ *	trim progresses as fast as possible.
+ * 3) start_time: the UNIXTIME of when the last manual TRIM operation was
+ *	started. If no manual trim was ever initiated on the pool, this is
+ *	zero.
+ * 4) stop_time: the UNIXTIME of when the last manual TRIM operation has
+ *	stopped on the pool. If a trim was started (start_time != 0), but has
+ *	not yet completed, stop_time will be zero. If a trim is NOT currently
+ *	ongoing and start_time is non-zero, this indicates that the previously
+ *	initiated TRIM operation was interrupted.
+ */
+extern void
+spa_get_trim_prog(spa_t *spa, uint64_t *prog, uint64_t *rate,
+    uint64_t *start_time, uint64_t *stop_time)
+{
+	uint64_t total = 0;
+	vdev_t *root_vd = spa->spa_root_vdev;
+
+	ASSERT(spa_config_held(spa, SCL_CONFIG, RW_READER));
+	mutex_enter(&spa->spa_man_trim_lock);
+	if (spa->spa_num_man_trimming > 0) {
+		for (uint64_t i = 0; i < root_vd->vdev_children; i++) {
+			total += root_vd->vdev_child[i]->vdev_trim_prog;
+		}
+	}
+	*prog = total;
+	*rate = spa->spa_man_trim_rate;
+	*start_time = spa->spa_man_trim_start_time;
+	*stop_time = spa->spa_man_trim_stop_time;
+	mutex_exit(&spa->spa_man_trim_lock);
+}
+
+/*
+ * Callback when a vdev_man_trim has finished on a single top-level vdev.
+ */
+static void
+spa_vdev_man_trim_done(spa_t *spa)
+{
+	dmu_tx_t *time_update_tx = NULL;
+
+	mutex_enter(&spa->spa_man_trim_lock);
+	ASSERT(spa->spa_num_man_trimming > 0);
+	spa->spa_num_man_trimming--;
+	if (spa->spa_num_man_trimming == 0) {
+		/* if we were interrupted, leave stop_time at zero */
+		if (!spa->spa_man_trim_stop)
+			time_update_tx = spa_trim_update_time(spa, UINT64_MAX,
+			    gethrestime_sec());
+		spa_event_notify(spa, NULL, ESC_ZFS_TRIM_FINISH);
+		spa_async_request(spa, SPA_ASYNC_MAN_TRIM_TASKQ_DESTROY);
+		cv_broadcast(&spa->spa_man_trim_done_cv);
+	}
+	mutex_exit(&spa->spa_man_trim_lock);
+
+	if (time_update_tx != NULL)
+		dmu_tx_commit(time_update_tx);
+}
+
+/*
+ * Called from vdev_auto_trim when a vdev has completed its auto-trim
+ * processing.
+ */
+static void
+spa_vdev_auto_trim_done(spa_t *spa)
+{
+	mutex_enter(&spa->spa_auto_trim_lock);
+	ASSERT(spa->spa_num_auto_trimming > 0);
+	spa->spa_num_auto_trimming--;
+	if (spa->spa_num_auto_trimming == 0)
+		cv_broadcast(&spa->spa_auto_trim_done_cv);
+	mutex_exit(&spa->spa_auto_trim_lock);
+}
+
+/*
+ * Determines the minimum sensible rate at which a manual TRIM can be
+ * performed on a given spa and returns it. Since we perform TRIM in
+ * metaslab-sized increments, we'll just let the longest step between
+ * metaslab TRIMs be 100s (random number, really). Thus, on a typical
+ * 200-metaslab vdev, the longest TRIM should take is about 5.5 hours.
+ * It *can* take longer if the device is really slow respond to
+ * zio_trim() commands or it contains more than 200 metaslabs, or
+ * metaslab sizes vary widely between top-level vdevs.
+ */
+static uint64_t
+spa_min_trim_rate(spa_t *spa)
+{
+	uint64_t smallest_ms_sz = UINT64_MAX;
+
+	/* find the smallest metaslab */
+	spa_config_enter(spa, SCL_CONFIG, FTAG, RW_READER);
+	for (uint64_t i = 0; i < spa->spa_root_vdev->vdev_children; i++) {
+		smallest_ms_sz = MIN(smallest_ms_sz,
+		    spa->spa_root_vdev->vdev_child[i]->vdev_ms[0]->ms_size);
+	}
+	spa_config_exit(spa, SCL_CONFIG, FTAG);
+	VERIFY(smallest_ms_sz != 0);
+
+	/* minimum TRIM rate is 1/100th of the smallest metaslab size */
+	return (smallest_ms_sz / 100);
 }

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -7157,7 +7157,7 @@ spa_trim_update_time_sync(void *arg, dmu_tx_t *tx)
  * Passing UINT64_MAX for either start_time or stop_time means that no
  * update to that value should be recorded.
  */
-static dmu_tx_t *
+static void
 spa_trim_update_time(spa_t *spa, uint64_t start_time, uint64_t stop_time)
 {
 	int err;
@@ -7172,12 +7172,11 @@ spa_trim_update_time(spa_t *spa, uint64_t start_time, uint64_t stop_time)
 	err = dmu_tx_assign(tx, TXG_WAIT);
 	if (err) {
 		dmu_tx_abort(tx);
-		return (NULL);
+		return;
 	}
 	dsl_sync_task_nowait(spa_get_dsl(spa), spa_trim_update_time_sync,
 	    spa, 1, ZFS_SPACE_CHECK_RESERVED, tx);
-
-	return (tx);
+	dmu_tx_commit(tx);
 }
 
 /*
@@ -7189,8 +7188,6 @@ spa_trim_update_time(spa_t *spa, uint64_t start_time, uint64_t stop_time)
 extern void
 spa_man_trim(spa_t *spa, uint64_t rate)
 {
-	dmu_tx_t *time_update_tx;
-
 	mutex_enter(&spa->spa_man_trim_lock);
 
 	if (rate != 0)
@@ -7225,11 +7222,8 @@ spa_man_trim(spa_t *spa, uint64_t rate)
 		    (void (*)(void *))vdev_man_trim, vti, TQ_SLEEP);
 	}
 	spa_config_exit(spa, SCL_CONFIG, FTAG);
-	time_update_tx = spa_trim_update_time(spa, gethrestime_sec(), 0);
+	spa_trim_update_time(spa, gethrestime_sec(), 0);
 	mutex_exit(&spa->spa_man_trim_lock);
-	/* mustn't hold spa_man_trim_lock to prevent deadlock /w syncing ctx */
-	if (time_update_tx != NULL)
-		dmu_tx_commit(time_update_tx);
 }
 
 /*
@@ -7311,24 +7305,20 @@ spa_get_trim_prog(spa_t *spa, uint64_t *prog, uint64_t *rate,
 static void
 spa_vdev_man_trim_done(spa_t *spa)
 {
-	dmu_tx_t *time_update_tx = NULL;
-
 	mutex_enter(&spa->spa_man_trim_lock);
 	ASSERT(spa->spa_num_man_trimming > 0);
 	spa->spa_num_man_trimming--;
 	if (spa->spa_num_man_trimming == 0) {
 		/* if we were interrupted, leave stop_time at zero */
-		if (!spa->spa_man_trim_stop)
-			time_update_tx = spa_trim_update_time(spa, UINT64_MAX,
+		if (!spa->spa_man_trim_stop) {
+			spa_trim_update_time(spa, UINT64_MAX,
 			    gethrestime_sec());
+		}
 		spa_event_notify(spa, NULL, ESC_ZFS_TRIM_FINISH);
 		spa_async_request(spa, SPA_ASYNC_MAN_TRIM_TASKQ_DESTROY);
 		cv_broadcast(&spa->spa_man_trim_done_cv);
 	}
 	mutex_exit(&spa->spa_man_trim_lock);
-
-	if (time_update_tx != NULL)
-		dmu_tx_commit(time_update_tx);
 }
 
 /*
@@ -7348,13 +7338,15 @@ spa_vdev_auto_trim_done(spa_t *spa)
 
 /*
  * Determines the minimum sensible rate at which a manual TRIM can be
- * performed on a given spa and returns it. Since we perform TRIM in
- * metaslab-sized increments, we'll just let the longest step between
- * metaslab TRIMs be 100s (random number, really). Thus, on a typical
- * 200-metaslab vdev, the longest TRIM should take is about 5.5 hours.
- * It *can* take longer if the device is really slow respond to
- * zio_trim() commands or it contains more than 200 metaslabs, or
- * metaslab sizes vary widely between top-level vdevs.
+ * performed on a given spa and returns it (in bytes per second). The
+ * value is calculated by assuming that TRIMming a metaslab should take
+ * no more than 1000s. The exact value here is not important, we just want
+ * to make sure that the calculated delay values in vdev_man_trim aren't
+ * too large (which might cause integer precision issues). Thus, on a
+ * typical 200-metaslab vdev, the longest TRIM should take is about 55
+ * hours. It *can* take longer if the device is really slow respond to
+ * zio_trim() commands or it contains more than 200 metaslabs, or metaslab
+ * sizes vary widely between top-level vdevs.
  */
 static uint64_t
 spa_min_trim_rate(spa_t *spa)
@@ -7370,6 +7362,6 @@ spa_min_trim_rate(spa_t *spa)
 	spa_config_exit(spa, SCL_CONFIG, FTAG);
 	VERIFY(smallest_ms_sz != 0);
 
-	/* minimum TRIM rate is 1/100th of the smallest metaslab size */
-	return (smallest_ms_sz / 100);
+	/* minimum TRIM rate is 1/1000th of the smallest metaslab size */
+	return (smallest_ms_sz / 1000);
 }

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -7329,7 +7329,7 @@ static void
 spa_vdev_auto_trim_done(spa_t *spa)
 {
 	mutex_enter(&spa->spa_auto_trim_lock);
-	ASSERT(spa->spa_num_auto_trimming > 0);
+	VERIFY(spa->spa_num_auto_trimming > 0);
 	spa->spa_num_auto_trimming--;
 	if (spa->spa_num_auto_trimming == 0)
 		cv_broadcast(&spa->spa_auto_trim_done_cv);

--- a/usr/src/uts/common/fs/zfs/spa_config.c
+++ b/usr/src/uts/common/fs/zfs/spa_config.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
  */
 
@@ -447,6 +447,19 @@ spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg, int getstats)
 	nvroot = vdev_config_generate(spa, vd, getstats, config_gen_flags);
 	fnvlist_add_nvlist(config, ZPOOL_CONFIG_VDEV_TREE, nvroot);
 	nvlist_free(nvroot);
+
+	/* If we're getting stats, calculate trim progress from leaf vdevs. */
+	if (getstats) {
+		uint64_t prog, rate, start_time, stop_time;
+
+		spa_get_trim_prog(spa, &prog, &rate, &start_time, &stop_time);
+		fnvlist_add_uint64(config, ZPOOL_CONFIG_TRIM_PROG, prog);
+		fnvlist_add_uint64(config, ZPOOL_CONFIG_TRIM_RATE, rate);
+		fnvlist_add_uint64(config, ZPOOL_CONFIG_TRIM_START_TIME,
+		    start_time);
+		fnvlist_add_uint64(config, ZPOOL_CONFIG_TRIM_STOP_TIME,
+		    stop_time);
+	}
 
 	/*
 	 * Store what's necessary for reading the MOS in the label.

--- a/usr/src/uts/common/fs/zfs/spa_misc.c
+++ b/usr/src/uts/common/fs/zfs/spa_misc.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -225,6 +225,14 @@
  * manipulation of the namespace.
  */
 
+struct spa_trimstats {
+	kstat_named_t	st_extents;		/* # of extents issued to zio */
+	kstat_named_t	st_bytes;		/* # of bytes issued to zio */
+	kstat_named_t	st_extents_skipped;	/* # of extents too small */
+	kstat_named_t	st_bytes_skipped;	/* bytes in extents_skipped */
+	kstat_named_t	st_auto_slow;		/* trim slow, exts dropped */
+};
+
 static avl_tree_t spa_namespace_avl;
 kmutex_t spa_namespace_lock;
 static kcondvar_t spa_namespace_cv;
@@ -349,6 +357,14 @@ int spa_asize_inflation = 24;
  */
 int spa_slop_shift = 5;
 uint64_t spa_min_slop = 128 * 1024 * 1024;
+
+/*
+ * Percentage of the number of CPUs to use as the autotrim taskq thread count.
+ */
+uint64_t zfs_auto_trim_taskq_batch_pct = 75;
+
+static void spa_trimstats_create(spa_t *spa);
+static void spa_trimstats_destroy(spa_t *spa);
 
 /*
  * ==========================================================================
@@ -571,12 +587,17 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	mutex_init(&spa->spa_vdev_top_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_iokstat_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_alloc_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&spa->spa_auto_trim_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&spa->spa_man_trim_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	cv_init(&spa->spa_async_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_evicting_os_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_proc_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_scrub_io_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_suspend_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&spa->spa_auto_trim_done_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&spa->spa_man_trim_update_cv, NULL, CV_DEFAULT, NULL);
+	cv_init(&spa->spa_man_trim_done_cv, NULL, CV_DEFAULT, NULL);
 
 	for (int t = 0; t < TXG_SIZE; t++)
 		bplist_create(&spa->spa_free_bplist[t]);
@@ -660,6 +681,8 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 		kstat_install(spa->spa_iokstat);
 	}
 
+	spa_trimstats_create(spa);
+
 	spa->spa_debug = ((zfs_flags & ZFS_DEBUG_SPA) != 0);
 
 	spa->spa_min_ashift = INT_MAX;
@@ -725,6 +748,8 @@ spa_remove(spa_t *spa)
 
 	spa_config_lock_destroy(spa);
 
+	spa_trimstats_destroy(spa);
+
 	kstat_delete(spa->spa_iokstat);
 	spa->spa_iokstat = NULL;
 
@@ -738,6 +763,9 @@ spa_remove(spa_t *spa)
 	cv_destroy(&spa->spa_proc_cv);
 	cv_destroy(&spa->spa_scrub_io_cv);
 	cv_destroy(&spa->spa_suspend_cv);
+	cv_destroy(&spa->spa_auto_trim_done_cv);
+	cv_destroy(&spa->spa_man_trim_update_cv);
+	cv_destroy(&spa->spa_man_trim_done_cv);
 
 	mutex_destroy(&spa->spa_alloc_lock);
 	mutex_destroy(&spa->spa_async_lock);
@@ -752,6 +780,8 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_suspend_lock);
 	mutex_destroy(&spa->spa_vdev_top_lock);
 	mutex_destroy(&spa->spa_iokstat_lock);
+	mutex_destroy(&spa->spa_auto_trim_lock);
+	mutex_destroy(&spa->spa_man_trim_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }
@@ -1075,6 +1105,9 @@ spa_vdev_enter(spa_t *spa)
 {
 	mutex_enter(&spa->spa_vdev_top_lock);
 	mutex_enter(&spa_namespace_lock);
+	mutex_enter(&spa->spa_auto_trim_lock);
+	mutex_enter(&spa->spa_man_trim_lock);
+	spa_trim_stop_wait(spa);
 	return (spa_vdev_config_enter(spa));
 }
 
@@ -1166,6 +1199,8 @@ int
 spa_vdev_exit(spa_t *spa, vdev_t *vd, uint64_t txg, int error)
 {
 	spa_vdev_config_exit(spa, vd, txg, error, FTAG);
+	mutex_exit(&spa->spa_man_trim_lock);
+	mutex_exit(&spa->spa_auto_trim_lock);
 	mutex_exit(&spa_namespace_lock);
 	mutex_exit(&spa->spa_vdev_top_lock);
 
@@ -1776,6 +1811,18 @@ spa_deadman_synctime(spa_t *spa)
 	return (spa->spa_deadman_synctime);
 }
 
+spa_force_trim_t
+spa_get_force_trim(spa_t *spa)
+{
+	return (spa->spa_force_trim);
+}
+
+spa_auto_trim_t
+spa_get_auto_trim(spa_t *spa)
+{
+	return (spa->spa_auto_trim);
+}
+
 uint64_t
 dva_get_dsize_sync(spa_t *spa, const dva_t *dva)
 {
@@ -2055,4 +2102,168 @@ spa_maxblocksize(spa_t *spa)
 		return (SPA_MAXBLOCKSIZE);
 	else
 		return (SPA_OLD_MAXBLOCKSIZE);
+}
+
+/*
+ * Creates the trim kstats structure for a spa.
+ */
+static void
+spa_trimstats_create(spa_t *spa)
+{
+	/* truncate pool name to accomodate "_trimstats" suffix */
+	char short_spa_name[KSTAT_STRLEN - 10];
+	char name[KSTAT_STRLEN];
+
+	ASSERT3P(spa->spa_trimstats, ==, NULL);
+	ASSERT3P(spa->spa_trimstats_ks, ==, NULL);
+
+	(void) snprintf(short_spa_name, sizeof (short_spa_name), "%s",
+	    spa->spa_name);
+	(void) snprintf(name, sizeof (name), "%s_trimstats", short_spa_name);
+
+	spa->spa_trimstats_ks = kstat_create("zfs", 0, name, "misc",
+	    KSTAT_TYPE_NAMED, sizeof (*spa->spa_trimstats) /
+	    sizeof (kstat_named_t), 0);
+	if (spa->spa_trimstats_ks) {
+		spa->spa_trimstats = spa->spa_trimstats_ks->ks_data;
+
+#ifdef _KERNEL
+		kstat_named_init(&spa->spa_trimstats->st_extents,
+		    "extents", KSTAT_DATA_UINT64);
+		kstat_named_init(&spa->spa_trimstats->st_bytes,
+		    "bytes", KSTAT_DATA_UINT64);
+		kstat_named_init(&spa->spa_trimstats->st_extents_skipped,
+		    "extents_skipped", KSTAT_DATA_UINT64);
+		kstat_named_init(&spa->spa_trimstats->st_bytes_skipped,
+		    "bytes_skipped", KSTAT_DATA_UINT64);
+		kstat_named_init(&spa->spa_trimstats->st_auto_slow,
+		    "auto_slow", KSTAT_DATA_UINT64);
+#endif	/* _KERNEL */
+
+		kstat_install(spa->spa_trimstats_ks);
+	} else {
+		cmn_err(CE_NOTE, "!Cannot create trim kstats for pool %s",
+		    spa->spa_name);
+	}
+}
+
+/*
+ * Destroys the trim kstats for a spa.
+ */
+static void
+spa_trimstats_destroy(spa_t *spa)
+{
+	if (spa->spa_trimstats_ks) {
+		kstat_delete(spa->spa_trimstats_ks);
+		spa->spa_trimstats = NULL;
+		spa->spa_trimstats_ks = NULL;
+	}
+}
+
+/*
+ * Updates the numerical trim kstats for a spa.
+ */
+void
+spa_trimstats_update(spa_t *spa, uint64_t extents, uint64_t bytes,
+    uint64_t extents_skipped, uint64_t bytes_skipped)
+{
+	spa_trimstats_t *st = spa->spa_trimstats;
+	if (st) {
+		atomic_add_64(&st->st_extents.value.ui64, extents);
+		atomic_add_64(&st->st_bytes.value.ui64, bytes);
+		atomic_add_64(&st->st_extents_skipped.value.ui64,
+		    extents_skipped);
+		atomic_add_64(&st->st_bytes_skipped.value.ui64,
+		    bytes_skipped);
+	}
+}
+
+/*
+ * Increments the slow-trim kstat for a spa.
+ */
+void
+spa_trimstats_auto_slow_incr(spa_t *spa)
+{
+	spa_trimstats_t *st = spa->spa_trimstats;
+	if (st)
+		atomic_inc_64(&st->st_auto_slow.value.ui64);
+}
+
+/*
+ * Creates the taskq used for dispatching auto-trim. This is called only when
+ * the property is set to `on' or when the pool is loaded (and the autotrim
+ * property is `on').
+ */
+void
+spa_auto_trim_taskq_create(spa_t *spa)
+{
+	char name[MAXPATHLEN];
+	ASSERT(MUTEX_HELD(&spa->spa_auto_trim_lock));
+	ASSERT(spa->spa_auto_trim_taskq == NULL);
+	(void) snprintf(name, sizeof (name), "%s_auto_trim", spa->spa_name);
+	spa->spa_auto_trim_taskq = taskq_create(name,
+	    zfs_auto_trim_taskq_batch_pct, minclsyspri, 1, INT_MAX,
+	    TASKQ_THREADS_CPU_PCT);
+	VERIFY(spa->spa_auto_trim_taskq != NULL);
+}
+
+/*
+ * Creates the taskq for dispatching manual trim. This taskq is recreated
+ * each time `zpool trim <poolname>' is issued and destroyed after the run
+ * completes in an async spa request.
+ */
+void
+spa_man_trim_taskq_create(spa_t *spa)
+{
+	char name[MAXPATHLEN];
+	ASSERT(MUTEX_HELD(&spa->spa_man_trim_lock));
+	spa_async_unrequest(spa, SPA_ASYNC_MAN_TRIM_TASKQ_DESTROY);
+	if (spa->spa_man_trim_taskq != NULL)
+		/*
+		 * The async taskq destroy has been pre-empted, so just
+		 * return, the taskq is still good to use.
+		 */
+		return;
+	(void) snprintf(name, sizeof (name), "%s_man_trim", spa->spa_name);
+	spa->spa_man_trim_taskq = taskq_create(name,
+	    spa->spa_root_vdev->vdev_children, minclsyspri,
+	    spa->spa_root_vdev->vdev_children,
+	    spa->spa_root_vdev->vdev_children, TASKQ_PREPOPULATE);
+	VERIFY(spa->spa_man_trim_taskq != NULL);
+}
+
+/*
+ * Destroys the taskq created in spa_auto_trim_taskq_create. The taskq
+ * is only destroyed when the autotrim property is set to `off'.
+ */
+void
+spa_auto_trim_taskq_destroy(spa_t *spa)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_auto_trim_lock));
+	ASSERT(spa->spa_auto_trim_taskq != NULL);
+	while (spa->spa_num_auto_trimming != 0)
+		cv_wait(&spa->spa_auto_trim_done_cv, &spa->spa_auto_trim_lock);
+	taskq_destroy(spa->spa_auto_trim_taskq);
+	spa->spa_auto_trim_taskq = NULL;
+}
+
+/*
+ * Destroys the taskq created in spa_man_trim_taskq_create. The taskq is
+ * destroyed after a manual trim run completes from an async spa request.
+ * There is a bit of lag between an async request being issued at the
+ * completion of a trim run and it finally being acted on, hence why this
+ * function checks if new manual trimming threads haven't been re-spawned.
+ * If they have, we assume the async spa request been preempted by another
+ * manual trim request and we back off.
+ */
+void
+spa_man_trim_taskq_destroy(spa_t *spa)
+{
+	ASSERT(MUTEX_HELD(&spa->spa_man_trim_lock));
+	ASSERT(spa->spa_man_trim_taskq != NULL);
+	if (spa->spa_num_man_trimming != 0)
+		/* another trim got started before we got here, back off */
+		return;
+	taskq_destroy(spa->spa_man_trim_taskq);
+	spa->spa_man_trim_taskq = NULL;
 }

--- a/usr/src/uts/common/fs/zfs/spa_misc.c
+++ b/usr/src/uts/common/fs/zfs/spa_misc.c
@@ -378,7 +378,11 @@ spa_config_lock_init(spa_t *spa)
 		spa_config_lock_t *scl = &spa->spa_config_lock[i];
 		mutex_init(&scl->scl_lock, NULL, MUTEX_DEFAULT, NULL);
 		cv_init(&scl->scl_cv, NULL, CV_DEFAULT, NULL);
+#ifdef	DEBUG
+		refcount_create_tracked(&scl->scl_count);
+#else	/* DEBUG */
 		refcount_create_untracked(&scl->scl_count);
+#endif	/* !DEBUG */
 		scl->scl_writer = NULL;
 		scl->scl_write_wanted = 0;
 	}

--- a/usr/src/uts/common/fs/zfs/sys/dmu.h
+++ b/usr/src/uts/common/fs/zfs/sys/dmu.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
  * Copyright 2013 DEY Storage Systems, Inc.
  * Copyright 2014 HybridCluster. All rights reserved.
@@ -324,6 +324,8 @@ typedef struct dmu_buf {
 #define	DMU_POOL_EMPTY_BPOBJ		"empty_bpobj"
 #define	DMU_POOL_CHECKSUM_SALT		"org.illumos:checksum_salt"
 #define	DMU_POOL_VDEV_ZAP_MAP		"com.delphix:vdev_zap_map"
+#define	DMU_POOL_TRIM_START_TIME	"trim_start_time"
+#define	DMU_POOL_TRIM_STOP_TIME		"trim_stop_time"
 
 /*
  * Allocate an object from this objset.  The range of object numbers

--- a/usr/src/uts/common/fs/zfs/sys/metaslab.h
+++ b/usr/src/uts/common/fs/zfs/sys/metaslab.h
@@ -57,7 +57,7 @@ void metaslab_sync(metaslab_t *, uint64_t);
 void metaslab_sync_done(metaslab_t *, uint64_t);
 void metaslab_sync_reassess(metaslab_group_t *);
 uint64_t metaslab_block_maxsize(metaslab_t *);
-void metaslab_auto_trim(metaslab_t *, uint64_t, boolean_t);
+void metaslab_auto_trim(metaslab_t *, boolean_t);
 uint64_t metaslab_trim_mem_used(metaslab_t *);
 
 #define	METASLAB_HINTBP_FAVOR		0x0

--- a/usr/src/uts/common/fs/zfs/sys/metaslab.h
+++ b/usr/src/uts/common/fs/zfs/sys/metaslab.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #ifndef _SYS_METASLAB_H
@@ -56,6 +57,8 @@ void metaslab_sync(metaslab_t *, uint64_t);
 void metaslab_sync_done(metaslab_t *, uint64_t);
 void metaslab_sync_reassess(metaslab_group_t *);
 uint64_t metaslab_block_maxsize(metaslab_t *);
+void metaslab_auto_trim(metaslab_t *, uint64_t, boolean_t);
+uint64_t metaslab_trim_mem_used(metaslab_t *);
 
 #define	METASLAB_HINTBP_FAVOR		0x0
 #define	METASLAB_HINTBP_AVOID		0x1
@@ -69,6 +72,7 @@ int metaslab_alloc(spa_t *, metaslab_class_t *, uint64_t,
 void metaslab_free(spa_t *, const blkptr_t *, uint64_t, boolean_t);
 int metaslab_claim(spa_t *, const blkptr_t *, uint64_t);
 void metaslab_check_free(spa_t *, const blkptr_t *);
+zio_t *metaslab_trim_all(metaslab_t *, uint64_t *, uint64_t *, boolean_t *);
 
 void metaslab_alloc_trace_init(void);
 void metaslab_alloc_trace_fini(void);
@@ -103,6 +107,9 @@ uint64_t metaslab_group_fragmentation(metaslab_group_t *);
 void metaslab_group_histogram_remove(metaslab_group_t *, metaslab_t *);
 void metaslab_group_alloc_decrement(spa_t *, uint64_t, void *, int);
 void metaslab_group_alloc_verify(spa_t *, const blkptr_t *, void *);
+
+void metaslab_trimstats_create(spa_t *spa);
+void metaslab_trimstats_destroy(spa_t *spa);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/fs/zfs/sys/metaslab_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/metaslab_impl.h
@@ -247,11 +247,6 @@ struct metaslab_group {
 	uint64_t		mg_histogram[RANGE_TREE_HISTOGRAM_SIZE];
 };
 
-typedef struct {
-	uint64_t	ts_birth;	/* TXG at which this trimset starts */
-	range_tree_t	*ts_tree;	/* tree of extents in the trimset */
-} metaslab_trimset_t;
-
 /*
  * This value defines the number of elements in the ms_lbas array. The value
  * of 64 was chosen as it covers all power of 2 buckets up to UINT64_MAX.
@@ -326,10 +321,10 @@ struct metaslab {
 	range_tree_t	*ms_alloctree[TXG_SIZE];
 	range_tree_t	*ms_tree;
 
-	metaslab_trimset_t	*ms_cur_ts; /* currently prepared trims */
-	metaslab_trimset_t	*ms_prev_ts;  /* previous (aging) trims */
-	kcondvar_t		ms_trim_cv;
-	metaslab_trimset_t	*ms_trimming_ts;
+	range_tree_t	*ms_cur_ts;		/* currently prepared trims */
+	range_tree_t	*ms_prev_ts;		/* previous (aging) trims */
+	kcondvar_t	ms_trim_cv;
+	range_tree_t	*ms_trimming_ts;	/* in flight trims */
 
 	/*
 	 * The following range trees are accessed only from syncing context.

--- a/usr/src/uts/common/fs/zfs/sys/metaslab_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/metaslab_impl.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #ifndef _SYS_METASLAB_IMPL_H
@@ -246,6 +247,11 @@ struct metaslab_group {
 	uint64_t		mg_histogram[RANGE_TREE_HISTOGRAM_SIZE];
 };
 
+typedef struct {
+	uint64_t	ts_birth;	/* TXG at which this trimset starts */
+	range_tree_t	*ts_tree;	/* tree of extents in the trimset */
+} metaslab_trimset_t;
+
 /*
  * This value defines the number of elements in the ms_lbas array. The value
  * of 64 was chosen as it covers all power of 2 buckets up to UINT64_MAX.
@@ -320,6 +326,11 @@ struct metaslab {
 	range_tree_t	*ms_alloctree[TXG_SIZE];
 	range_tree_t	*ms_tree;
 
+	metaslab_trimset_t	*ms_cur_ts; /* currently prepared trims */
+	metaslab_trimset_t	*ms_prev_ts;  /* previous (aging) trims */
+	kcondvar_t		ms_trim_cv;
+	metaslab_trimset_t	*ms_trimming_ts;
+
 	/*
 	 * The following range trees are accessed only from syncing context.
 	 * ms_free*tree only have entries while syncing, and are empty
@@ -330,6 +341,7 @@ struct metaslab {
 	range_tree_t	*ms_defertree[TXG_DEFER_SIZE];
 
 	boolean_t	ms_condensing;	/* condensing? */
+	kcondvar_t	ms_condensing_cv;
 	boolean_t	ms_condense_wanted;
 
 	/*

--- a/usr/src/uts/common/fs/zfs/sys/range_tree.h
+++ b/usr/src/uts/common/fs/zfs/sys/range_tree.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #ifndef _SYS_RANGE_TREE_H
@@ -78,6 +79,9 @@ void range_tree_fini(void);
 range_tree_t *range_tree_create(range_tree_ops_t *ops, void *arg, kmutex_t *lp);
 void range_tree_destroy(range_tree_t *rt);
 boolean_t range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size);
+boolean_t range_tree_contains_part(range_tree_t *rt, uint64_t start,
+    uint64_t size);
+uint64_t range_tree_find_gap(range_tree_t *rt, uint64_t start, uint64_t size);
 uint64_t range_tree_space(range_tree_t *rt);
 void range_tree_verify(range_tree_t *rt, uint64_t start, uint64_t size);
 void range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst);

--- a/usr/src/uts/common/fs/zfs/sys/range_tree.h
+++ b/usr/src/uts/common/fs/zfs/sys/range_tree.h
@@ -81,7 +81,6 @@ void range_tree_destroy(range_tree_t *rt);
 boolean_t range_tree_contains(range_tree_t *rt, uint64_t start, uint64_t size);
 boolean_t range_tree_contains_part(range_tree_t *rt, uint64_t start,
     uint64_t size);
-uint64_t range_tree_find_gap(range_tree_t *rt, uint64_t start, uint64_t size);
 uint64_t range_tree_space(range_tree_t *rt);
 void range_tree_verify(range_tree_t *rt, uint64_t start, uint64_t size);
 void range_tree_swap(range_tree_t **rtsrc, range_tree_t **rtdst);

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -606,6 +606,28 @@ typedef enum spa_import_type {
 	SPA_IMPORT_ASSEMBLE
 } spa_import_type_t;
 
+/*
+ * Should we force sending TRIM commands even to devices which evidently
+ * don't support it?
+ *	OFF: no, only send to devices which indicated support
+ *	ON: yes, force send to everybody
+ */
+typedef enum {
+	SPA_FORCE_TRIM_OFF = 0,	/* default */
+	SPA_FORCE_TRIM_ON
+} spa_force_trim_t;
+
+/*
+ * Should we send TRIM commands in-line during normal pool operation while
+ * deleting stuff?
+ *	OFF: no
+ *	ON: yes
+ */
+typedef enum {
+	SPA_AUTO_TRIM_OFF = 0,	/* default */
+	SPA_AUTO_TRIM_ON
+} spa_auto_trim_t;
+
 /* state manipulation functions */
 extern int spa_open(const char *pool, spa_t **, void *tag);
 extern int spa_open_rewind(const char *pool, spa_t **, void *tag,
@@ -631,14 +653,15 @@ extern void spa_inject_delref(spa_t *spa);
 extern void spa_scan_stat_init(spa_t *spa);
 extern int spa_scan_get_stats(spa_t *spa, pool_scan_stat_t *ps);
 
-#define	SPA_ASYNC_CONFIG_UPDATE	0x01
-#define	SPA_ASYNC_REMOVE	0x02
-#define	SPA_ASYNC_PROBE		0x04
-#define	SPA_ASYNC_RESILVER_DONE	0x08
-#define	SPA_ASYNC_RESILVER	0x10
-#define	SPA_ASYNC_AUTOEXPAND	0x20
-#define	SPA_ASYNC_REMOVE_DONE	0x40
-#define	SPA_ASYNC_REMOVE_STOP	0x80
+#define	SPA_ASYNC_CONFIG_UPDATE			0x01
+#define	SPA_ASYNC_REMOVE			0x02
+#define	SPA_ASYNC_PROBE				0x04
+#define	SPA_ASYNC_RESILVER_DONE			0x08
+#define	SPA_ASYNC_RESILVER			0x10
+#define	SPA_ASYNC_AUTOEXPAND			0x20
+#define	SPA_ASYNC_REMOVE_DONE			0x40
+#define	SPA_ASYNC_REMOVE_STOP			0x80
+#define	SPA_ASYNC_MAN_TRIM_TASKQ_DESTROY	0x100
 
 /*
  * Controls the behavior of spa_vdev_remove().
@@ -675,6 +698,13 @@ extern void spa_l2cache_drop(spa_t *spa);
 /* scanning */
 extern int spa_scan(spa_t *spa, pool_scan_func_t func);
 extern int spa_scan_stop(spa_t *spa);
+
+/* trimming */
+extern void spa_man_trim(spa_t *spa, uint64_t rate);
+extern void spa_man_trim_stop(spa_t *spa);
+extern void spa_get_trim_prog(spa_t *spa, uint64_t *prog, uint64_t *rate,
+    uint64_t *start_time, uint64_t *stop_time);
+extern void spa_trim_stop_wait(spa_t *spa);
 
 /* spa syncing */
 extern void spa_sync(spa_t *spa, uint64_t txg); /* only for DMU use */
@@ -797,6 +827,8 @@ extern uint64_t spa_bootfs(spa_t *spa);
 extern uint64_t spa_delegation(spa_t *spa);
 extern objset_t *spa_meta_objset(spa_t *spa);
 extern uint64_t spa_deadman_synctime(spa_t *spa);
+extern spa_force_trim_t spa_get_force_trim(spa_t *spa);
+extern spa_auto_trim_t spa_get_auto_trim(spa_t *spa);
 
 /* Miscellaneous support routines */
 extern void spa_activate_mos_feature(spa_t *spa, const char *feature,
@@ -877,6 +909,11 @@ extern void spa_configfile_set(spa_t *, nvlist_t *, boolean_t);
 
 /* asynchronous event notification */
 extern void spa_event_notify(spa_t *spa, vdev_t *vdev, const char *name);
+
+/* TRIM/UNMAP kstat update */
+extern void spa_trimstats_update(spa_t *spa, uint64_t extents, uint64_t bytes,
+    uint64_t extents_skipped, uint64_t bytes_skipped);
+extern void spa_trimstats_auto_slow_incr(spa_t *spa);
 
 #ifdef ZFS_DEBUG
 #define	dprintf_bp(bp, fmt, ...) do {				\

--- a/usr/src/uts/common/fs/zfs/sys/spa_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa_impl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
  * Copyright 2013 Saso Kiselkov. All rights reserved.
  */
@@ -122,6 +122,8 @@ typedef enum spa_all_vdev_zap_action {
 	AVZ_ACTION_REBUILD,	/* Populate the new AVZ, see spa_avz_rebuild */
 	AVZ_ACTION_INITIALIZE
 } spa_avz_action_t;
+
+typedef struct spa_trimstats spa_trimstats_t;
 
 struct spa {
 	/*
@@ -265,6 +267,26 @@ struct spa {
 	uint64_t	spa_all_vdev_zaps;	/* ZAP of per-vd ZAP obj #s */
 	spa_avz_action_t	spa_avz_action;	/* destroy/rebuild AVZ? */
 
+	/* TRIM */
+	uint64_t	spa_force_trim;		/* force sending trim? */
+	uint64_t	spa_auto_trim;		/* see spa_auto_trim_t */
+
+	kmutex_t	spa_auto_trim_lock;
+	kcondvar_t	spa_auto_trim_done_cv;	/* all autotrim thrd's exited */
+	uint64_t	spa_num_auto_trimming;	/* # of autotrim threads */
+	taskq_t		*spa_auto_trim_taskq;
+
+	kmutex_t	spa_man_trim_lock;
+	uint64_t	spa_man_trim_rate;	/* rate of trim in bytes/sec */
+	uint64_t	spa_num_man_trimming;	/* # of manual trim threads */
+	boolean_t	spa_man_trim_stop;	/* requested manual trim stop */
+	kcondvar_t	spa_man_trim_update_cv;	/* updates to TRIM settings */
+	kcondvar_t	spa_man_trim_done_cv;	/* manual trim has completed */
+	/* For details on trim start/stop times see spa_get_trim_prog. */
+	uint64_t	spa_man_trim_start_time;
+	uint64_t	spa_man_trim_stop_time;
+	taskq_t		*spa_man_trim_taskq;
+
 	/*
 	 * spa_iokstat_lock protects spa_iokstat and
 	 * spa_queue_stats[].
@@ -275,6 +297,10 @@ struct spa {
 		int spa_active;
 		int spa_queued;
 	} spa_queue_stats[ZIO_PRIORITY_NUM_QUEUEABLE];
+
+	/* TRIM/UNMAP kstats */
+	spa_trimstats_t	*spa_trimstats;		/* alloc'd by kstat_create */
+	struct kstat	*spa_trimstats_ks;
 
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
 
@@ -292,6 +318,11 @@ extern const char *spa_config_path;
 
 extern void spa_taskq_dispatch_ent(spa_t *spa, zio_type_t t, zio_taskq_type_t q,
     task_func_t *func, void *arg, uint_t flags, taskq_ent_t *ent);
+
+extern void spa_auto_trim_taskq_create(spa_t *spa);
+extern void spa_man_trim_taskq_create(spa_t *spa);
+extern void spa_auto_trim_taskq_destroy(spa_t *spa);
+extern void spa_man_trim_taskq_destroy(spa_t *spa);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/fs/zfs/sys/vdev.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #ifndef _SYS_VDEV_H
@@ -44,6 +45,13 @@ typedef enum vdev_dtl_type {
 	DTL_OUTAGE,	/* temporarily missing (used to attempt detach) */
 	DTL_TYPES
 } vdev_dtl_type_t;
+
+typedef struct vdev_trim_info {
+	vdev_t *vti_vdev;
+	uint64_t vti_txg;	/* ignored for manual trim */
+	void (*vti_done_cb)(void *);
+	void *vti_done_arg;
+} vdev_trim_info_t;
 
 extern boolean_t zfs_nocacheflush;
 
@@ -141,6 +149,10 @@ typedef enum vdev_config_flag {
 extern void vdev_top_config_generate(spa_t *spa, nvlist_t *config);
 extern nvlist_t *vdev_config_generate(spa_t *spa, vdev_t *vd,
     boolean_t getstats, vdev_config_flag_t flags);
+
+extern void vdev_man_trim(vdev_trim_info_t *vti);
+extern void vdev_auto_trim(vdev_trim_info_t *vti);
+extern void vdev_trim_stop_wait(vdev_t *vd);
 
 /*
  * Label routines

--- a/usr/src/uts/common/fs/zfs/sys/vdev.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev.h
@@ -153,6 +153,7 @@ extern nvlist_t *vdev_config_generate(spa_t *spa, vdev_t *vd,
 extern void vdev_man_trim(vdev_trim_info_t *vti);
 extern void vdev_auto_trim(vdev_trim_info_t *vti);
 extern void vdev_trim_stop_wait(vdev_t *vd);
+extern boolean_t vdev_trim_should_stop(vdev_t *vd);
 
 /*
  * Label routines

--- a/usr/src/uts/common/fs/zfs/sys/zio.h
+++ b/usr/src/uts/common/fs/zfs/sys/zio.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
@@ -38,6 +38,7 @@
 #include <sys/avl.h>
 #include <sys/fs/zfs.h>
 #include <sys/zio_impl.h>
+#include <sys/dkio.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -233,6 +234,9 @@ typedef void zio_done_func_t(zio_t *zio);
 
 extern boolean_t zio_dva_throttle_enabled;
 extern const char *zio_type_name[ZIO_TYPES];
+extern boolean_t zfs_trim;
+
+struct range_tree;
 
 /*
  * A bookmark is a four-tuple <objset, object, level, blkid> that uniquely
@@ -286,6 +290,9 @@ typedef struct zbookmark_phys {
 	((zb)->zb_object == ZB_ROOT_OBJECT &&	\
 	(zb)->zb_level == ZB_ROOT_LEVEL &&	\
 	(zb)->zb_blkid == ZB_ROOT_BLKID)
+
+#define	ZIO_IS_TRIM(zio)	\
+	((zio)->io_type == ZIO_TYPE_IOCTL && (zio)->io_cmd == DKIOCFREE)
 
 typedef struct zio_prop {
 	enum zio_checksum	zp_checksum;
@@ -412,6 +419,10 @@ struct zio {
 	/* io_lsize != io_orig_size iff this is a raw write */
 	uint64_t	io_lsize;
 
+	/* Used by trim zios */
+	dkioc_free_list_t	*io_dfl;
+	boolean_t		io_dfl_free_on_destroy;
+
 	/* Stuff for the vdev stack */
 	vdev_t		*io_vd;
 	void		*io_vsd;
@@ -490,6 +501,14 @@ extern zio_t *zio_claim(zio_t *pio, spa_t *spa, uint64_t txg,
 
 extern zio_t *zio_ioctl(zio_t *pio, spa_t *spa, vdev_t *vd, int cmd,
     zio_done_func_t *done, void *private, enum zio_flag flags);
+
+extern zio_t *zio_trim_dfl(zio_t *pio, spa_t *spa, vdev_t *vd,
+    dkioc_free_list_t *dfl, boolean_t dfl_free_on_destroy, boolean_t auto_trim,
+    zio_done_func_t *done, void *private);
+
+extern zio_t *zio_trim_tree(zio_t *pio, spa_t *spa, vdev_t *vd,
+    struct range_tree *tree, boolean_t auto_trim, zio_done_func_t *done,
+    void *private, int dkiocfree_flags, metaslab_t *msp);
 
 extern zio_t *zio_read_phys(zio_t *pio, vdev_t *vd, uint64_t offset,
     uint64_t size, struct abd *data, int checksum,

--- a/usr/src/uts/common/fs/zfs/sys/zio_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zio_impl.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #ifndef _ZIO_IMPL_H
@@ -236,6 +237,11 @@ enum zio_stage {
 	(ZIO_INTERLOCK_STAGES |			\
 	ZIO_STAGE_VDEV_IO_START |		\
 	ZIO_STAGE_VDEV_IO_ASSESS)
+
+#define	ZIO_TRIM_PIPELINE			\
+	(ZIO_INTERLOCK_STAGES |			\
+	ZIO_STAGE_ISSUE_ASYNC |			\
+	ZIO_VDEV_IO_STAGES)
 
 #define	ZIO_BLOCKING_STAGES			\
 	(ZIO_STAGE_DVA_ALLOCATE |		\

--- a/usr/src/uts/common/fs/zfs/sys/zio_priority.h
+++ b/usr/src/uts/common/fs/zfs/sys/zio_priority.h
@@ -14,6 +14,7 @@
  */
 /*
  * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 #ifndef	_ZIO_PRIORITY_H
 #define	_ZIO_PRIORITY_H
@@ -28,6 +29,14 @@ typedef enum zio_priority {
 	ZIO_PRIORITY_ASYNC_READ,	/* prefetch */
 	ZIO_PRIORITY_ASYNC_WRITE,	/* spa_sync() */
 	ZIO_PRIORITY_SCRUB,		/* asynchronous scrub/resilver reads */
+	/*
+	 * Trims are separated into auto & manual trims. If a manual trim is
+	 * initiated, auto trims are discarded late in the zio pipeline just
+	 * prior to being issued. This lets manual trim start up much faster
+	 * if a lot of auto trims have already been queued up.
+	 */
+	ZIO_PRIORITY_AUTO_TRIM,		/* async auto trim operation */
+	ZIO_PRIORITY_MAN_TRIM,		/* manual trim operation */
 	ZIO_PRIORITY_NUM_QUEUEABLE,
 
 	ZIO_PRIORITY_NOW		/* non-queued i/os (e.g. free) */

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -3549,6 +3549,7 @@ vdev_man_trim(vdev_trim_info_t *vti)
 	hrtime_t t = gethrtime();
 	spa_t *spa = vti->vti_vdev->vdev_spa;
 	vdev_t *vd = vti->vti_vdev;
+	uint64_t ms_count;
 	uint64_t i, cursor;
 	boolean_t was_loaded = B_FALSE;
 
@@ -3556,20 +3557,22 @@ vdev_man_trim(vdev_trim_info_t *vti)
 	vd->vdev_trim_prog = 0;
 
 	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
+	ms_count = vd->vdev_ms_count;
+	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+
 	ASSERT(vd->vdev_ms[0] != NULL);
 	cursor = vd->vdev_ms[0]->ms_start;
 	i = 0;
-	while (i < vti->vti_vdev->vdev_ms_count && !spa->spa_man_trim_stop) {
+	while (i < ms_count && !spa->spa_man_trim_stop) {
 		uint64_t delta;
 		metaslab_t *msp = vd->vdev_ms[i];
 		zio_t *trim_io;
 
 		trim_io = metaslab_trim_all(msp, &cursor, &delta, &was_loaded);
-		spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 
 		if (trim_io != NULL) {
 			ASSERT3U(cursor, >=, vd->vdev_ms[0]->ms_start);
-			vd->vdev_trim_prog = cursor - vd->vdev_ms[0]->ms_start;
+			vd->vdev_trim_prog += delta;
 			(void) zio_wait(trim_io);
 		} else {
 			/*
@@ -3611,17 +3614,8 @@ vdev_man_trim(vdev_trim_info_t *vti)
 				break;
 			}
 		}
-		spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
 	}
-	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 out:
-	/*
-	 * Ensure we're marked as "completed" even if we've had to stop
-	 * before processing all metaslabs.
-	 */
-	mutex_enter(&vd->vdev_stat_lock);
-	vd->vdev_trim_prog = vd->vdev_stat.vs_space;
-	mutex_exit(&vd->vdev_stat_lock);
 	vd->vdev_man_trimming = B_FALSE;
 
 	ASSERT(vti->vti_done_cb != NULL);
@@ -3641,6 +3635,7 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	uint64_t txg = vti->vti_txg;
 	uint64_t txgs_per_trim = zfs_txgs_per_trim;
 	uint64_t mlim = 0, mused = 0;
+	uint64_t ms_count = vd->vdev_ms_count;
 	boolean_t preserve_spilled;
 
 	ASSERT3P(vd->vdev_top, ==, vd);
@@ -3655,8 +3650,7 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	 * autotrim run. But we only do so if the amount of memory consumed
 	 * by the extents doesn't exceed a threshold, otherwise we drop them.
 	 */
-	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
-	for (uint64_t i = 0; i < vd->vdev_ms_count; i++)
+	for (uint64_t i = 0; i < ms_count; i++)
 		mused += metaslab_trim_mem_used(vd->vdev_ms[i]);
 	mlim = (physmem * PAGESIZE) / (zfs_trim_mem_lim_fact *
 	    spa->spa_root_vdev->vdev_children);
@@ -3673,11 +3667,8 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	 * txgs_per_trim. Thus, for the default 200 metaslabs and 32
 	 * txgs_per_trim, we'll only be trimming ~6.25 metaslabs per txg.
 	 */
-	for (uint64_t i = txg % txgs_per_trim; i < vd->vdev_ms_count;
-	    i += txgs_per_trim)
+	for (uint64_t i = txg % txgs_per_trim; i < ms_count; i += txgs_per_trim)
 		metaslab_auto_trim(vd->vdev_ms[i], preserve_spilled);
-
-	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 
 out:
 	ASSERT(vti->vti_done_cb != NULL);
@@ -3734,4 +3725,14 @@ vdev_trim_stop_wait(vdev_t *vd)
 	trim_stop_set(vd, B_TRUE);
 	trim_stop_wait(vd);
 	trim_stop_set(vd, B_FALSE);
+}
+
+/*
+ * Returns true if a management operation (such as attach/add) is trying to
+ * grab this vdev and therefore any ongoing trims should be canceled.
+ */
+boolean_t
+vdev_trim_should_stop(vdev_t *vd)
+{
+	return (vd->vdev_trim_zios_stop);
 }

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -83,6 +83,34 @@ int metaslabs_per_vdev = 200;
 uint64_t zfs_trim_mem_lim_fact = 50;
 
 /*
+ * How many TXG's worth of updates should be aggregated per TRIM/UNMAP
+ * issued to the underlying vdev. We keep two range trees of extents
+ * (called "trim sets") to be trimmed per metaslab, the `current' and
+ * the `previous' TS. New free's are added to the current TS. Then,
+ * once `zfs_txgs_per_trim' transactions have elapsed, the `current'
+ * TS becomes the `previous' TS and a new, blank TS is created to be
+ * the new `current', which will then start accumulating any new frees.
+ * Once another zfs_txgs_per_trim TXGs have passed, the previous TS's
+ * extents are trimmed, the TS is destroyed and the current TS again
+ * becomes the previous TS.
+ * This serves to fulfill two functions: aggregate many small frees
+ * into fewer larger trim operations (which should help with devices
+ * which do not take so kindly to them) and to allow for disaster
+ * recovery (extents won't get trimmed immediately, but instead only
+ * after passing this rather long timeout, thus preserving
+ * 'zfs import -F' functionality).
+ * The exact default value of this tunable is a tradeoff between:
+ * 1) Keeping the trim commands reasonably small.
+ * 2) Keeping the ability to rollback back for as many txgs as possible.
+ * 3) Waiting around too long that the user starts to get uneasy about not
+ *	seeing any space being freed after they remove some files.
+ * The default value of 32 is the maximum number of uberblocks in a vdev
+ * label, assuming a 4k physical sector size (which seems to be the almost
+ * universal smallest sector size used in SSDs).
+ */
+unsigned int zfs_txgs_per_trim = 32;
+
+/*
  * Given a vdev type, return the appropriate ops vector.
  */
 static vdev_ops_t *
@@ -3610,6 +3638,7 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	vdev_t *vd = vti->vti_vdev;
 	spa_t *spa = vd->vdev_spa;
 	uint64_t txg = vti->vti_txg;
+	uint64_t txgs_per_trim = zfs_txgs_per_trim;
 	uint64_t mlim = 0, mused = 0;
 	boolean_t limited;
 
@@ -3626,8 +3655,20 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	limited = mused > mlim;
 	DTRACE_PROBE3(autotrim__mem__lim, vdev_t *, vd, uint64_t, mused,
 	    uint64_t, mlim);
-	for (uint64_t i = 0; i < vd->vdev_ms_count; i++)
-		metaslab_auto_trim(vd->vdev_ms[i], txg, !limited);
+
+	/*
+	 * Since we typically have hundreds of metaslabs per vdev, but we only
+	 * trim them once every zfs_txgs_per_trim txgs, it'd be best if we
+	 * could sequence the TRIM commands from all metaslabs so that they
+	 * don't all always pound the device in the same txg. We do so taking
+	 * the txg number modulo txgs_per_trim and then skipping by
+	 * txgs_per_trim. Thus, for the default 200 metaslabs and 32
+	 * txgs_per_trim, we'll only be trimming ~6.25 metaslabs per txg.
+	 */
+	for (uint64_t i = txg % txgs_per_trim; i < vd->vdev_ms_count;
+	    i += txgs_per_trim)
+		metaslab_auto_trim(vd->vdev_ms[i], !limited);
+
 	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 
 out:

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
- * Copyright 2017 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Toomas Soome <tsoome@me.com>
  */
@@ -72,6 +72,15 @@ int zfs_scrub_limit = 10;
  * more than) this number of metaslabs.
  */
 int metaslabs_per_vdev = 200;
+
+/*
+ * If we accumulate a lot of trim extents due to trim running slow, this
+ * is the memory pressure valve. We limit the amount of memory consumed
+ * by the extents in memory to physmem/zfs_trim_mem_lim_fact (by default
+ * 2%). If we exceed this limit, we start throwing out new extents
+ * without queueing them.
+ */
+uint64_t zfs_trim_mem_lim_fact = 50;
 
 /*
  * Given a vdev type, return the appropriate ops vector.
@@ -362,6 +371,9 @@ vdev_alloc_common(spa_t *spa, uint_t id, uint64_t guid, vdev_ops_t *ops)
 	vd->vdev_stat.vs_timestamp = gethrtime();
 	vdev_queue_init(vd);
 	vdev_cache_init(vd);
+
+	mutex_init(&vd->vdev_trim_zios_lock, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&vd->vdev_trim_zios_cv, NULL, CV_DEFAULT, NULL);
 
 	return (vd);
 }
@@ -684,6 +696,10 @@ vdev_free(vdev_t *vd)
 	mutex_destroy(&vd->vdev_dtl_lock);
 	mutex_destroy(&vd->vdev_stat_lock);
 	mutex_destroy(&vd->vdev_probe_lock);
+
+	ASSERT0(vd->vdev_trim_zios);
+	mutex_destroy(&vd->vdev_trim_zios_lock);
+	cv_destroy(&vd->vdev_trim_zios_cv);
 
 	if (vd == spa->spa_root_vdev)
 		spa->spa_root_vdev = NULL;
@@ -1645,6 +1661,23 @@ vdev_dirty(vdev_t *vd, int flags, void *arg, uint64_t txg)
 		(void) txg_list_add(&vd->vdev_dtl_list, arg, txg);
 
 	(void) txg_list_add(&vd->vdev_spa->spa_vdev_txg_list, vd, txg);
+}
+
+boolean_t
+vdev_is_dirty(vdev_t *vd, int flags, void *arg)
+{
+	ASSERT(vd == vd->vdev_top);
+	ASSERT(!vd->vdev_ishole);
+	ASSERT(ISP2(flags));
+	ASSERT(spa_writeable(vd->vdev_spa));
+	ASSERT3U(flags, ==, VDD_METASLAB);
+
+	for (uint64_t txg = 0; txg < TXG_SIZE; txg++) {
+		if (txg_list_member(&vd->vdev_ms_list, arg, txg))
+			return (B_TRUE);
+	}
+
+	return (B_FALSE);
 }
 
 void
@@ -3475,4 +3508,181 @@ vdev_deadman(vdev_t *vd)
 		}
 		mutex_exit(&vq->vq_lock);
 	}
+}
+
+/*
+ * Implements the per-vdev portion of manual TRIM. The function passes over
+ * all metaslabs on this vdev and performs a metaslab_trim_all on them. It's
+ * also responsible for rate-control if spa_man_trim_rate is non-zero.
+ */
+void
+vdev_man_trim(vdev_trim_info_t *vti)
+{
+	clock_t t = ddi_get_lbolt();
+	spa_t *spa = vti->vti_vdev->vdev_spa;
+	vdev_t *vd = vti->vti_vdev;
+	uint64_t i, cursor;
+	boolean_t was_loaded = B_FALSE;
+
+	vd->vdev_man_trimming = B_TRUE;
+	vd->vdev_trim_prog = 0;
+
+	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
+	ASSERT(vd->vdev_ms[0] != NULL);
+	cursor = vd->vdev_ms[0]->ms_start;
+	i = 0;
+	while (i < vti->vti_vdev->vdev_ms_count && !spa->spa_man_trim_stop) {
+		uint64_t delta;
+		metaslab_t *msp = vd->vdev_ms[i];
+		zio_t *trim_io;
+
+		trim_io = metaslab_trim_all(msp, &cursor, &delta, &was_loaded);
+		spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+
+		if (trim_io != NULL) {
+			ASSERT3U(cursor, >=, vd->vdev_ms[0]->ms_start);
+			vd->vdev_trim_prog = cursor - vd->vdev_ms[0]->ms_start;
+			(void) zio_wait(trim_io);
+		} else {
+			/*
+			 * If there was nothing more left to trim, that means
+			 * this metaslab is either done trimming, or we
+			 * couldn't load it, move to the next one.
+			 */
+			i++;
+			if (i < vti->vti_vdev->vdev_ms_count)
+				ASSERT3U(vd->vdev_ms[i]->ms_start, ==, cursor);
+		}
+
+		/* delay loop to handle fixed-rate trimming */
+		for (;;) {
+			uint64_t rate = spa->spa_man_trim_rate;
+			uint64_t sleep_delay;
+			clock_t t1;
+
+			if (rate == 0) {
+				/* No delay, just update 't' and move on. */
+				t = ddi_get_lbolt();
+				break;
+			}
+
+			sleep_delay = (delta * hz) / rate;
+			mutex_enter(&spa->spa_man_trim_lock);
+			t1 = cv_timedwait(&spa->spa_man_trim_update_cv,
+			    &spa->spa_man_trim_lock, t + sleep_delay);
+			mutex_exit(&spa->spa_man_trim_lock);
+
+			/* If interrupted, don't try to relock, get out */
+			if (spa->spa_man_trim_stop)
+				goto out;
+
+			/* Timeout passed, move on to the next chunk. */
+			if (t1 == -1) {
+				t += sleep_delay;
+				break;
+			}
+		}
+		spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
+	}
+	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+out:
+	/*
+	 * Ensure we're marked as "completed" even if we've had to stop
+	 * before processing all metaslabs.
+	 */
+	mutex_enter(&vd->vdev_stat_lock);
+	vd->vdev_trim_prog = vd->vdev_stat.vs_space;
+	mutex_exit(&vd->vdev_stat_lock);
+	vd->vdev_man_trimming = B_FALSE;
+
+	ASSERT(vti->vti_done_cb != NULL);
+	vti->vti_done_cb(vti->vti_done_arg);
+
+	kmem_free(vti, sizeof (*vti));
+}
+
+/*
+ * Runs through all metaslabs on the vdev and does their autotrim processing.
+ */
+void
+vdev_auto_trim(vdev_trim_info_t *vti)
+{
+	vdev_t *vd = vti->vti_vdev;
+	spa_t *spa = vd->vdev_spa;
+	uint64_t txg = vti->vti_txg;
+	uint64_t mlim = 0, mused = 0;
+	boolean_t limited;
+
+	ASSERT3P(vd->vdev_top, ==, vd);
+
+	if (vd->vdev_man_trimming)
+		goto out;
+
+	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
+	for (uint64_t i = 0; i < vd->vdev_ms_count; i++)
+		mused += metaslab_trim_mem_used(vd->vdev_ms[i]);
+	mlim = (physmem * PAGESIZE) / (zfs_trim_mem_lim_fact *
+	    spa->spa_root_vdev->vdev_children);
+	limited = mused > mlim;
+	DTRACE_PROBE3(autotrim__mem__lim, vdev_t *, vd, uint64_t, mused,
+	    uint64_t, mlim);
+	for (uint64_t i = 0; i < vd->vdev_ms_count; i++)
+		metaslab_auto_trim(vd->vdev_ms[i], txg, !limited);
+	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
+
+out:
+	ASSERT(vti->vti_done_cb != NULL);
+	vti->vti_done_cb(vti->vti_done_arg);
+
+	kmem_free(vti, sizeof (*vti));
+}
+
+static void
+trim_stop_set(vdev_t *vd, boolean_t flag)
+{
+	mutex_enter(&vd->vdev_trim_zios_lock);
+	vd->vdev_trim_zios_stop = flag;
+	mutex_exit(&vd->vdev_trim_zios_lock);
+
+	for (uint64_t i = 0; i < vd->vdev_children; i++)
+		trim_stop_set(vd->vdev_child[i], flag);
+}
+
+static void
+trim_stop_wait(vdev_t *vd)
+{
+	mutex_enter(&vd->vdev_trim_zios_lock);
+	while (vd->vdev_trim_zios)
+		cv_wait(&vd->vdev_trim_zios_cv, &vd->vdev_trim_zios_lock);
+	mutex_exit(&vd->vdev_trim_zios_lock);
+
+	for (uint64_t i = 0; i < vd->vdev_children; i++)
+		trim_stop_wait(vd->vdev_child[i]);
+}
+
+/*
+ * This function stops all asynchronous trim I/O going to a vdev and all
+ * its children. Because trim zios occur outside of the normal transactional
+ * machinery, we can't rely on the DMU hooks to stop I/O to devices being
+ * removed or reconfigured. Therefore, all pool management tasks which
+ * change the vdev configuration need to stop trim I/Os explicitly.
+ * After this function returns, it is guaranteed that no trim zios will be
+ * executing on the vdev or any of its children until either of the
+ * trim locks is released.
+ */
+void
+vdev_trim_stop_wait(vdev_t *vd)
+{
+	ASSERT(MUTEX_HELD(&vd->vdev_spa->spa_man_trim_lock));
+	ASSERT(MUTEX_HELD(&vd->vdev_spa->spa_auto_trim_lock));
+	/*
+	 * First we mark all devices as requesting a trim stop. This starts
+	 * the vdev queue drain (via zio_trim_should_bypass) quickly, then
+	 * we actually wait for all trim zios to get destroyed and then we
+	 * unmark the stop condition so trim zios can configure once the
+	 * pool management operation is done.
+	 */
+	trim_stop_set(vd, B_TRUE);
+	trim_stop_wait(vd);
+	trim_stop_set(vd, B_FALSE);
 }

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -3546,7 +3546,7 @@ vdev_deadman(vdev_t *vd)
 void
 vdev_man_trim(vdev_trim_info_t *vti)
 {
-	clock_t t = ddi_get_lbolt();
+	hrtime_t t = gethrtime();
 	spa_t *spa = vti->vti_vdev->vdev_spa;
 	vdev_t *vd = vti->vti_vdev;
 	uint64_t i, cursor;
@@ -3585,19 +3585,20 @@ vdev_man_trim(vdev_trim_info_t *vti)
 		/* delay loop to handle fixed-rate trimming */
 		for (;;) {
 			uint64_t rate = spa->spa_man_trim_rate;
-			uint64_t sleep_delay;
-			clock_t t1;
+			hrtime_t sleep_delay;
+			hrtime_t t1;
 
 			if (rate == 0) {
 				/* No delay, just update 't' and move on. */
-				t = ddi_get_lbolt();
+				t = gethrtime();
 				break;
 			}
 
-			sleep_delay = (delta * hz) / rate;
+			sleep_delay = SEC2NSEC(delta) / rate;
 			mutex_enter(&spa->spa_man_trim_lock);
-			t1 = cv_timedwait(&spa->spa_man_trim_update_cv,
-			    &spa->spa_man_trim_lock, t + sleep_delay);
+			t1 = cv_timedwait_hires(&spa->spa_man_trim_update_cv,
+			    &spa->spa_man_trim_lock, t + sleep_delay,
+			    nsec_per_tick, CALLOUT_FLAG_ABSOLUTE);
 			mutex_exit(&spa->spa_man_trim_lock);
 
 			/* If interrupted, don't try to relock, get out */
@@ -3640,19 +3641,26 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	uint64_t txg = vti->vti_txg;
 	uint64_t txgs_per_trim = zfs_txgs_per_trim;
 	uint64_t mlim = 0, mused = 0;
-	boolean_t limited;
+	boolean_t preserve_spilled;
 
 	ASSERT3P(vd->vdev_top, ==, vd);
 
 	if (vd->vdev_man_trimming)
 		goto out;
 
+	/*
+	 * In case trimming is slow and the previous trim run has no yet
+	 * finished, we order metaslab_auto_trim to keep the extents that
+	 * were about to be trimmed so that they can be trimmed in a future
+	 * autotrim run. But we only do so if the amount of memory consumed
+	 * by the extents doesn't exceed a threshold, otherwise we drop them.
+	 */
 	spa_config_enter(spa, SCL_STATE_ALL, FTAG, RW_READER);
 	for (uint64_t i = 0; i < vd->vdev_ms_count; i++)
 		mused += metaslab_trim_mem_used(vd->vdev_ms[i]);
 	mlim = (physmem * PAGESIZE) / (zfs_trim_mem_lim_fact *
 	    spa->spa_root_vdev->vdev_children);
-	limited = mused > mlim;
+	preserve_spilled = mused < mlim;
 	DTRACE_PROBE3(autotrim__mem__lim, vdev_t *, vd, uint64_t, mused,
 	    uint64_t, mlim);
 
@@ -3667,7 +3675,7 @@ vdev_auto_trim(vdev_trim_info_t *vti)
 	 */
 	for (uint64_t i = txg % txgs_per_trim; i < vd->vdev_ms_count;
 	    i += txgs_per_trim)
-		metaslab_auto_trim(vd->vdev_ms[i], !limited);
+		metaslab_auto_trim(vd->vdev_ms[i], preserve_spilled);
 
 	spa_config_exit(spa, SCL_STATE_ALL, FTAG);
 

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
- * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Joyent, Inc.  All rights reserved.
  */
 
@@ -485,6 +485,10 @@ vdev_disk_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 		(void) ldi_ev_register_callbacks(dvd->vd_lh, ecookie,
 		    &vdev_disk_dgrd_callb, (void *) vd, &lcb->lcb_id);
 	}
+
+	/* Reset TRIM flag, as underlying device support may have changed */
+	vd->vdev_notrim = B_FALSE;
+
 skip_open:
 	/*
 	 * Determine the actual size of the device.
@@ -754,6 +758,36 @@ vdev_disk_io_start(zio_t *zio)
 
 			break;
 
+		case DKIOCFREE:
+			if (!zfs_trim)
+				break;
+			/*
+			 * We perform device support checks here instead of
+			 * in zio_trim_*(), as zio_trim_*() might be invoked
+			 * on a top-level vdev, whereas vdev_disk_io_start
+			 * is guaranteed to be operating a leaf disk vdev.
+			 */
+			if (vd->vdev_notrim &&
+			    spa_get_force_trim(vd->vdev_spa) !=
+			    SPA_FORCE_TRIM_ON) {
+				zio->io_error = SET_ERROR(ENOTSUP);
+				break;
+			}
+
+			/*
+			 * zio->io_private contains a dkioc_free_list_t
+			 * specifying which offsets are to be freed
+			 */
+			ASSERT(zio->io_dfl != NULL);
+			error = ldi_ioctl(dvd->vd_lh, zio->io_cmd,
+			    (uintptr_t)zio->io_dfl, FKIOCTL, kcred, NULL);
+
+			if (error == ENOTSUP || error == ENOTTY)
+				vd->vdev_notrim = B_TRUE;
+			zio->io_error = error;
+
+			break;
+
 		default:
 			zio->io_error = SET_ERROR(ENOTSUP);
 		}
@@ -826,16 +860,17 @@ vdev_disk_io_done(zio_t *zio)
 }
 
 vdev_ops_t vdev_disk_ops = {
-	vdev_disk_open,
-	vdev_disk_close,
-	vdev_default_asize,
-	vdev_disk_io_start,
-	vdev_disk_io_done,
-	NULL,
-	vdev_disk_hold,
-	vdev_disk_rele,
-	VDEV_TYPE_DISK,		/* name of this vdev type */
-	B_TRUE			/* leaf vdev */
+	.vdev_op_open =		vdev_disk_open,
+	.vdev_op_close =	vdev_disk_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_disk_io_start,
+	.vdev_op_io_done =	vdev_disk_io_done,
+	.vdev_op_state_change =	NULL,
+	.vdev_op_hold =		vdev_disk_hold,
+	.vdev_op_rele =		vdev_disk_rele,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_DISK,	/* name of this vdev type */
+	.vdev_op_leaf =		B_TRUE		/* leaf vdev */
 };
 
 /*

--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -781,9 +781,6 @@ vdev_disk_io_start(zio_t *zio)
 			ASSERT(zio->io_dfl != NULL);
 			error = ldi_ioctl(dvd->vd_lh, zio->io_cmd,
 			    (uintptr_t)zio->io_dfl, FKIOCTL, kcred, NULL);
-
-			if (error == ENOTSUP || error == ENOTTY)
-				vd->vdev_notrim = B_TRUE;
 			zio->io_error = error;
 
 			break;

--- a/usr/src/uts/common/fs/zfs/vdev_file.c
+++ b/usr/src/uts/common/fs/zfs/vdev_file.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -32,6 +33,9 @@
 #include <sys/fs/zfs.h>
 #include <sys/fm/fs/zfs.h>
 #include <sys/abd.h>
+#include <sys/fcntl.h>
+#include <sys/vnode.h>
+#include <sys/dkioc_free_util.h>
 
 /*
  * Virtual device vector for files.
@@ -210,6 +214,35 @@ vdev_file_io_start(zio_t *zio)
 			zio->io_error = VOP_FSYNC(vf->vf_vnode, FSYNC | FDSYNC,
 			    kcred, NULL);
 			break;
+		case DKIOCFREE:
+		{
+			const dkioc_free_list_t *dfl = zio->io_dfl;
+
+			ASSERT(dfl != NULL);
+			if (!zfs_trim)
+				break;
+			for (int i = 0; i < dfl->dfl_num_exts; i++) {
+				struct flock64 flck;
+				int error;
+
+				if (dfl->dfl_exts[i].dfle_length == 0)
+					continue;
+
+				bzero(&flck, sizeof (flck));
+				flck.l_type = F_FREESP;
+				flck.l_start = dfl->dfl_exts[i].dfle_start +
+				    dfl->dfl_offset;
+				flck.l_len = dfl->dfl_exts[i].dfle_length;
+
+				error = VOP_SPACE(vf->vf_vnode,
+				    F_FREESP, &flck, 0, 0, kcred, NULL);
+				if (error != 0) {
+					zio->io_error = SET_ERROR(error);
+					break;
+				}
+			}
+			break;
+		}
 		default:
 			zio->io_error = SET_ERROR(ENOTSUP);
 		}
@@ -254,16 +287,17 @@ vdev_file_io_done(zio_t *zio)
 }
 
 vdev_ops_t vdev_file_ops = {
-	vdev_file_open,
-	vdev_file_close,
-	vdev_default_asize,
-	vdev_file_io_start,
-	vdev_file_io_done,
-	NULL,
-	vdev_file_hold,
-	vdev_file_rele,
-	VDEV_TYPE_FILE,		/* name of this vdev type */
-	B_TRUE			/* leaf vdev */
+	.vdev_op_open =		vdev_file_open,
+	.vdev_op_close =	vdev_file_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_file_io_start,
+	.vdev_op_io_done =	vdev_file_io_done,
+	.vdev_op_state_change =	NULL,
+	.vdev_op_hold =		vdev_file_hold,
+	.vdev_op_rele =		vdev_file_rele,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_FILE,	/* name of this vdev type */
+	.vdev_op_leaf =		B_TRUE		/* leaf vdev */
 };
 
 /*
@@ -272,16 +306,17 @@ vdev_ops_t vdev_file_ops = {
 #ifndef _KERNEL
 
 vdev_ops_t vdev_disk_ops = {
-	vdev_file_open,
-	vdev_file_close,
-	vdev_default_asize,
-	vdev_file_io_start,
-	vdev_file_io_done,
-	NULL,
-	vdev_file_hold,
-	vdev_file_rele,
-	VDEV_TYPE_DISK,		/* name of this vdev type */
-	B_TRUE			/* leaf vdev */
+	.vdev_op_open =		vdev_file_open,
+	.vdev_op_close =	vdev_file_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_file_io_start,
+	.vdev_op_io_done =	vdev_file_io_done,
+	.vdev_op_state_change =	NULL,
+	.vdev_op_hold =		vdev_file_hold,
+	.vdev_op_rele =		vdev_file_rele,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_DISK,	/* name of this vdev type */
+	.vdev_op_leaf =		B_TRUE		/* leaf vdev */
 };
 
 #endif

--- a/usr/src/uts/common/fs/zfs/vdev_label.c
+++ b/usr/src/uts/common/fs/zfs/vdev_label.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 /*
@@ -392,6 +393,12 @@ vdev_config_generate(spa_t *spa, vdev_t *vd, boolean_t getstats,
 		if (vd->vdev_splitting && vd->vdev_orig_guid != 0LL) {
 			fnvlist_add_uint64(nv, ZPOOL_CONFIG_ORIG_GUID,
 			    vd->vdev_orig_guid);
+		}
+
+		/* grab per-leaf-vdev trim stats */
+		if (getstats) {
+			fnvlist_add_uint64(nv, ZPOOL_CONFIG_TRIM_PROG,
+			    vd->vdev_trim_prog);
 		}
 	}
 

--- a/usr/src/uts/common/fs/zfs/vdev_mirror.c
+++ b/usr/src/uts/common/fs/zfs/vdev_mirror.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -340,6 +341,9 @@ vdev_mirror_io_done(zio_t *zio)
 	int good_copies = 0;
 	int unexpected_errors = 0;
 
+	if (ZIO_IS_TRIM(zio))
+		return;
+
 	for (c = 0; c < mm->mm_children; c++) {
 		mc = &mm->mm_child[c];
 
@@ -455,40 +459,43 @@ vdev_mirror_state_change(vdev_t *vd, int faulted, int degraded)
 }
 
 vdev_ops_t vdev_mirror_ops = {
-	vdev_mirror_open,
-	vdev_mirror_close,
-	vdev_default_asize,
-	vdev_mirror_io_start,
-	vdev_mirror_io_done,
-	vdev_mirror_state_change,
-	NULL,
-	NULL,
-	VDEV_TYPE_MIRROR,	/* name of this vdev type */
-	B_FALSE			/* not a leaf vdev */
+	.vdev_op_open =		vdev_mirror_open,
+	.vdev_op_close =	vdev_mirror_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_mirror_io_start,
+	.vdev_op_io_done =	vdev_mirror_io_done,
+	.vdev_op_state_change =	vdev_mirror_state_change,
+	.vdev_op_hold =		NULL,
+	.vdev_op_rele =		NULL,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_MIRROR, /* name of this vdev type */
+	.vdev_op_leaf =		B_FALSE		/* not a leaf vdev */
 };
 
 vdev_ops_t vdev_replacing_ops = {
-	vdev_mirror_open,
-	vdev_mirror_close,
-	vdev_default_asize,
-	vdev_mirror_io_start,
-	vdev_mirror_io_done,
-	vdev_mirror_state_change,
-	NULL,
-	NULL,
-	VDEV_TYPE_REPLACING,	/* name of this vdev type */
-	B_FALSE			/* not a leaf vdev */
+	.vdev_op_open =		vdev_mirror_open,
+	.vdev_op_close =	vdev_mirror_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_mirror_io_start,
+	.vdev_op_io_done =	vdev_mirror_io_done,
+	.vdev_op_state_change =	vdev_mirror_state_change,
+	.vdev_op_hold =		NULL,
+	.vdev_op_rele =		NULL,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_REPLACING, /* name of this vd type */
+	.vdev_op_leaf =		B_FALSE		/* not a leaf vdev */
 };
 
 vdev_ops_t vdev_spare_ops = {
-	vdev_mirror_open,
-	vdev_mirror_close,
-	vdev_default_asize,
-	vdev_mirror_io_start,
-	vdev_mirror_io_done,
-	vdev_mirror_state_change,
-	NULL,
-	NULL,
-	VDEV_TYPE_SPARE,	/* name of this vdev type */
-	B_FALSE			/* not a leaf vdev */
+	.vdev_op_open =		vdev_mirror_open,
+	.vdev_op_close =	vdev_mirror_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_mirror_io_start,
+	.vdev_op_io_done =	vdev_mirror_io_done,
+	.vdev_op_state_change =	vdev_mirror_state_change,
+	.vdev_op_hold =		NULL,
+	.vdev_op_rele =		NULL,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_SPARE, /* name of this vdev type */
+	.vdev_op_leaf =		B_FALSE		/* not a leaf vdev */
 };

--- a/usr/src/uts/common/fs/zfs/vdev_missing.c
+++ b/usr/src/uts/common/fs/zfs/vdev_missing.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 /*
@@ -80,27 +81,29 @@ vdev_missing_io_done(zio_t *zio)
 }
 
 vdev_ops_t vdev_missing_ops = {
-	vdev_missing_open,
-	vdev_missing_close,
-	vdev_default_asize,
-	vdev_missing_io_start,
-	vdev_missing_io_done,
-	NULL,
-	NULL,
-	NULL,
-	VDEV_TYPE_MISSING,	/* name of this vdev type */
-	B_TRUE			/* leaf vdev */
+	.vdev_op_open =		vdev_missing_open,
+	.vdev_op_close =	vdev_missing_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_missing_io_start,
+	.vdev_op_io_done =	vdev_missing_io_done,
+	.vdev_op_state_change =	NULL,
+	.vdev_op_hold =		NULL,
+	.vdev_op_rele =		NULL,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_MISSING, /* name of this vdev type */
+	.vdev_op_leaf =		B_TRUE		/* leaf vdev */
 };
 
 vdev_ops_t vdev_hole_ops = {
-	vdev_missing_open,
-	vdev_missing_close,
-	vdev_default_asize,
-	vdev_missing_io_start,
-	vdev_missing_io_done,
-	NULL,
-	NULL,
-	NULL,
-	VDEV_TYPE_HOLE,		/* name of this vdev type */
-	B_TRUE			/* leaf vdev */
+	.vdev_op_open =		vdev_missing_open,
+	.vdev_op_close =	vdev_missing_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	vdev_missing_io_start,
+	.vdev_op_io_done =	vdev_missing_io_done,
+	.vdev_op_state_change =	NULL,
+	.vdev_op_hold =		NULL,
+	.vdev_op_rele =		NULL,
+	.vdev_op_trim =		NULL,
+	.vdev_op_type =		VDEV_TYPE_HOLE,	/* name of this vdev type */
+	.vdev_op_leaf =		B_TRUE		/* leaf vdev */
 };

--- a/usr/src/uts/common/fs/zfs/vdev_queue.c
+++ b/usr/src/uts/common/fs/zfs/vdev_queue.c
@@ -26,6 +26,7 @@
 /*
  * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -148,6 +149,8 @@ uint32_t zfs_vdev_async_write_min_active = 1;
 uint32_t zfs_vdev_async_write_max_active = 10;
 uint32_t zfs_vdev_scrub_min_active = 1;
 uint32_t zfs_vdev_scrub_max_active = 2;
+uint32_t zfs_vdev_trim_min_active = 1;
+uint32_t zfs_vdev_trim_max_active = 10;
 
 /*
  * When the pool has less than zfs_vdev_async_write_active_min_dirty_percent
@@ -214,11 +217,14 @@ vdev_queue_class_tree(vdev_queue_t *vq, zio_priority_t p)
 static inline avl_tree_t *
 vdev_queue_type_tree(vdev_queue_t *vq, zio_type_t t)
 {
-	ASSERT(t == ZIO_TYPE_READ || t == ZIO_TYPE_WRITE);
+	ASSERT(t == ZIO_TYPE_READ || t == ZIO_TYPE_WRITE ||
+	    t == ZIO_TYPE_IOCTL);
 	if (t == ZIO_TYPE_READ)
 		return (&vq->vq_read_offset_tree);
-	else
+	else if (t == ZIO_TYPE_WRITE)
 		return (&vq->vq_write_offset_tree);
+	else
+		return (NULL);
 }
 
 int
@@ -264,8 +270,12 @@ vdev_queue_init(vdev_t *vd)
 		 * The synchronous i/o queues are dispatched in FIFO rather
 		 * than LBA order.  This provides more consistent latency for
 		 * these i/os.
+		 * The same is true of the TRIM queue, where LBA ordering
+		 * doesn't help.
 		 */
-		if (p == ZIO_PRIORITY_SYNC_READ || p == ZIO_PRIORITY_SYNC_WRITE)
+		if (p == ZIO_PRIORITY_SYNC_READ ||
+		    p == ZIO_PRIORITY_SYNC_WRITE ||
+		    p == ZIO_PRIORITY_AUTO_TRIM || p == ZIO_PRIORITY_MAN_TRIM)
 			compfn = vdev_queue_timestamp_compare;
 		else
 			compfn = vdev_queue_offset_compare;
@@ -293,10 +303,13 @@ static void
 vdev_queue_io_add(vdev_queue_t *vq, zio_t *zio)
 {
 	spa_t *spa = zio->io_spa;
+	avl_tree_t *qtt;
 
 	ASSERT3U(zio->io_priority, <, ZIO_PRIORITY_NUM_QUEUEABLE);
 	avl_add(vdev_queue_class_tree(vq, zio->io_priority), zio);
-	avl_add(vdev_queue_type_tree(vq, zio->io_type), zio);
+	qtt = vdev_queue_type_tree(vq, zio->io_type);
+	if (qtt != NULL)
+		avl_add(qtt, zio);
 
 	mutex_enter(&spa->spa_iokstat_lock);
 	spa->spa_queue_stats[zio->io_priority].spa_queued++;
@@ -309,10 +322,13 @@ static void
 vdev_queue_io_remove(vdev_queue_t *vq, zio_t *zio)
 {
 	spa_t *spa = zio->io_spa;
+	avl_tree_t *qtt;
 
 	ASSERT3U(zio->io_priority, <, ZIO_PRIORITY_NUM_QUEUEABLE);
 	avl_remove(vdev_queue_class_tree(vq, zio->io_priority), zio);
-	avl_remove(vdev_queue_type_tree(vq, zio->io_type), zio);
+	qtt = vdev_queue_type_tree(vq, zio->io_type);
+	if (qtt != NULL)
+		avl_remove(qtt, zio);
 
 	mutex_enter(&spa->spa_iokstat_lock);
 	ASSERT3U(spa->spa_queue_stats[zio->io_priority].spa_queued, >, 0);
@@ -394,6 +410,9 @@ vdev_queue_class_min_active(zio_priority_t p)
 		return (zfs_vdev_async_write_min_active);
 	case ZIO_PRIORITY_SCRUB:
 		return (zfs_vdev_scrub_min_active);
+	case ZIO_PRIORITY_AUTO_TRIM:
+	case ZIO_PRIORITY_MAN_TRIM:
+		return (zfs_vdev_trim_min_active);
 	default:
 		panic("invalid priority %u", p);
 		return (0);
@@ -453,6 +472,9 @@ vdev_queue_class_max_active(spa_t *spa, zio_priority_t p)
 		return (vdev_queue_max_async_writes(spa));
 	case ZIO_PRIORITY_SCRUB:
 		return (zfs_vdev_scrub_max_active);
+	case ZIO_PRIORITY_AUTO_TRIM:
+	case ZIO_PRIORITY_MAN_TRIM:
+		return (zfs_vdev_trim_max_active);
 	default:
 		panic("invalid priority %u", p);
 		return (0);
@@ -664,7 +686,7 @@ again:
 	 * For LBA-ordered queues (async / scrub), issue the i/o which follows
 	 * the most recently issued i/o in LBA (offset) order.
 	 *
-	 * For FIFO queues (sync), issue the i/o with the lowest timestamp.
+	 * For FIFO queues (sync/trim), issue the i/o with the lowest timestamp.
 	 */
 	tree = vdev_queue_class_tree(vq, p);
 	search.io_timestamp = 0;
@@ -696,7 +718,10 @@ again:
 	}
 
 	vdev_queue_pending_add(vq, zio);
-	vq->vq_last_offset = zio->io_offset;
+	/* trim I/Os have no single meaningful offset */
+	if (zio->io_priority != ZIO_PRIORITY_AUTO_TRIM ||
+	    zio->io_priority != ZIO_PRIORITY_MAN_TRIM)
+		vq->vq_last_offset = zio->io_offset;
 
 	return (zio);
 }
@@ -719,11 +744,12 @@ vdev_queue_io(zio_t *zio)
 		    zio->io_priority != ZIO_PRIORITY_ASYNC_READ &&
 		    zio->io_priority != ZIO_PRIORITY_SCRUB)
 			zio->io_priority = ZIO_PRIORITY_ASYNC_READ;
-	} else {
-		ASSERT(zio->io_type == ZIO_TYPE_WRITE);
+	} else if (zio->io_type == ZIO_TYPE_WRITE) {
 		if (zio->io_priority != ZIO_PRIORITY_SYNC_WRITE &&
 		    zio->io_priority != ZIO_PRIORITY_ASYNC_WRITE)
 			zio->io_priority = ZIO_PRIORITY_ASYNC_WRITE;
+	} else {
+		ASSERT(ZIO_IS_TRIM(zio));
 	}
 
 	zio->io_flags |= ZIO_FLAG_DONT_CACHE | ZIO_FLAG_DONT_QUEUE;

--- a/usr/src/uts/common/fs/zfs/vdev_root.c
+++ b/usr/src/uts/common/fs/zfs/vdev_root.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2013 by Delphix. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -109,14 +110,15 @@ vdev_root_state_change(vdev_t *vd, int faulted, int degraded)
 }
 
 vdev_ops_t vdev_root_ops = {
-	vdev_root_open,
-	vdev_root_close,
-	vdev_default_asize,
-	NULL,			/* io_start - not applicable to the root */
-	NULL,			/* io_done - not applicable to the root */
-	vdev_root_state_change,
-	NULL,
-	NULL,
-	VDEV_TYPE_ROOT,		/* name of this vdev type */
-	B_FALSE			/* not a leaf vdev */
+	.vdev_op_open =		vdev_root_open,
+	.vdev_op_close =	vdev_root_close,
+	.vdev_op_asize =	vdev_default_asize,
+	.vdev_op_io_start =	NULL,		/* not applicable to the root */
+	.vdev_op_io_done =	NULL,		/* not applicable to the root */
+	.vdev_op_state_change =	vdev_root_state_change,
+	.vdev_op_hold =		NULL,		/* not applicable to the root */
+	.vdev_op_rele =		NULL,		/* not applicable to the root */
+	.vdev_op_trim =		NULL,		/* not applicable to the root */
+	.vdev_op_type =		VDEV_TYPE_ROOT,	/* name of this vdev type */
+	.vdev_op_leaf =		B_FALSE		/* not a leaf vdev */
 };

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -3456,9 +3456,13 @@ zio_vdev_io_assess(zio_t *zio)
 	 * that we don't bother with it in the future.
 	 */
 	if ((zio->io_error == ENOTSUP || zio->io_error == ENOTTY) &&
-	    zio->io_type == ZIO_TYPE_IOCTL &&
-	    zio->io_cmd == DKIOCFLUSHWRITECACHE && vd != NULL)
-		vd->vdev_nowritecache = B_TRUE;
+	    zio->io_type == ZIO_TYPE_IOCTL && vd != NULL) {
+		if (zio->io_cmd == DKIOCFLUSHWRITECACHE)
+			vd->vdev_nowritecache = B_TRUE;
+		if (zio->io_cmd == DKIOCFREE)
+			vd->vdev_notrim = B_TRUE;
+	}
+
 
 	if (zio->io_error)
 		zio->io_pipeline = ZIO_INTERLOCK_PIPELINE;

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -1061,7 +1061,7 @@ zio_trim_check(uint64_t start, uint64_t len, void *msp)
 		mutex_enter(&ms->ms_lock);
 	ASSERT(ms->ms_trimming_ts != NULL);
 	if (ms->ms_loaded)
-		ASSERT(range_tree_contains(ms->ms_trimming_ts->ts_tree,
+		ASSERT(range_tree_contains(ms->ms_trimming_ts,
 		    start - VDEV_LABEL_START_SIZE, len));
 	if (!held)
 		mutex_exit(&ms->ms_lock);

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
- * Copyright (c) 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  */
 
@@ -40,6 +40,7 @@
 #include <sys/ddt.h>
 #include <sys/blkptr.h>
 #include <sys/zfeature.h>
+#include <sys/dkioc_free_util.h>
 #include <sys/metaslab_impl.h>
 #include <sys/abd.h>
 
@@ -106,6 +107,14 @@ int zio_buf_debug_limit = 0;
 #endif
 
 static void zio_taskq_dispatch(zio_t *, zio_taskq_type_t, boolean_t);
+
+/*
+ * Tunable to allow for debugging SCSI UNMAP/SATA TRIM calls. Disabling
+ * it will prevent ZFS from attempting to issue DKIOCFREE ioctls to the
+ * underlying storage.
+ */
+boolean_t zfs_trim = B_TRUE;
+uint64_t zfs_trim_min_ext_sz = 128 << 10;	/* 128k */
 
 void
 zio_init(void)
@@ -627,11 +636,25 @@ zio_create(zio_t *pio, spa_t *spa, uint64_t txg, const blkptr_t *bp,
 static void
 zio_destroy(zio_t *zio)
 {
+	if (ZIO_IS_TRIM(zio)) {
+		vdev_t *vd = zio->io_vd;
+		ASSERT(vd != NULL);
+		ASSERT(!MUTEX_HELD(&vd->vdev_trim_zios_lock));
+		mutex_enter(&vd->vdev_trim_zios_lock);
+		ASSERT(vd->vdev_trim_zios != 0);
+		vd->vdev_trim_zios--;
+		cv_broadcast(&vd->vdev_trim_zios_cv);
+		mutex_exit(&vd->vdev_trim_zios_lock);
+	}
 	metaslab_trace_fini(&zio->io_alloc_list);
 	list_destroy(&zio->io_parent_list);
 	list_destroy(&zio->io_child_list);
 	mutex_destroy(&zio->io_lock);
 	cv_destroy(&zio->io_cv);
+	if (zio->io_dfl != NULL && zio->io_dfl_free_on_destroy)
+		dfl_free(zio->io_dfl);
+	else
+		ASSERT0(zio->io_dfl_free_on_destroy);
 	kmem_cache_free(zio_cache, zio);
 }
 
@@ -946,6 +969,175 @@ zio_ioctl(zio_t *pio, spa_t *spa, vdev_t *vd, int cmd,
 	}
 
 	return (zio);
+}
+
+/*
+ * Performs the same function as zio_trim_tree, but takes a dkioc_free_list_t
+ * instead of a range tree of extents. The `dfl' argument is stored in the
+ * zio and shouldn't be altered by the caller after calling zio_trim_dfl.
+ * If `dfl_free_on_destroy' is true, the zio will destroy and free the list
+ * using dfl_free after the zio is done executing.
+ */
+zio_t *
+zio_trim_dfl(zio_t *pio, spa_t *spa, vdev_t *vd, dkioc_free_list_t *dfl,
+    boolean_t dfl_free_on_destroy, boolean_t auto_trim,
+    zio_done_func_t *done, void *private)
+{
+	zio_t *zio;
+	int c;
+
+	ASSERT(dfl->dfl_num_exts != 0);
+
+	if (vd->vdev_ops->vdev_op_leaf) {
+		/*
+		 * A trim zio is a special ioctl zio that can enter the vdev
+		 * queue. We don't want to be sorted in the queue by offset,
+		 * but sometimes the queue requires that, so we fake an
+		 * offset value. We simply use the offset of the first extent
+		 * and the minimum allocation unit on the vdev to keep the
+		 * queue's algorithms working more-or-less as they should.
+		 */
+		uint64_t off = dfl->dfl_exts[0].dfle_start;
+
+		zio = zio_create(pio, spa, 0, NULL, NULL, 1 << vd->vdev_ashift,
+		    1 << vd->vdev_ashift, done, private, ZIO_TYPE_IOCTL,
+		    auto_trim ? ZIO_PRIORITY_AUTO_TRIM : ZIO_PRIORITY_MAN_TRIM,
+		    ZIO_FLAG_CANFAIL | ZIO_FLAG_DONT_RETRY |
+		    ZIO_FLAG_DONT_PROPAGATE | ZIO_FLAG_DONT_AGGREGATE |
+		    ZIO_FLAG_PHYSICAL, vd, off, NULL, ZIO_STAGE_OPEN,
+		    ZIO_TRIM_PIPELINE);
+		zio->io_cmd = DKIOCFREE;
+		zio->io_dfl = dfl;
+		zio->io_dfl_free_on_destroy = dfl_free_on_destroy;
+
+		mutex_enter(&vd->vdev_trim_zios_lock);
+		vd->vdev_trim_zios++;
+		mutex_exit(&vd->vdev_trim_zios_lock);
+	} else {
+		/*
+		 * Trims to non-leaf vdevs have two possible paths. For vdevs
+		 * that do not provide a specific trim fanout handler, we
+		 * simply duplicate the trim to each child. vdevs which do
+		 * have a trim fanout handler are responsible for doing the
+		 * fanout themselves.
+		 */
+		zio = zio_null(pio, spa, vd, done, private, 0);
+		zio->io_dfl = dfl;
+		zio->io_dfl_free_on_destroy = dfl_free_on_destroy;
+
+		if (vd->vdev_ops->vdev_op_trim != NULL) {
+			vd->vdev_ops->vdev_op_trim(vd, zio, dfl, auto_trim);
+		} else {
+			for (c = 0; c < vd->vdev_children; c++) {
+				zio_nowait(zio_trim_dfl(zio, spa,
+				    vd->vdev_child[c], dfl, B_FALSE, auto_trim,
+				    NULL, NULL));
+			}
+		}
+	}
+
+	return (zio);
+}
+
+/*
+ * This check is used by zio_trim_tree to set in dfl_ck_func to help debugging
+ * extent trimming. If the SCSI driver (sd) was compiled with the DEBUG flag
+ * set, dfl_ck_func is called for every extent to verify that it is indeed
+ * ok to be trimmed. This function compares the extent address with the tree
+ * of free blocks (ms_tree) in the metaslab which this trim was originally
+ * part of.
+ */
+static void
+zio_trim_check(uint64_t start, uint64_t len, void *msp)
+{
+	metaslab_t *ms = msp;
+	boolean_t held = MUTEX_HELD(&ms->ms_lock);
+	if (!held)
+		mutex_enter(&ms->ms_lock);
+	ASSERT(ms->ms_trimming_ts != NULL);
+	if (ms->ms_loaded)
+		ASSERT(range_tree_contains(ms->ms_trimming_ts->ts_tree,
+		    start - VDEV_LABEL_START_SIZE, len));
+	if (!held)
+		mutex_exit(&ms->ms_lock);
+}
+
+/*
+ * Takes a bunch of freed extents and tells the underlying vdevs that the
+ * space associated with these extents can be released.
+ * This is used by flash storage to pre-erase blocks for rapid reuse later
+ * and thin-provisioned block storage to reclaim unused blocks.
+ * This function is actually a front-end to zio_trim_dfl. It simply converts
+ * the provided range_tree's contents into a dkioc_free_list_t and calls
+ * zio_trim_dfl with it. The `tree' argument is not used after this function
+ * returns and can be discarded by the caller.
+ */
+zio_t *
+zio_trim_tree(zio_t *pio, spa_t *spa, vdev_t *vd, struct range_tree *tree,
+    boolean_t auto_trim, zio_done_func_t *done, void *private,
+    int dkiocfree_flags, metaslab_t *msp)
+{
+	dkioc_free_list_t *dfl = NULL;
+	range_seg_t *rs;
+	uint64_t rs_idx;
+	uint64_t num_exts;
+	uint64_t bytes_issued = 0, bytes_skipped = 0, exts_skipped = 0;
+
+	ASSERT(range_tree_space(tree) != 0);
+
+	num_exts = avl_numnodes(&tree->rt_root);
+	dfl = kmem_zalloc(DFL_SZ(num_exts), KM_SLEEP);
+	dfl->dfl_flags = dkiocfree_flags;
+	dfl->dfl_num_exts = num_exts;
+	dfl->dfl_offset = VDEV_LABEL_START_SIZE;
+	if (msp) {
+		dfl->dfl_ck_func = zio_trim_check;
+		dfl->dfl_ck_arg = msp;
+	}
+
+	for (rs = avl_first(&tree->rt_root), rs_idx = 0; rs != NULL;
+	    rs = AVL_NEXT(&tree->rt_root, rs)) {
+		uint64_t len = rs->rs_end - rs->rs_start;
+
+		/* Skip extents that are too short to bother with. */
+		if (len < zfs_trim_min_ext_sz) {
+			bytes_skipped += len;
+			exts_skipped++;
+			continue;
+		}
+
+		dfl->dfl_exts[rs_idx].dfle_start = rs->rs_start;
+		dfl->dfl_exts[rs_idx].dfle_length = len;
+
+		/* check we're a multiple of the vdev ashift */
+		ASSERT0(dfl->dfl_exts[rs_idx].dfle_start &
+		    ((1 << vd->vdev_ashift) - 1));
+		ASSERT0(dfl->dfl_exts[rs_idx].dfle_length &
+		    ((1 << vd->vdev_ashift) - 1));
+
+		rs_idx++;
+		bytes_issued += len;
+	}
+
+	spa_trimstats_update(spa, rs_idx, bytes_issued, exts_skipped,
+	    bytes_skipped);
+
+	/* the zfs_trim_min_ext_sz filter may have shortened the list */
+	if (dfl->dfl_num_exts != rs_idx) {
+		if (rs_idx == 0) {
+			/* Removing short extents has removed all extents. */
+			dfl_free(dfl);
+			return (zio_null(pio, spa, vd, done, private, 0));
+		}
+		dkioc_free_list_t *dfl2 = kmem_zalloc(DFL_SZ(rs_idx), KM_SLEEP);
+		bcopy(dfl, dfl2, DFL_SZ(rs_idx));
+		dfl2->dfl_num_exts = rs_idx;
+		dfl_free(dfl);
+		dfl = dfl2;
+	}
+
+	return (zio_trim_dfl(pio, spa, vd, dfl, B_TRUE, auto_trim, done,
+	    private));
 }
 
 zio_t *
@@ -2971,6 +3163,30 @@ zio_free_zil(spa_t *spa, uint64_t txg, blkptr_t *bp)
  * ==========================================================================
  */
 
+/*
+ * Late pipeline bypass for trim zios. Because our zio trim queues can be
+ * pretty long and we might want to quickly terminate trims for performance
+ * reasons, we check the following conditions:
+ * 1) If a manual trim was initiated with the queue full of auto trim zios,
+ *	we want to skip doing the auto trims, because they hold up the manual
+ *	trim unnecessarily. Manual trim processes all empty space anyway.
+ * 2) If the autotrim property of the pool is flipped to off, usually due to
+ *	performance reasons, we want to stop trying to do autotrims/
+ * 3) If a manual trim shutdown was requested, immediately terminate them.
+ * 4) If a pool vdev reconfiguration is imminent, we must discard all queued
+ *	up trims to let it proceed as quickly as possible.
+ */
+static inline boolean_t
+zio_trim_should_bypass(const zio_t *zio)
+{
+	ASSERT(ZIO_IS_TRIM(zio));
+	return ((zio->io_priority == ZIO_PRIORITY_AUTO_TRIM &&
+	    (zio->io_vd->vdev_top->vdev_man_trimming ||
+	    zio->io_spa->spa_auto_trim != SPA_AUTO_TRIM_ON)) ||
+	    (zio->io_priority == ZIO_PRIORITY_MAN_TRIM &&
+	    zio->io_spa->spa_man_trim_stop) ||
+	    zio->io_vd->vdev_trim_zios_stop);
+}
 
 /*
  * Issue an I/O to the underlying vdev. Typically the issue pipeline
@@ -3081,7 +3297,8 @@ zio_vdev_io_start(zio_t *zio)
 	}
 
 	if (vd->vdev_ops->vdev_op_leaf &&
-	    (zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE)) {
+	    (zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE ||
+	    ZIO_IS_TRIM(zio))) {
 
 		if (zio->io_type == ZIO_TYPE_READ && vdev_cache_read(zio))
 			return (ZIO_PIPELINE_CONTINUE);
@@ -3095,6 +3312,9 @@ zio_vdev_io_start(zio_t *zio)
 			return (ZIO_PIPELINE_STOP);
 		}
 	}
+
+	if (ZIO_IS_TRIM(zio) && zio_trim_should_bypass(zio))
+		return (ZIO_PIPELINE_CONTINUE);
 
 	vd->vdev_ops->vdev_op_io_start(zio);
 	return (ZIO_PIPELINE_STOP);
@@ -3110,7 +3330,8 @@ zio_vdev_io_done(zio_t *zio)
 	if (zio_wait_for_children(zio, ZIO_CHILD_VDEV, ZIO_WAIT_DONE))
 		return (ZIO_PIPELINE_STOP);
 
-	ASSERT(zio->io_type == ZIO_TYPE_READ || zio->io_type == ZIO_TYPE_WRITE);
+	ASSERT(zio->io_type == ZIO_TYPE_READ ||
+	    zio->io_type == ZIO_TYPE_WRITE || ZIO_IS_TRIM(zio));
 
 	if (vd != NULL && vd->vdev_ops->vdev_op_leaf) {
 
@@ -3126,7 +3347,7 @@ zio_vdev_io_done(zio_t *zio)
 		if (zio_injection_enabled && zio->io_error == 0)
 			zio->io_error = zio_handle_label_injection(zio, EIO);
 
-		if (zio->io_error) {
+		if (zio->io_error && !ZIO_IS_TRIM(zio)) {
 			if (!vdev_accessible(vd, zio)) {
 				zio->io_error = SET_ERROR(ENXIO);
 			} else {

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -988,7 +988,12 @@ zio_trim_dfl(zio_t *pio, spa_t *spa, vdev_t *vd, dkioc_free_list_t *dfl,
 
 	ASSERT(dfl->dfl_num_exts != 0);
 
-	if (vd->vdev_ops->vdev_op_leaf) {
+	if (!vdev_writeable(vd)) {
+		/* Skip unavailable vdevs, just create a dummy zio. */
+		zio = zio_null(pio, spa, vd, done, private, 0);
+		zio->io_dfl = dfl;
+		zio->io_dfl_free_on_destroy = dfl_free_on_destroy;
+	} else if (vd->vdev_ops->vdev_op_leaf) {
 		/*
 		 * A trim zio is a special ioctl zio that can enter the vdev
 		 * queue. We don't want to be sorted in the queue by offset,

--- a/usr/src/uts/common/fs/zfs/zvol.c
+++ b/usr/src/uts/common/fs/zfs/zvol.c
@@ -23,7 +23,7 @@
  *
  * Portions Copyright 2010 Robert Milkowski
  *
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
@@ -88,6 +88,7 @@
 #include <sys/dmu_tx.h>
 #include <sys/zfeature.h>
 #include <sys/zio_checksum.h>
+#include <sys/dkioc_free_util.h>
 
 #include "zfs_namecheck.h"
 
@@ -1779,43 +1780,63 @@ zvol_ioctl(dev_t dev, int cmd, intptr_t arg, int flag, cred_t *cr, int *rvalp)
 
 	case DKIOCFREE:
 	{
-		dkioc_free_t df;
+		dkioc_free_list_t *dfl;
 		dmu_tx_t *tx;
+
+		mutex_exit(&zfsdev_state_lock);
 
 		if (!zvol_unmap_enabled)
 			break;
 
-		if (ddi_copyin((void *)arg, &df, sizeof (df), flag)) {
-			error = SET_ERROR(EFAULT);
-			break;
-		}
-
-		/*
-		 * Apply Postel's Law to length-checking.  If they overshoot,
-		 * just blank out until the end, if there's a need to blank
-		 * out anything.
-		 */
-		if (df.df_start >= zv->zv_volsize)
-			break;	/* No need to do anything... */
-
-		mutex_exit(&zfsdev_state_lock);
-
-		rl = zfs_range_lock(&zv->zv_znode, df.df_start, df.df_length,
-		    RL_WRITER);
-		tx = dmu_tx_create(zv->zv_objset);
-		dmu_tx_mark_netfree(tx);
-		error = dmu_tx_assign(tx, TXG_WAIT);
-		if (error != 0) {
-			dmu_tx_abort(tx);
+		if (!(flag & FKIOCTL)) {
+			error = dfl_copyin((void *)arg, &dfl, flag, KM_SLEEP);
+			if (error != 0)
+				break;
 		} else {
-			zvol_log_truncate(zv, tx, df.df_start,
-			    df.df_length, B_TRUE);
-			dmu_tx_commit(tx);
-			error = dmu_free_long_range(zv->zv_objset, ZVOL_OBJ,
-			    df.df_start, df.df_length);
+			dfl = (dkioc_free_list_t *)arg;
+			ASSERT3U(dfl->dfl_num_exts, <=, DFL_COPYIN_MAX_EXTS);
+			if (dfl->dfl_num_exts > DFL_COPYIN_MAX_EXTS) {
+				error = SET_ERROR(EINVAL);
+				break;
+			}
 		}
 
-		zfs_range_unlock(rl);
+		for (int i = 0; i < dfl->dfl_num_exts; i++) {
+			uint64_t start = dfl->dfl_exts[i].dfle_start,
+			    length = dfl->dfl_exts[i].dfle_length,
+			    end = start + length;
+
+			/*
+			 * Apply Postel's Law to length-checking.  If they
+			 * overshoot, just blank out until the end, if there's
+			 * a need to blank out anything.
+			 */
+			if (start >= zv->zv_volsize)
+				continue;	/* No need to do anything... */
+			if (end > zv->zv_volsize) {
+				end = DMU_OBJECT_END;
+				length = end - start;
+			}
+
+			rl = zfs_range_lock(&zv->zv_znode, start, length,
+			    RL_WRITER);
+			tx = dmu_tx_create(zv->zv_objset);
+			error = dmu_tx_assign(tx, TXG_WAIT);
+			if (error != 0) {
+				dmu_tx_abort(tx);
+			} else {
+				zvol_log_truncate(zv, tx, start, length,
+				    B_TRUE);
+				dmu_tx_commit(tx);
+				error = dmu_free_long_range(zv->zv_objset,
+				    ZVOL_OBJ, start, length);
+			}
+
+			zfs_range_unlock(rl);
+
+			if (error != 0)
+				break;
+		}
 
 		/*
 		 * If the write-cache is disabled, 'sync' property
@@ -1828,9 +1849,12 @@ zvol_ioctl(dev_t dev, int cmd, intptr_t arg, int flag, cred_t *cr, int *rvalp)
 		if ((error == 0) && zvol_unmap_sync_enabled &&
 		    (!(zv->zv_flags & ZVOL_WCE) ||
 		    (zv->zv_objset->os_sync == ZFS_SYNC_ALWAYS) ||
-		    (df.df_flags & DF_WAIT_SYNC))) {
+		    (dfl->dfl_flags & DF_WAIT_SYNC))) {
 			zil_commit(zv->zv_zilog, ZVOL_OBJ);
 		}
+
+		if (!(flag & FKIOCTL))
+			dfl_free(dfl);
 
 		return (error);
 	}

--- a/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd.c
+++ b/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc. All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  */
 
@@ -3689,22 +3689,26 @@ out:
 
 /*
  * Unmap a region in a volume.  Currently only supported for zvols.
+ * The list of extents to be freed is passed in a dkioc_free_list_t
+ * which the caller is responsible for destroying.
  */
 int
-sbd_unmap(sbd_lu_t *sl, uint64_t offset, uint64_t length)
+sbd_unmap(sbd_lu_t *sl, dkioc_free_list_t *dfl)
 {
 	vnode_t *vp;
-	int unused;
-	dkioc_free_t df;
+	int unused, ret;
 
-	/* Right now, we only support UNMAP on zvols. */
-	if (!(sl->sl_flags & SL_ZFS_META))
-		return (EIO);
+	/* Nothing to do */
+	if (dfl->dfl_num_exts == 0)
+		return (0);
 
-	df.df_flags = (sl->sl_flags & SL_WRITEBACK_CACHE_DISABLE) ?
+	/*
+	 * TODO: unmap performance may be improved by not doing the synchronous
+	 * removal of the blocks and writing of the metadata.  The
+	 * transaction is in the zil so the state should be stable.
+	 */
+	dfl->dfl_flags = (sl->sl_flags & SL_WRITEBACK_CACHE_DISABLE) ?
 	    DF_WAIT_SYNC : 0;
-	df.df_start = offset;
-	df.df_length = length;
 
 	/* Use the data vnode we have to send a fop_ioctl(). */
 	vp = sl->sl_data_vp;
@@ -3713,6 +3717,8 @@ sbd_unmap(sbd_lu_t *sl, uint64_t offset, uint64_t length)
 		return (EIO);
 	}
 
-	return (VOP_IOCTL(vp, DKIOCFREE, (intptr_t)(&df), FKIOCTL, kcred,
-	    &unused, NULL));
+	ret = VOP_IOCTL(vp, DKIOCFREE, (intptr_t)dfl, FKIOCTL, kcred,
+	    &unused, NULL);
+
+	return (ret);
 }

--- a/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_scsi.c
+++ b/usr/src/uts/common/io/comstar/lu/stmf_sbd/sbd_scsi.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 by Delphix. All rights reserved.
  */
 
@@ -37,6 +37,7 @@
 #include <sys/atomic.h>
 #include <sys/sdt.h>
 #include <sys/dkio.h>
+#include <sys/dkioc_free_util.h>
 
 #include <sys/stmf.h>
 #include <sys/lpif.h>
@@ -2467,12 +2468,18 @@ sbd_handle_write_same(scsi_task_t *task, struct stmf_data_buf *initial_dbuf)
 
 	/* Check if the command is for the unmap function */
 	if (unmap) {
-		if (sbd_unmap(sl, addr, len) != 0) {
+		dkioc_free_list_t *dfl = kmem_zalloc(DFL_SZ(1), KM_SLEEP);
+
+		dfl->dfl_num_exts = 1;
+		dfl->dfl_exts[0].dfle_start = addr;
+		dfl->dfl_exts[0].dfle_length = len;
+		if (sbd_unmap(sl, dfl) != 0) {
 			stmf_scsilib_send_status(task, STATUS_CHECK,
 			    STMF_SAA_LBA_OUT_OF_RANGE);
 		} else {
 			stmf_scsilib_send_status(task, STATUS_GOOD, 0);
 		}
+		dfl_free(dfl);
 		return;
 	}
 
@@ -2576,7 +2583,9 @@ sbd_handle_unmap_xfer(scsi_task_t *task, uint8_t *buf, uint32_t buflen)
 	uint32_t ulen, dlen, num_desc;
 	uint64_t addr, len;
 	uint8_t *p;
+	dkioc_free_list_t *dfl;
 	int ret;
+	int i;
 
 	if (buflen < 24) {
 		stmf_scsilib_send_status(task, STATUS_CHECK,
@@ -2593,20 +2602,28 @@ sbd_handle_unmap_xfer(scsi_task_t *task, uint8_t *buf, uint32_t buflen)
 		return;
 	}
 
-	for (p = buf + 8; num_desc; num_desc--, p += 16) {
+	dfl = kmem_zalloc(DFL_SZ(num_desc), KM_SLEEP);
+	dfl->dfl_num_exts = num_desc;
+	for (p = buf + 8, i = 0; num_desc; num_desc--, p += 16, i++) {
 		addr = READ_SCSI64(p, uint64_t);
 		addr <<= sl->sl_data_blocksize_shift;
 		len = READ_SCSI32(p+8, uint64_t);
 		len <<= sl->sl_data_blocksize_shift;
-		ret = sbd_unmap(sl, addr, len);
-		if (ret != 0) {
-			stmf_scsilib_send_status(task, STATUS_CHECK,
-			    STMF_SAA_LBA_OUT_OF_RANGE);
-			return;
-		}
+		/* Prepare a list of extents to unmap */
+		dfl->dfl_exts[i].dfle_start = addr;
+		dfl->dfl_exts[i].dfle_length = len;
+	}
+	ASSERT(i == dfl->dfl_num_exts);
+
+	/* Finally execute the unmap operations in a single step */
+	ret = sbd_unmap(sl, dfl);
+	dfl_free(dfl);
+	if (ret != 0) {
+		stmf_scsilib_send_status(task, STATUS_CHECK,
+		    STMF_SAA_LBA_OUT_OF_RANGE);
+		return;
 	}
 
-unmap_done:
 	stmf_scsilib_send_status(task, STATUS_GOOD, 0);
 }
 

--- a/usr/src/uts/common/io/comstar/lu/stmf_sbd/stmf_sbd.h
+++ b/usr/src/uts/common/io/comstar/lu/stmf_sbd/stmf_sbd.h
@@ -21,11 +21,13 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  *
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_STMF_SBD_H
 #define	_STMF_SBD_H
+
+#include <sys/dkio.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -300,7 +302,7 @@ sbd_status_t sbd_write_lu_info(sbd_lu_t *sl);
 sbd_status_t sbd_flush_data_cache(sbd_lu_t *sl, int fsync_done);
 sbd_status_t sbd_wcd_set(int wcd, sbd_lu_t *sl);
 void sbd_wcd_get(int *wcd, sbd_lu_t *sl);
-int sbd_unmap(sbd_lu_t *, uint64_t, uint64_t);
+int sbd_unmap(sbd_lu_t *sl, dkioc_free_list_t *dfl);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/io/iwn/if_iwn.c
+++ b/usr/src/uts/common/io/iwn/if_iwn.c
@@ -19,6 +19,7 @@
 
 /*
  * Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+ * Copyright (c) 2017 Nexenta Systems, Inc. All rights reserved.
  */
 
 /*
@@ -2049,7 +2050,7 @@ iwn_reset_tx_ring(struct iwn_softc *sc, struct iwn_tx_ring *ring)
 		}
 
 	/* Clear TX descriptors. */
-	memset(ring->desc, 0, ring->desc_dma.size);
+	(void) memset(ring->desc, 0, ring->desc_dma.size);
 	(void) ddi_dma_sync(ring->desc_dma.dma_hdl, 0, 0, DDI_DMA_SYNC_FORDEV);
 	sc->qfullmsk &= ~(1 << ring->qid);
 	ring->queued = 0;
@@ -2080,7 +2081,7 @@ iwn5000_ict_reset(struct iwn_softc *sc)
 	IWN_WRITE(sc, IWN_INT_MASK, 0);
 
 	/* Reset ICT table. */
-	memset(sc->ict, 0, IWN_ICT_SIZE);
+	(void) memset(sc->ict, 0, IWN_ICT_SIZE);
 	sc->ict_cur = 0;
 
 	/* Set physical address of ICT table (4KB aligned). */
@@ -2376,7 +2377,7 @@ iwn_read_eeprom_enhinfo(struct iwn_softc *sc)
 	iwn_read_prom_data(sc, base + IWN6000_EEPROM_ENHINFO,
 	    enhinfo, sizeof enhinfo);
 
-	memset(sc->enh_maxpwr, 0, sizeof sc->enh_maxpwr);
+	(void) memset(sc->enh_maxpwr, 0, sizeof sc->enh_maxpwr);
 	for (i = 0; i < __arraycount(enhinfo); i++) {
 		if (enhinfo[i].chan == 0 || enhinfo[i].reserved != 0)
 			continue;	/* Skip invalid entries. */
@@ -2635,7 +2636,7 @@ iwn_rx_phy(struct iwn_softc *sc, struct iwn_rx_desc *desc,
 	DTRACE_PROBE1(rx__phy, struct iwn_rx_stat *, stat);
 
 	/* Save RX statistics, they will be used on MPDU_RX_DONE. */
-	memcpy(&sc->last_rx_stat, stat, sizeof (*stat));
+	(void) memcpy(&sc->last_rx_stat, stat, sizeof (*stat));
 	sc->last_rx_valid = 1;
 }
 
@@ -2818,7 +2819,7 @@ iwn5000_rx_calib_results(struct iwn_softc *sc, struct iwn_rx_desc *desc,
 		return;
 	}
 	sc->calibcmd[idx].len = len;
-	memcpy(sc->calibcmd[idx].buf, calib, len);
+	(void) memcpy(sc->calibcmd[idx].buf, calib, len);
 }
 
 /*
@@ -3088,7 +3089,7 @@ iwn_notif_intr(struct iwn_softc *sc)
 			}
 			if (uc->subtype == IWN_UCODE_INIT) {
 				/* Save microcontroller report. */
-				memcpy(&sc->ucode_info, uc, sizeof (*uc));
+				(void) memcpy(&sc->ucode_info, uc, sizeof (*uc));
 			}
 			/* Save the address of the error log in SRAM. */
 			sc->errptr = le32toh(uc->errptr);
@@ -3930,7 +3931,7 @@ iwn_send(ieee80211com_t *ic, mblk_t *mp, uint8_t type)
 
 	/* Copy 802.11 header in TX command. */
 	/* XXX NetBSD changed this in rev 1.20 */
-	memcpy(((uint8_t *)tx) + sizeof(*tx), wh, hdrlen);
+	(void) memcpy(((uint8_t *)tx) + sizeof(*tx), wh, hdrlen);
 	mp->b_rptr += hdrlen;
 
 	bcopy(mp->b_rptr, data->dma_data.vaddr, totlen - hdrlen);
@@ -4431,7 +4432,7 @@ iwn_cmd(struct iwn_softc *sc, uint8_t code, void *buf, int size, int async)
 	cmd->qid = ring->qid;
 	cmd->idx = ring->cur;
 	bzero(cmd->data, size);
-	memcpy(cmd->data, buf, size);
+	(void) memcpy(cmd->data, buf, size);
 
 	bzero(desc, sizeof(*desc));
 	desc->nsegs = 1;
@@ -4485,9 +4486,9 @@ iwn4965_add_node(struct iwn_softc *sc, struct iwn_node_info *node, int async)
 	 */
 	src = (char *)node;
 	dst = (char *)&hnode;
-	memcpy(dst, src, 48);
+	(void) memcpy(dst, src, 48);
 	/* Skip TSC, RX MIC and TX MIC fields from ``src''. */
-	memcpy(dst + 48, src + 72, 20);
+	(void) memcpy(dst + 48, src + 72, 20);
 	return iwn_cmd(sc, IWN_CMD_ADD_NODE, &hnode, sizeof hnode, async);
 }
 
@@ -4511,7 +4512,7 @@ iwn_set_link_quality(struct iwn_softc *sc, struct ieee80211_node *ni)
 	/* Use the first valid TX antenna. */
 	txant = IWN_LSB(sc->txchainmask);
 
-	memset(&linkq, 0, sizeof linkq);
+	(void) memset(&linkq, 0, sizeof linkq);
 	linkq.id = wn->id;
 	linkq.antmsk_1stream = txant;
 	linkq.antmsk_2stream = IWN_ANT_AB;
@@ -4546,7 +4547,7 @@ iwn_add_broadcast_node(struct iwn_softc *sc, int async)
 	uint8_t txant;
 	int i, error;
 
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	IEEE80211_ADDR_COPY(node.macaddr, etherbroadcastaddr);
 	node.id = sc->broadcast_id;
 	DTRACE_PROBE(add__broadcast__node);
@@ -4556,7 +4557,7 @@ iwn_add_broadcast_node(struct iwn_softc *sc, int async)
 	/* Use the first valid TX antenna. */
 	txant = IWN_LSB(sc->txchainmask);
 
-	memset(&linkq, 0, sizeof linkq);
+	(void) memset(&linkq, 0, sizeof linkq);
 	linkq.id = sc->broadcast_id;
 	linkq.antmsk_1stream = txant;
 	linkq.antmsk_2stream = IWN_ANT_AB;
@@ -4617,7 +4618,7 @@ iwn_set_critical_temp(struct iwn_softc *sc)
 
 	sc->sc_misc->crit_temp.value.ul = temp;
 
-	memset(&crit, 0, sizeof crit);
+	(void) memset(&crit, 0, sizeof crit);
 	crit.tempR = htole32(temp);
 	return iwn_cmd(sc, IWN_CMD_SET_CRITICAL_TEMP, &crit, sizeof crit, 0);
 }
@@ -4628,8 +4629,8 @@ iwn_set_timing(struct iwn_softc *sc, struct ieee80211_node *ni)
 	struct iwn_cmd_timing cmd;
 	uint64_t val, mod;
 
-	memset(&cmd, 0, sizeof cmd);
-	memcpy(&cmd.tstamp, ni->in_tstamp.data, sizeof (uint64_t));
+	(void) memset(&cmd, 0, sizeof cmd);
+	(void) memcpy(&cmd.tstamp, ni->in_tstamp.data, sizeof (uint64_t));
 	cmd.bintval = htole16(ni->in_intval);
 	cmd.lintval = htole16(10);
 
@@ -4688,7 +4689,7 @@ iwn4965_set_txpower(struct iwn_softc *sc, int async)
 	sc->sc_txpower->chan.value.l = chan;
 	ch = &ic->ic_sup_channels[chan];
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.band = IEEE80211_IS_CHAN_5GHZ(ch) ? 0 : 1;
 	cmd.chan = chan;
 
@@ -4813,7 +4814,7 @@ iwn5000_set_txpower(struct iwn_softc *sc, int async)
 	 * TX power calibration is handled automatically by the firmware
 	 * for 5000 Series.
 	 */
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.global_limit = 2 * IWN5000_TXPOWER_MAX_DBM;	/* 16 dBm */
 	cmd.flags = IWN5000_TXPOWER_NO_CLOSED;
 	cmd.srv_limit = IWN5000_TXPOWER_AUTO;
@@ -4935,7 +4936,7 @@ iwn_init_sensitivity(struct iwn_softc *sc)
 	int error;
 
 	/* Reset calibration state machine. */
-	memset(calib, 0, sizeof (*calib));
+	(void) memset(calib, 0, sizeof (*calib));
 	calib->state = IWN_CALIB_STATE_INIT;
 	calib->cck_state = IWN_CCK_STATE_HIFA;
 	/* Set initial correlation values. */
@@ -5019,7 +5020,7 @@ iwn4965_init_gains(struct iwn_softc *sc)
 {
 	struct iwn_phy_calib_gain cmd;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = IWN4965_PHY_CALIB_DIFF_GAIN;
 	/* Differential gains initially set to 0 for all 3 antennas. */
 	return iwn_cmd(sc, IWN_CMD_PHY_CALIB, &cmd, sizeof cmd, 1);
@@ -5030,7 +5031,7 @@ iwn5000_init_gains(struct iwn_softc *sc)
 {
 	struct iwn_phy_calib cmd;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = sc->reset_noise_gain;
 	cmd.ngroups = 1;
 	cmd.isvalid = 1;
@@ -5050,7 +5051,7 @@ iwn4965_set_gains(struct iwn_softc *sc)
 		if (sc->chainmask & (1 << i))
 			noise = MIN(calib->noise[i], noise);
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = IWN4965_PHY_CALIB_DIFF_GAIN;
 	/* Set differential gains for connected antennas. */
 	for (i = 0; i < 3; i++) {
@@ -5078,7 +5079,7 @@ iwn5000_set_gains(struct iwn_softc *sc)
 	/* We collected 20 beacons and !=6050 need a 1.5 factor. */
 	div = (sc->hw_type == IWN_HW_REV_TYPE_6050) ? 20 : 30;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = sc->noise_gain;
 	cmd.ngroups = 1;
 	cmd.isvalid = 1;
@@ -5257,7 +5258,7 @@ iwn_send_sensitivity(struct iwn_softc *sc)
 	struct iwn_enhanced_sensitivity_cmd cmd;
 	int len;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	len = sizeof (struct iwn_sensitivity_cmd);
 	cmd.which = IWN_SENSITIVITY_WORKTBL;
 	/* OFDM modulation. */
@@ -5320,7 +5321,7 @@ iwn_set_pslevel(struct iwn_softc *sc, int dtim, int level, int async)
 	else
 		pmgt = &iwn_pmgt[2][level];
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	if (level != 0)	/* not CAM */
 		cmd.flags |= htole16(IWN_PS_ALLOW_SLEEP);
 	if (level == 5)
@@ -5359,7 +5360,7 @@ iwn5000_runtime_calib(struct iwn_softc *sc)
 {
 	struct iwn5000_calib_config cmd;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.ucode.once.enable = 0xffffffff;
 	cmd.ucode.once.start = IWN5000_CALIB_DC;
 	return iwn_cmd(sc, IWN5000_CMD_CALIB_CONFIG, &cmd, sizeof(cmd), 0);
@@ -5370,7 +5371,7 @@ iwn_config_bt_coex_bluetooth(struct iwn_softc *sc)
 {
 	struct iwn_bluetooth bluetooth;
 
-	memset(&bluetooth, 0, sizeof bluetooth);
+	(void) memset(&bluetooth, 0, sizeof bluetooth);
 	bluetooth.flags = IWN_BT_COEX_ENABLE;
 	bluetooth.lead_time = IWN_BT_LEAD_TIME_DEF;
 	bluetooth.max_kill = IWN_BT_MAX_KILL_DEF;
@@ -5383,7 +5384,7 @@ iwn_config_bt_coex_prio_table(struct iwn_softc *sc)
 {
 	uint8_t prio_table[16];
 
-	memset(&prio_table, 0, sizeof prio_table);
+	(void) memset(&prio_table, 0, sizeof prio_table);
 	prio_table[ 0] =  6;	/* init calibration 1		*/
 	prio_table[ 1] =  7;	/* init calibration 2		*/
 	prio_table[ 2] =  2;	/* periodic calib low 1		*/
@@ -5443,7 +5444,7 @@ iwn_config_bt_coex_adv_config(struct iwn_softc *sc, struct iwn_bt_basic *basic,
 	}
 
 	/* Force BT state machine change */
-	memset(&btprot, 0, sizeof btprot);
+	(void) memset(&btprot, 0, sizeof btprot);
 	btprot.open = 1;
 	btprot.type = 1;
 	error = iwn_cmd(sc, IWN_CMD_BT_COEX_PROT, &btprot, sizeof btprot, 1);
@@ -5466,7 +5467,7 @@ iwn_config_bt_coex_adv1(struct iwn_softc *sc)
 {
 	struct iwn_bt_adv1 d;
 
-	memset(&d, 0, sizeof d);
+	(void) memset(&d, 0, sizeof d);
 	d.prio_boost = IWN_BT_PRIO_BOOST_DEF;
 	d.tx_prio_boost = 0;
 	d.rx_prio_boost = 0;
@@ -5478,7 +5479,7 @@ iwn_config_bt_coex_adv2(struct iwn_softc *sc)
 {
 	struct iwn_bt_adv2 d;
 
-	memset(&d, 0, sizeof d);
+	(void) memset(&d, 0, sizeof d);
 	d.prio_boost = IWN_BT_PRIO_BOOST_DEF;
 	d.tx_prio_boost = 0;
 	d.rx_prio_boost = 0;
@@ -5547,7 +5548,7 @@ iwn_config(struct iwn_softc *sc)
 	}
 
 	/* Set mode, channel, RX filter and enable RX. */
-	memset(&sc->rxon, 0, sizeof (struct iwn_rxon));
+	(void) memset(&sc->rxon, 0, sizeof (struct iwn_rxon));
 	IEEE80211_ADDR_COPY(sc->rxon.myaddr, ic->ic_macaddr);
 	IEEE80211_ADDR_COPY(sc->rxon.wlap, ic->ic_macaddr);
 	sc->rxon.chan = ieee80211_chan2ieee(ic, ic->ic_ibss_chan);
@@ -5758,14 +5759,14 @@ iwn_scan(struct iwn_softc *sc, uint16_t flags)
 	essid = (struct iwn_scan_essid *)(tx + 1);
 	if (ic->ic_des_esslen != 0) {
 		char essidstr[IEEE80211_NWID_LEN+1];
-		memcpy(essidstr, ic->ic_des_essid, ic->ic_des_esslen);
+		(void) memcpy(essidstr, ic->ic_des_essid, ic->ic_des_esslen);
 		essidstr[ic->ic_des_esslen] = '\0';
 
 		DTRACE_PROBE1(scan__direct, char *, essidstr);
 
 		essid[0].id = IEEE80211_ELEMID_SSID;
 		essid[0].len = ic->ic_des_esslen;
-		memcpy(essid[0].data, ic->ic_des_essid, ic->ic_des_esslen);
+		(void) memcpy(essid[0].data, ic->ic_des_essid, ic->ic_des_esslen);
 
 		is_active = 1;
 		/* hdr->crc_threshold = 0x1; */
@@ -6039,7 +6040,7 @@ iwn_run(struct iwn_softc *sc)
 	iwn_newassoc(ni, 1);
 
 	/* Add BSS node. */
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	IEEE80211_ADDR_COPY(node.macaddr, ni->in_macaddr);
 	node.id = IWN_ID_BSS;
 #ifdef notyet
@@ -6104,14 +6105,14 @@ iwn_set_key(struct ieee80211com *ic, struct ieee80211_node *ni,
 	if (k->k_flags & IEEE80211_KEY_GROUP)
 		kflags |= IWN_KFLAG_GROUP;
 
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	node.id = (k->k_flags & IEEE80211_KEY_GROUP) ?
 	    sc->broadcast_id : wn->id;
 	node.control = IWN_NODE_UPDATE;
 	node.flags = IWN_FLAG_SET_KEY;
 	node.kflags = htole16(kflags);
 	node.kid = k->k_id;
-	memcpy(node.key, k->k_key, k->k_len);
+	(void) memcpy(node.key, k->k_key, k->k_len);
 	DTRACE_PROBE2(set__key, int, k->k_id, int, node.id);
 	return ops->add_node(sc, &node, 1);
 }
@@ -6133,7 +6134,7 @@ iwn_delete_key(struct ieee80211com *ic, struct ieee80211_node *ni,
 	}
 	if (ic->ic_state != IEEE80211_S_RUN)
 		return;	/* Nothing to do. */
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	node.id = (k->k_flags & IEEE80211_KEY_GROUP) ?
 	    sc->broadcast_id : wn->id;
 	node.control = IWN_NODE_UPDATE;
@@ -6160,7 +6161,7 @@ iwn_ampdu_rx_start(struct ieee80211com *ic, struct ieee80211_node *ni,
 	struct iwn_node *wn = (void *)ni;
 	struct iwn_node_info node;
 
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	node.id = wn->id;
 	node.control = IWN_NODE_UPDATE;
 	node.flags = IWN_FLAG_SET_ADDBA;
@@ -6183,7 +6184,7 @@ iwn_ampdu_rx_stop(struct ieee80211com *ic, struct ieee80211_node *ni,
 	struct iwn_node *wn = (void *)ni;
 	struct iwn_node_info node;
 
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	node.id = wn->id;
 	node.control = IWN_NODE_UPDATE;
 	node.flags = IWN_FLAG_SET_DELBA;
@@ -6209,7 +6210,7 @@ iwn_ampdu_tx_start(struct ieee80211com *ic, struct ieee80211_node *ni,
 
 	/* Enable TX for the specified RA/TID. */
 	wn->disable_tid &= ~(1 << tid);
-	memset(&node, 0, sizeof node);
+	(void) memset(&node, 0, sizeof node);
 	node.id = wn->id;
 	node.control = IWN_NODE_UPDATE;
 	node.flags = IWN_FLAG_SET_DISABLE_TID;
@@ -6373,7 +6374,7 @@ iwn5000_query_calibration(struct iwn_softc *sc)
 
 	ASSERT(mutex_owned(&sc->sc_mtx));
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.ucode.once.enable = 0xffffffff;
 	cmd.ucode.once.start  = 0xffffffff;
 	cmd.ucode.once.send   = 0xffffffff;
@@ -6427,14 +6428,14 @@ iwn5000_send_wimax_coex(struct iwn_softc *sc)
 		    IWN_WIMAX_COEX_UNASSOC_WA_UNMASK |
 		    IWN_WIMAX_COEX_STA_TABLE_VALID |
 		    IWN_WIMAX_COEX_ENABLE;
-		memcpy(wimax.events, iwn6050_wimax_events,
+		(void) memcpy(wimax.events, iwn6050_wimax_events,
 		    sizeof iwn6050_wimax_events);
 	} else
 #endif
 	{
 		/* Disable WiMAX coexistence. */
 		wimax.flags = 0;
-		memset(wimax.events, 0, sizeof wimax.events);
+		(void) memset(wimax.events, 0, sizeof wimax.events);
 	}
 	return iwn_cmd(sc, IWN5000_CMD_WIMAX_COEX, &wimax, sizeof wimax, 0);
 }
@@ -6444,7 +6445,7 @@ iwn6000_temp_offset_calib(struct iwn_softc *sc)
 {
 	struct iwn6000_phy_calib_temp_offset cmd;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = IWN6000_PHY_CALIB_TEMP_OFFSET;
 	cmd.ngroups = 1;
 	cmd.isvalid = 1;
@@ -6461,7 +6462,7 @@ iwn2000_temp_offset_calib(struct iwn_softc *sc)
 {
 	struct iwn2000_phy_calib_temp_offset cmd;
 
-	memset(&cmd, 0, sizeof cmd);
+	(void) memset(&cmd, 0, sizeof cmd);
 	cmd.code = IWN2000_PHY_CALIB_TEMP_OFFSET;
 	cmd.ngroups = 1;
 	cmd.isvalid = 1;
@@ -6598,7 +6599,7 @@ iwn5000_post_alive(struct iwn_softc *sc)
 		struct iwn5000_phy_calib_crystal cmd;
 
 		/* Perform crystal calibration. */
-		memset(&cmd, 0, sizeof cmd);
+		(void) memset(&cmd, 0, sizeof cmd);
 		cmd.code = IWN5000_PHY_CALIB_CRYSTAL;
 		cmd.ngroups = 1;
 		cmd.isvalid = 1;
@@ -6689,8 +6690,8 @@ iwn4965_load_firmware(struct iwn_softc *sc)
 	ASSERT(mutex_owned(&sc->sc_mtx));
 
 	/* Copy initialization sections into pre-allocated DMA-safe memory. */
-	memcpy(dma->vaddr, fw->init.data, fw->init.datasz);
-	memcpy((char *)dma->vaddr + IWN4965_FW_DATA_MAXSZ,
+	(void) memcpy(dma->vaddr, fw->init.data, fw->init.datasz);
+	(void) memcpy((char *)dma->vaddr + IWN4965_FW_DATA_MAXSZ,
 	    fw->init.text, fw->init.textsz);
 	(void) ddi_dma_sync(dma->dma_hdl, 0, 0, DDI_DMA_SYNC_FORDEV);
 
@@ -6730,8 +6731,8 @@ iwn4965_load_firmware(struct iwn_softc *sc)
 	sc->sc_misc->temp.value.ul = sc->temp;
 
 	/* Copy runtime sections into pre-allocated DMA-safe memory. */
-	memcpy(dma->vaddr, fw->main.data, fw->main.datasz);
-	memcpy((char *)dma->vaddr + IWN4965_FW_DATA_MAXSZ,
+	(void) memcpy(dma->vaddr, fw->main.data, fw->main.datasz);
+	(void) memcpy((char *)dma->vaddr + IWN4965_FW_DATA_MAXSZ,
 	    fw->main.text, fw->main.textsz);
 	(void) ddi_dma_sync(dma->dma_hdl, 0, 0, DDI_DMA_SYNC_FORDEV);
 
@@ -6760,7 +6761,7 @@ iwn5000_load_firmware_section(struct iwn_softc *sc, uint32_t dst,
 	ASSERT(mutex_owned(&sc->sc_mtx));
 
 	/* Copy firmware section into pre-allocated DMA-safe memory. */
-	memcpy(dma->vaddr, section, size);
+	(void) memcpy(dma->vaddr, section, size);
 	(void) ddi_dma_sync(dma->dma_hdl, 0, 0, DDI_DMA_SYNC_FORDEV);
 
 	if ((error = iwn_nic_lock(sc)) != 0)

--- a/usr/src/uts/common/io/sata/impl/sata.c
+++ b/usr/src/uts/common/io/sata/impl/sata.c
@@ -23,7 +23,7 @@
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Argo Technologies SA
  */
 
@@ -4845,7 +4845,7 @@ sata_txlt_unmap(sata_pkt_txlate_t *spx)
 	bdlen = scsipkt->pkt_cdbp[7];
 	bdlen = (bdlen << 8) + scsipkt->pkt_cdbp[8] - paramlen;
 	if ((bdlen < 0) || ((bdlen % 16) != 0) ||
-	    (bdlen > (bp->b_bcount - paramlen))) {
+	    ((bp != NULL) && (bdlen > (bp->b_bcount - paramlen)))) {
 		SATADBG1(SATA_DBG_SCSI_IF, spx->txlt_sata_hba_inst,
 		    "sata_txlt_unmap: invalid block descriptor length", NULL);
 		mutex_exit(cport_mutex);

--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -52,6 +52,7 @@
 #include <sys/efi_partition.h>
 #include <sys/var.h>
 #include <sys/aio_req.h>
+#include <sys/dkioc_free_util.h>
 
 #ifdef __lock_lint
 #define	_LP64
@@ -1151,6 +1152,24 @@ static int sd_pm_idletime = 1;
 
 #endif	/* #if (defined(__fibre)) */
 
+typedef struct unmap_param_hdr_s {
+	uint16_t	uph_data_len;
+	uint16_t	uph_descr_data_len;
+	uint32_t	uph_reserved;
+} unmap_param_hdr_t;
+
+typedef struct unmap_blk_descr_s {
+	uint64_t	ubd_lba;
+	uint32_t	ubd_lba_cnt;
+	uint32_t	ubd_reserved;
+} unmap_blk_descr_t;
+
+/* Max number of block descriptors in UNMAP command */
+#define	SD_UNMAP_MAX_DESCR \
+	((UINT16_MAX - sizeof (unmap_param_hdr_t)) / sizeof (unmap_blk_descr_t))
+/* Max size of the UNMAP parameter list in bytes */
+#define	SD_UNMAP_PARAM_LIST_MAXSZ	(sizeof (unmap_param_hdr_t) + \
+	SD_UNMAP_MAX_DESCR * sizeof (unmap_blk_descr_t))
 
 int _init(void);
 int _fini(void);
@@ -1533,6 +1552,8 @@ static int sd_send_scsi_PERSISTENT_RESERVE_OUT(sd_ssc_t *ssc,
 static int sd_send_scsi_SYNCHRONIZE_CACHE(struct sd_lun *un,
 	struct dk_callback *dkc);
 static int sd_send_scsi_SYNCHRONIZE_CACHE_biodone(struct buf *bp);
+static int sd_send_scsi_UNMAP(dev_t dev, sd_ssc_t *ssc, dkioc_free_list_t *dfl,
+	int flag);
 static int sd_send_scsi_GET_CONFIGURATION(sd_ssc_t *ssc,
 	struct uscsi_cmd *ucmdbuf, uchar_t *rqbuf, uint_t rqbuflen,
 	uchar_t *bufaddr, uint_t buflen, int path_flag);
@@ -5336,6 +5357,86 @@ sd_update_block_info(struct sd_lun *un, uint32_t lbasize, uint64_t capacity)
 	}
 }
 
+/*
+ * Parses the SCSI Block Limits VPD page (0xB0). It's legal to pass NULL for
+ * vpd_pg, in which case all the block limits will be reset to the defaults.
+ */
+static void
+sd_parse_blk_limits_vpd(struct sd_lun *un, uchar_t *vpd_pg)
+{
+	sd_blk_limits_t *lim = &un->un_blk_lim;
+	unsigned pg_len;
+
+	if (vpd_pg != NULL)
+		pg_len = BE_IN16(&vpd_pg[2]);
+	else
+		pg_len = 0;
+
+	/* Block Limits VPD can be 16 bytes or 64 bytes long - support both */
+	if (pg_len >= 0x10) {
+		lim->lim_opt_xfer_len_gran = BE_IN16(&vpd_pg[6]);
+		lim->lim_max_xfer_len = BE_IN32(&vpd_pg[8]);
+		lim->lim_opt_xfer_len = BE_IN32(&vpd_pg[12]);
+	} else {
+		lim->lim_opt_xfer_len_gran = 0;
+		lim->lim_max_xfer_len = UINT32_MAX;
+		lim->lim_opt_xfer_len = UINT32_MAX;
+	}
+	if (pg_len >= 0x3c) {
+		lim->lim_max_pfetch_len = BE_IN32(&vpd_pg[16]);
+		/*
+		 * A zero in either of the following two fields indicates lack
+		 * of UNMAP support.
+		 */
+		lim->lim_max_unmap_lba_cnt = BE_IN32(&vpd_pg[20]);
+		lim->lim_max_unmap_descr_cnt = BE_IN32(&vpd_pg[24]);
+		lim->lim_opt_unmap_gran = BE_IN32(&vpd_pg[28]);
+		if ((vpd_pg[32] >> 7) == 1) {
+			/* left-most bit on each byte is a flag */
+			lim->lim_unmap_gran_align =
+			    ((vpd_pg[32] & 0x7f) << 24) | (vpd_pg[33] << 16) |
+			    (vpd_pg[34] << 8) | vpd_pg[35];
+		} else {
+			lim->lim_unmap_gran_align = 0;
+		}
+		lim->lim_max_write_same_len = BE_IN64(&vpd_pg[36]);
+	} else {
+		lim->lim_max_pfetch_len = UINT32_MAX;
+		lim->lim_max_unmap_lba_cnt = UINT32_MAX;
+		lim->lim_max_unmap_descr_cnt = SD_UNMAP_MAX_DESCR;
+		lim->lim_opt_unmap_gran = 0;
+		lim->lim_unmap_gran_align = 0;
+		lim->lim_max_write_same_len = UINT64_MAX;
+	}
+}
+
+/*
+ * Collects VPD page B0 data if available (block limits). If the data is
+ * not available or querying the device failed, we revert to the defaults.
+ */
+static void
+sd_setup_blk_limits(sd_ssc_t *ssc)
+{
+	struct sd_lun	*un		= ssc->ssc_un;
+	uchar_t		*inqB0		= NULL;
+	size_t		inqB0_resid	= 0;
+	int		rval;
+
+	if (un->un_vpd_page_mask & SD_VPD_BLK_LIMITS_PG) {
+		inqB0 = kmem_zalloc(MAX_INQUIRY_SIZE, KM_SLEEP);
+		rval = sd_send_scsi_INQUIRY(ssc, inqB0, MAX_INQUIRY_SIZE, 0x01,
+		    0xB0, &inqB0_resid);
+		if (rval != 0) {
+			sd_ssc_assessment(ssc, SD_FMT_IGNORE);
+			kmem_free(inqB0, MAX_INQUIRY_SIZE);
+			inqB0 = NULL;
+		}
+	}
+	/* passing NULL inqB0 will reset to defaults */
+	sd_parse_blk_limits_vpd(ssc->ssc_un, inqB0);
+	if (inqB0)
+		kmem_free(inqB0, MAX_INQUIRY_SIZE);
+}
 
 /*
  *    Function: sd_register_devid
@@ -5864,6 +5965,9 @@ sd_check_vpd_page_support(sd_ssc_t *ssc)
 				break;
 			case 0x86:
 				un->un_vpd_page_mask |= SD_VPD_EXTENDED_DATA_PG;
+				break;
+			case 0xB0:
+				un->un_vpd_page_mask |= SD_VPD_BLK_LIMITS_PG;
 				break;
 			case 0xB1:
 				un->un_vpd_page_mask |= SD_VPD_DEV_CHARACTER_PG;
@@ -7756,6 +7860,27 @@ sd_unit_attach(dev_info_t *devi)
 	SD_TRACE(SD_LOG_ATTACH_DETACH, un,
 	    "sd_unit_attach: un:0x%p un_stats created\n", un);
 
+	un->un_unmapstats_ks = kstat_create(sd_label, instance, "unmapstats",
+	    "misc", KSTAT_TYPE_NAMED, sizeof (*un->un_unmapstats) /
+	    sizeof (kstat_named_t), 0);
+	if (un->un_unmapstats_ks) {
+		un->un_unmapstats = un->un_unmapstats_ks->ks_data;
+
+		kstat_named_init(&un->un_unmapstats->us_cmds,
+		    "commands", KSTAT_DATA_UINT64);
+		kstat_named_init(&un->un_unmapstats->us_errs,
+		    "errors", KSTAT_DATA_UINT64);
+		kstat_named_init(&un->un_unmapstats->us_extents,
+		    "extents", KSTAT_DATA_UINT64);
+		kstat_named_init(&un->un_unmapstats->us_bytes,
+		    "bytes", KSTAT_DATA_UINT64);
+
+		kstat_install(un->un_unmapstats_ks);
+	} else {
+		cmn_err(CE_NOTE, "!Cannot create unmap kstats for disk %d",
+		    instance);
+	}
+
 	sd_create_errstats(un, instance);
 	if (un->un_errstats == NULL) {
 		goto create_errstats_failed;
@@ -8393,6 +8518,7 @@ sd_unit_attach(dev_info_t *devi)
 	SD_TRACE(SD_LOG_ATTACH_DETACH, un,
 	    "sd_unit_attach: un:0x%p errstats set\n", un);
 
+	sd_setup_blk_limits(ssc);
 
 	/*
 	 * After successfully attaching an instance, we record the information
@@ -8967,6 +9093,11 @@ sd_unit_detach(dev_info_t *devi)
 	if (un->un_stats != NULL) {
 		kstat_delete(un->un_stats);
 		un->un_stats = NULL;
+	}
+	if (un->un_unmapstats != NULL) {
+		kstat_delete(un->un_unmapstats_ks);
+		un->un_unmapstats_ks = NULL;
+		un->un_unmapstats = NULL;
 	}
 	if (un->un_errstats != NULL) {
 		kstat_delete(un->un_errstats);
@@ -20340,10 +20471,20 @@ sd_send_scsi_READ_CAPACITY_16(sd_ssc_t *ssc, uint64_t *capp, uint32_t *lbap,
 		 *		(MSB in byte:8 & LSB in byte:11)
 		 *
 		 *  byte 13: LOGICAL BLOCKS PER PHYSICAL BLOCK EXPONENT
+		 *
+		 *  byte 14:
+		 *	bit 7: Thin-Provisioning Enabled
+		 *	bit 6: Thin-Provisioning Read Zeros
 		 */
 		capacity = BE_64(capacity16_buf[0]);
 		lbasize = BE_32(*(uint32_t *)&capacity16_buf[1]);
 		lbpb_exp = (BE_64(capacity16_buf[1]) >> 16) & 0x0f;
+
+		un->un_thin_flags = 0;
+		if (((uint8_t *)capacity16_buf)[14] & (1 << 7))
+			un->un_thin_flags |= SD_THIN_PROV_ENABLED;
+		if (((uint8_t *)capacity16_buf)[14] & (1 << 6))
+			un->un_thin_flags |= SD_THIN_PROV_READ_ZEROS;
 
 		pbsize = lbasize << lbpb_exp;
 
@@ -21399,6 +21540,229 @@ done:
 	return (status);
 }
 
+/*
+ * Issues a single SCSI UNMAP command with a prepared UNMAP parameter list.
+ * Returns zero on success, or the non-zero command error code on failure.
+ */
+static int
+sd_send_scsi_UNMAP_issue_one(sd_ssc_t *ssc, unmap_param_hdr_t *uph,
+    uint64_t num_descr, uint64_t bytes)
+{
+	struct sd_lun		*un = ssc->ssc_un;
+	struct scsi_extended_sense	sense_buf;
+	union scsi_cdb		cdb;
+	struct uscsi_cmd	ucmd_buf;
+	int			status;
+	const uint64_t		param_size = sizeof (unmap_param_hdr_t) +
+	    num_descr * sizeof (unmap_blk_descr_t);
+
+	uph->uph_data_len = BE_16(param_size - 2);
+	uph->uph_descr_data_len = BE_16(param_size - 8);
+
+	bzero(&cdb, sizeof (cdb));
+	bzero(&ucmd_buf, sizeof (ucmd_buf));
+	bzero(&sense_buf, sizeof (struct scsi_extended_sense));
+
+	cdb.scc_cmd = SCMD_UNMAP;
+	FORMG1COUNT(&cdb, param_size);
+
+	ucmd_buf.uscsi_cdb	= (char *)&cdb;
+	ucmd_buf.uscsi_cdblen	= (uchar_t)CDB_GROUP1;
+	ucmd_buf.uscsi_bufaddr	= (caddr_t)uph;
+	ucmd_buf.uscsi_buflen	= param_size;
+	ucmd_buf.uscsi_rqbuf	= (caddr_t)&sense_buf;
+	ucmd_buf.uscsi_rqlen	= sizeof (struct scsi_extended_sense);
+	ucmd_buf.uscsi_flags	= USCSI_WRITE | USCSI_RQENABLE | USCSI_SILENT;
+	ucmd_buf.uscsi_timeout	= un->un_cmd_timeout;
+
+	status = sd_ssc_send(ssc, &ucmd_buf, FKIOCTL, UIO_SYSSPACE,
+	    SD_PATH_STANDARD);
+
+	switch (status) {
+	case 0:
+		sd_ssc_assessment(ssc, SD_FMT_STANDARD);
+
+		if (un->un_unmapstats) {
+			atomic_inc_64(&un->un_unmapstats->us_cmds.value.ui64);
+			atomic_add_64(&un->un_unmapstats->us_extents.value.ui64,
+			    num_descr);
+			atomic_add_64(&un->un_unmapstats->us_bytes.value.ui64,
+			    bytes);
+		}
+		break;	/* Success! */
+	case EIO:
+		if (un->un_unmapstats)
+			atomic_inc_64(&un->un_unmapstats->us_errs.value.ui64);
+		switch (ucmd_buf.uscsi_status) {
+		case STATUS_RESERVATION_CONFLICT:
+			status = EACCES;
+			break;
+		default:
+			break;
+		}
+		break;
+	default:
+		if (un->un_unmapstats)
+			atomic_inc_64(&un->un_unmapstats->us_errs.value.ui64);
+		break;
+	}
+
+	return (status);
+}
+
+/*
+ * Returns a pointer to the i'th block descriptor inside an UNMAP param list.
+ */
+static inline unmap_blk_descr_t *
+UNMAP_blk_descr_i(void *buf, uint64_t i)
+{
+	return ((unmap_blk_descr_t *)((uint8_t *)buf +
+	    sizeof (unmap_param_hdr_t) + (i * sizeof (unmap_blk_descr_t))));
+}
+
+/*
+ * Takes the list of extents from sd_send_scsi_UNMAP, chops it up, prepares
+ * UNMAP block descriptors and issues individual SCSI UNMAP commands. While
+ * doing so we consult the block limits to determine at most how many
+ * extents and LBAs we can UNMAP in one command.
+ * If a command fails for whatever, reason, extent list processing is aborted
+ * and the failed command's status is returned. Otherwise returns 0 on
+ * success.
+ */
+static int
+sd_send_scsi_UNMAP_issue(dev_t dev, sd_ssc_t *ssc, const dkioc_free_list_t *dfl)
+{
+	struct sd_lun		*un = ssc->ssc_un;
+	unmap_param_hdr_t	*uph;
+	sd_blk_limits_t		*lim = &un->un_blk_lim;
+	int			rval = 0;
+	int			partition;
+	/* partition offset & length in system blocks */
+	diskaddr_t		part_off_sysblks = 0, part_len_sysblks = 0;
+	uint64_t		part_off, part_len;
+	uint64_t		descr_cnt_lim, byte_cnt_lim;
+	uint64_t		descr_issued = 0, bytes_issued = 0;
+
+	uph = kmem_zalloc(SD_UNMAP_PARAM_LIST_MAXSZ, KM_SLEEP);
+
+	partition = SDPART(dev);
+	(void) cmlb_partinfo(un->un_cmlbhandle, partition, &part_len_sysblks,
+	    &part_off_sysblks, NULL, NULL, (void *)SD_PATH_DIRECT);
+	part_off = SD_SYSBLOCKS2BYTES(part_off_sysblks);
+	part_len = SD_SYSBLOCKS2BYTES(part_len_sysblks);
+
+	ASSERT(un->un_blk_lim.lim_max_unmap_lba_cnt != 0);
+	ASSERT(un->un_blk_lim.lim_max_unmap_descr_cnt != 0);
+	/* Spec says 0xffffffff are special values, so compute maximums. */
+	byte_cnt_lim = lim->lim_max_unmap_lba_cnt < UINT32_MAX ?
+	    (uint64_t)lim->lim_max_unmap_lba_cnt * un->un_tgt_blocksize :
+	    UINT64_MAX;
+	descr_cnt_lim = MIN(lim->lim_max_unmap_descr_cnt, SD_UNMAP_MAX_DESCR);
+
+	for (size_t i = 0; i < dfl->dfl_num_exts; i++) {
+		const dkioc_free_list_ext_t *ext = &dfl->dfl_exts[i];
+		uint64_t ext_start = ext->dfle_start;
+		uint64_t ext_length = ext->dfle_length;
+
+		while (ext_length > 0) {
+			unmap_blk_descr_t *ubd;
+			/* Respect device limit on LBA count per command */
+			uint64_t len = MIN(MIN(ext_length, byte_cnt_lim -
+			    bytes_issued), SD_TGTBLOCKS2BYTES(un, UINT32_MAX));
+
+			/* check partition limits */
+			if (ext_start + len > part_len) {
+				rval = SET_ERROR(EINVAL);
+				goto out;
+			}
+#ifdef	DEBUG
+			if (dfl->dfl_ck_func)
+				dfl->dfl_ck_func(dfl->dfl_offset + ext_start,
+				    len, dfl->dfl_ck_arg);
+#endif
+			ASSERT3U(descr_issued, <, descr_cnt_lim);
+			ASSERT3U(bytes_issued, <, byte_cnt_lim);
+			ubd = UNMAP_blk_descr_i(uph, descr_issued);
+
+			/* adjust in-partition addresses to be device-global */
+			ubd->ubd_lba = BE_64(SD_BYTES2TGTBLOCKS(un,
+			    dfl->dfl_offset + ext_start + part_off));
+			ubd->ubd_lba_cnt = BE_32(SD_BYTES2TGTBLOCKS(un, len));
+
+			descr_issued++;
+			bytes_issued += len;
+
+			/* Issue command when device limits reached */
+			if (descr_issued == descr_cnt_lim ||
+			    bytes_issued == byte_cnt_lim) {
+				rval = sd_send_scsi_UNMAP_issue_one(ssc, uph,
+				    descr_issued, bytes_issued);
+				if (rval != 0)
+					goto out;
+				descr_issued = 0;
+				bytes_issued = 0;
+			}
+
+			ext_start += len;
+			ext_length -= len;
+		}
+	}
+
+	if (descr_issued > 0) {
+		/* issue last command */
+		rval = sd_send_scsi_UNMAP_issue_one(ssc, uph, descr_issued,
+		    bytes_issued);
+	}
+
+out:
+	kmem_free(uph, SD_UNMAP_PARAM_LIST_MAXSZ);
+	return (rval);
+}
+
+/*
+ * Issues one or several UNMAP commands based on a list of extents to be
+ * unmapped. The internal multi-command processing is hidden, as the exact
+ * number of commands and extents per command is limited by both SCSI
+ * command syntax and device limits (as expressed in the SCSI Block Limits
+ * VPD page and un_blk_lim in struct sd_lun).
+ * Returns zero on success, or the error code of the first failed SCSI UNMAP
+ * command.
+ */
+static int
+sd_send_scsi_UNMAP(dev_t dev, sd_ssc_t *ssc, dkioc_free_list_t *dfl, int flag)
+{
+	struct sd_lun		*un = ssc->ssc_un;
+	int			rval = 0;
+
+	ASSERT(!mutex_owned(SD_MUTEX(un)));
+	ASSERT(dfl != NULL);
+
+	/* Per spec, any of these conditions signals lack of UNMAP support. */
+	if (!(un->un_thin_flags & SD_THIN_PROV_ENABLED) ||
+	    un->un_blk_lim.lim_max_unmap_descr_cnt == 0 ||
+	    un->un_blk_lim.lim_max_unmap_lba_cnt == 0) {
+		return (SET_ERROR(ENOTSUP));
+	}
+
+	/* For userspace calls we must copy in. */
+	if (!(flag & FKIOCTL)) {
+		int err = dfl_copyin(dfl, &dfl, flag, KM_SLEEP);
+		if (err != 0)
+			return (err);
+	} else if (dfl->dfl_num_exts > DFL_COPYIN_MAX_EXTS) {
+		ASSERT3U(dfl->dfl_num_exts, <=, DFL_COPYIN_MAX_EXTS);
+		return (SET_ERROR(EINVAL));
+	}
+
+	rval = sd_send_scsi_UNMAP_issue(dev, ssc, dfl);
+
+	if (!(flag & FKIOCTL)) {
+		dfl_free(dfl);
+		dfl = NULL;
+	}
+
+	return (rval);
+}
 
 /*
  *    Function: sd_send_scsi_GET_CONFIGURATION
@@ -23133,6 +23497,22 @@ skip_ready_valid:
 				/* synchronous SYNC CACHE request */
 				err = sd_send_scsi_SYNCHRONIZE_CACHE(un, NULL);
 			}
+		}
+		break;
+
+	case DKIOCFREE:
+		{
+			dkioc_free_list_t *dfl = (dkioc_free_list_t *)arg;
+
+			/* bad ioctls shouldn't panic */
+			if (dfl == NULL) {
+				/* check kernel callers strictly in debug */
+				ASSERT0(flag & FKIOCTL);
+				err = SET_ERROR(EINVAL);
+				break;
+			}
+			/* synchronous UNMAP request */
+			err = sd_send_scsi_UNMAP(dev, ssc, dfl, flag);
 		}
 		break;
 

--- a/usr/src/uts/common/os/dkioc_free_util.c
+++ b/usr/src/uts/common/os/dkioc_free_util.c
@@ -1,0 +1,82 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Nexenta Inc.  All rights reserved.
+ */
+
+/* needed when building libzpool */
+#ifndef	_KERNEL
+#include <sys/zfs_context.h>
+#endif
+
+#include <sys/sunddi.h>
+#include <sys/dkio.h>
+#include <sys/dkioc_free_util.h>
+#include <sys/sysmacros.h>
+#include <sys/file.h>
+#include <sys/sdt.h>
+
+/*
+ * Copy-in convenience function for variable-length dkioc_free_list_t
+ * structures. The pointer to be copied from is in `arg' (may be a pointer
+ * to userspace). A new buffer is allocated and a pointer to it is placed
+ * in `out'. `ddi_flags' indicates whether the pointer is from user-
+ * or kernelspace (FKIOCTL) and `kmflags' are the flags passed to
+ * kmem_zalloc when allocating the new structure.
+ * Returns 0 on success, or an errno on failure.
+ */
+int
+dfl_copyin(void *arg, dkioc_free_list_t **out, int ddi_flags, int kmflags)
+{
+	dkioc_free_list_t *dfl;
+
+	if (ddi_flags & FKIOCTL) {
+		dkioc_free_list_t *dfl_in = arg;
+
+		if (dfl_in->dfl_num_exts > DFL_COPYIN_MAX_EXTS)
+			return (SET_ERROR(EINVAL));
+		dfl = kmem_zalloc(DFL_SZ(dfl_in->dfl_num_exts), kmflags);
+		if (dfl == NULL)
+			return (SET_ERROR(ENOMEM));
+		bcopy(dfl_in, dfl, DFL_SZ(dfl_in->dfl_num_exts));
+	} else {
+		uint64_t num_exts;
+
+		if (ddi_copyin(((uint8_t *)arg) + offsetof(dkioc_free_list_t,
+		    dfl_num_exts), &num_exts, sizeof (num_exts),
+		    ddi_flags) != 0)
+			return (SET_ERROR(EFAULT));
+		if (num_exts > DFL_COPYIN_MAX_EXTS)
+			return (SET_ERROR(EINVAL));
+		dfl = kmem_zalloc(DFL_SZ(num_exts), kmflags);
+		if (dfl == NULL)
+			return (SET_ERROR(ENOMEM));
+		if (ddi_copyin(arg, dfl, DFL_SZ(num_exts), ddi_flags)) {
+			dfl_free(dfl);
+			return (SET_ERROR(EFAULT));
+		}
+
+		/* not valid from userspace */
+		dfl->dfl_ck_func = NULL;
+		dfl->dfl_ck_arg = NULL;
+	}
+
+	*out = dfl;
+	return (0);
+}
+
+/* Frees a variable-length dkioc_free_list_t structure. */
+void
+dfl_free(dkioc_free_list_t *dfl)
+{
+	kmem_free(dfl, DFL_SZ(dfl->dfl_num_exts));
+}

--- a/usr/src/uts/common/sys/Makefile
+++ b/usr/src/uts/common/sys/Makefile
@@ -25,7 +25,7 @@
 # Copyright 2013 Garrett D'Amore <garrett@damore.org>
 # Copyright 2013 Saso Kiselkov. All rights reserved.
 # Copyright 2015 Igor Kozhukhov <ikozhukhov@gmail.com>
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2017 Nexenta Systems, Inc.
 # Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 #
 
@@ -186,6 +186,7 @@ CHKHDRS=			\
 	disp.h			\
 	dkbad.h			\
 	dkio.h			\
+	dkioc_free_util.h	\
 	dklabel.h		\
 	dl.h			\
 	dlpi.h			\

--- a/usr/src/uts/common/sys/dkio.h
+++ b/usr/src/uts/common/sys/dkio.h
@@ -30,7 +30,6 @@
 #define	_SYS_DKIO_H
 
 #include <sys/dklabel.h>	/* Needed for NDKMAP define */
-#include <sys/int_limits.h>	/* Needed for UINT16_MAX */
 
 #ifdef	__cplusplus
 extern "C" {
@@ -537,7 +536,7 @@ typedef struct dkioc_free_list_ext_s {
 typedef struct dkioc_free_list_s {
 	uint64_t		dfl_flags;
 	uint64_t		dfl_num_exts;
-	int64_t			dfl_offset;
+	uint64_t		dfl_offset;
 
 	/*
 	 * N.B. this is only an internal debugging API! This is only called

--- a/usr/src/uts/common/sys/dkio.h
+++ b/usr/src/uts/common/sys/dkio.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 1982, 2010, Oracle and/or its affiliates. All rights reserved.
  *
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
  */
 
@@ -30,6 +30,7 @@
 #define	_SYS_DKIO_H
 
 #include <sys/dklabel.h>	/* Needed for NDKMAP define */
+#include <sys/int_limits.h>	/* Needed for UINT16_MAX */
 
 #ifdef	__cplusplus
 extern "C" {
@@ -523,17 +524,36 @@ typedef struct dk_updatefw_32 {
 
 /*
  * ioctl to free space (e.g. SCSI UNMAP) off a disk.
+ * Pass a dkioc_free_list_t containing a list of extents to be freed.
  */
 #define	DKIOCFREE	(DKIOC|50)
 
-typedef struct dkioc_free_s {
-	uint32_t df_flags;
-	uint32_t df_reserved;   /* For easy 64-bit alignment below... */
-	diskaddr_t df_start;
-	diskaddr_t df_length;
-} dkioc_free_t;
-
 #define	DF_WAIT_SYNC	0x00000001	/* Wait for full write-out of free. */
+typedef struct dkioc_free_list_ext_s {
+	uint64_t		dfle_start;
+	uint64_t		dfle_length;
+} dkioc_free_list_ext_t;
+
+typedef struct dkioc_free_list_s {
+	uint64_t		dfl_flags;
+	uint64_t		dfl_num_exts;
+	int64_t			dfl_offset;
+
+	/*
+	 * N.B. this is only an internal debugging API! This is only called
+	 * from debug builds of sd for integrity self-checking. The reason it
+	 * isn't #ifdef DEBUG is because that breaks ABI compatibility when
+	 * mixing DEBUG and non-DEBUG kernel modules and the cost of having
+	 * a couple unused pointers is too low to justify that risk.
+	 */
+	void			(*dfl_ck_func)(uint64_t, uint64_t, void *);
+	void			*dfl_ck_arg;
+
+	dkioc_free_list_ext_t	dfl_exts[1];
+} dkioc_free_list_t;
+#define	DFL_SZ(num_exts) \
+	(sizeof (dkioc_free_list_t) + \
+	(num_exts - 1) * sizeof (dkioc_free_list_ext_t))
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/common/sys/dkioc_free_util.h
+++ b/usr/src/uts/common/sys/dkioc_free_util.h
@@ -1,0 +1,34 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2017 Nexenta Inc.  All rights reserved.
+ */
+
+#ifndef _SYS_DKIOC_FREE_UTIL_H
+#define	_SYS_DKIOC_FREE_UTIL_H
+
+#include <sys/dkio.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#define	DFL_COPYIN_MAX_EXTS	(1024 * 1024)
+
+int dfl_copyin(void *arg, dkioc_free_list_t **out, int ddi_flags, int kmflags);
+void dfl_free(dkioc_free_list_t *dfl);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif /* _SYS_DKIOC_FREE_UTIL_H */

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, 2014 by Delphix. All rights reserved.
- * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  */
@@ -204,6 +204,8 @@ typedef enum {
 	ZPOOL_PROP_FRAGMENTATION,
 	ZPOOL_PROP_LEAKED,
 	ZPOOL_PROP_MAXBLOCKSIZE,
+	ZPOOL_PROP_FORCETRIM,
+	ZPOOL_PROP_AUTOTRIM,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -574,6 +576,10 @@ typedef struct zpool_rewind_policy {
 #define	ZPOOL_CONFIG_REMOVED		"removed"
 #define	ZPOOL_CONFIG_FRU		"fru"
 #define	ZPOOL_CONFIG_AUX_STATE		"aux_state"
+#define	ZPOOL_CONFIG_TRIM_PROG		"trim_prog"
+#define	ZPOOL_CONFIG_TRIM_RATE		"trim_rate"
+#define	ZPOOL_CONFIG_TRIM_START_TIME	"trim_start_time"
+#define	ZPOOL_CONFIG_TRIM_STOP_TIME	"trim_stop_time"
 
 /* Rewind policy parameters */
 #define	ZPOOL_REWIND_POLICY		"rewind-policy"
@@ -685,6 +691,14 @@ typedef enum pool_scan_func {
 	POOL_SCAN_RESILVER,
 	POOL_SCAN_FUNCS
 } pool_scan_func_t;
+
+/*
+ * TRIM command configuration info.
+ */
+typedef struct trim_cmd_info_s {
+	uint64_t	tci_start;	/* B_TRUE = start; B_FALSE = stop */
+	uint64_t	tci_rate;	/* requested TRIM rate in bytes/sec */
+} trim_cmd_info_t;
 
 /*
  * ZIO types.  Needed to interpret vdev statistics below.
@@ -873,6 +887,7 @@ typedef enum zfs_ioc {
 	ZFS_IOC_BOOKMARK,
 	ZFS_IOC_GET_BOOKMARKS,
 	ZFS_IOC_DESTROY_BOOKMARKS,
+	ZFS_IOC_POOL_TRIM,
 	ZFS_IOC_LAST
 } zfs_ioc_t;
 

--- a/usr/src/uts/common/sys/scsi/targets/sddef.h
+++ b/usr/src/uts/common/sys/scsi/targets/sddef.h
@@ -23,7 +23,7 @@
  */
 /*
  * Copyright 2011 cyril.galibern@opensvc.com
- * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  */
 
 #ifndef	_SYS_SCSI_TARGETS_SDDEF_H
@@ -215,6 +215,35 @@ struct sd_mapblocksize_info {
 _NOTE(SCHEME_PROTECTS_DATA("unshared data", sd_mapblocksize_info))
 
 
+/* Thin-provisioning (UNMAP) flags for un_thin_flags. */
+enum {
+	SD_THIN_PROV_ENABLED =		1 << 0,	/* UNMAP available */
+	SD_THIN_PROV_READ_ZEROS =	1 << 1	/* unmapped blk = zeros */
+};
+
+/*
+ * Device limits as read from the Block Limits VPD page (0xB0). If the page
+ * is unavailable, will be filled with some defaults.
+ */
+typedef struct sd_blk_limits_s {
+	uint16_t	lim_opt_xfer_len_gran;
+	uint32_t	lim_max_xfer_len;
+	uint32_t	lim_opt_xfer_len;
+	uint32_t	lim_max_pfetch_len;
+	uint32_t	lim_max_unmap_lba_cnt;
+	uint32_t	lim_max_unmap_descr_cnt;
+	uint32_t	lim_opt_unmap_gran;
+	uint32_t	lim_unmap_gran_align;
+	uint64_t	lim_max_write_same_len;
+} sd_blk_limits_t;
+
+typedef struct sd_unmapstats {
+	kstat_named_t	us_cmds;
+	kstat_named_t	us_errs;
+	kstat_named_t	us_extents;
+	kstat_named_t	us_bytes;
+} sd_unmapstats_t;
+
 /*
  * sd_lun: The main data structure for a scsi logical unit.
  * Stored as the softstate structure for each device.
@@ -356,6 +385,8 @@ struct sd_lun {
 	union	ocmap	un_ocmap;		/* open partition map */
 	struct	kstat	*un_pstats[NSDMAP];	/* partition statistics */
 	struct	kstat	*un_stats;		/* disk statistics */
+	sd_unmapstats_t	*un_unmapstats;		/* UNMAP stats structure */
+	struct	kstat	*un_unmapstats_ks;	/* UNMAP kstat */
 	kstat_t		*un_errstats;		/* for error statistics */
 	uint64_t	un_exclopen;		/* exclusive open bitmask */
 	ddi_devid_t	un_devid;		/* device id */
@@ -507,6 +538,12 @@ struct sd_lun {
 	struct sd_w_map	*un_wm;		/* head of sd_w_map chain */
 	uint64_t	un_rmw_incre_count;	/* count I/O */
 	timeout_id_t	un_rmw_msg_timeid;	/* for RMW message control */
+
+	/* Thin provisioning support (see SD_THIN_PROV_*) */
+	uint64_t	un_thin_flags;
+
+	/* Block limits (0xB0 VPD page) */
+	sd_blk_limits_t	un_blk_lim;
 
 	/* For timeout callback to issue a START STOP UNIT command */
 	timeout_id_t	un_startstop_timeid;
@@ -2381,7 +2418,8 @@ typedef struct disk_power_attr_pc {
 #define	SD_VPD_ASCII_OP_PG	0x08	/* 0x82 - ASCII Op Defs */
 #define	SD_VPD_DEVID_WWN_PG	0x10	/* 0x83 - Device Identification */
 #define	SD_VPD_EXTENDED_DATA_PG	0x80	/* 0x86 - Extended data about the lun */
-#define	SD_VPD_DEV_CHARACTER_PG	0x400	/* 0xB1 - Device Characteristics */
+#define	SD_VPD_BLK_LIMITS_PG	0x400	/* 0xB0 - Block Limits */
+#define	SD_VPD_DEV_CHARACTER_PG	0x800	/* 0xB1 - Device Characteristics */
 
 /*
  * Non-volatile cache support

--- a/usr/src/uts/common/sys/sysevent/eventdefs.h
+++ b/usr/src/uts/common/sys/sysevent/eventdefs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Nexenta Systems, Inc.
  */
 
 #ifndef	_SYS_SYSEVENT_EVENTDEFS_H
@@ -205,6 +205,8 @@ extern "C" {
 #define	ESC_ZFS_VDEV_SPARE		"ESC_ZFS_vdev_spare"
 #define	ESC_ZFS_BOOTFS_VDEV_ATTACH	"ESC_ZFS_bootfs_vdev_attach"
 #define	ESC_ZFS_POOL_REGUID		"ESC_ZFS_pool_reguid"
+#define	ESC_ZFS_TRIM_START		"ESC_ZFS_trim_start"
+#define	ESC_ZFS_TRIM_FINISH		"ESC_ZFS_trim_finish"
 
 /*
  * datalink subclass definitions.


### PR DESCRIPTION
This is an upstream of TRIM/UNMAP support and associated Illumos sd/sata driver bits from Nexenta. It has been in internal testing since March 2016 and is deemed ready for general use.
