### PR TITLE
7253 ztest failure: dsl_destroy_head(name) == 0 (0x10 == 0x0), file .…

### DIFF
--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -3216,9 +3216,12 @@ ztest_objset_destroy_cb(const char *name, void *arg)
 	 * Destroy the dataset.
 	 */
 	if (strchr(name, '@') != NULL) {
-		VERIFY0(dsl_destroy_snapshot(name, B_FALSE));
+		VERIFY0(dsl_destroy_snapshot(name, B_TRUE));
 	} else {
-		VERIFY0(dsl_destroy_head(name));
+		error = dsl_destroy_head(name);
+		/* There could be a hold on this dataset */
+		if (error != EBUSY)
+			ASSERT0(error);
 	}
 	return (0);
 }


### PR DESCRIPTION
…./ztest.c, line 3235

Reviewed by: Matthew Ahrens <mahrens@delphix.com> (@ahrens)
Reviewed by: Paul Dagnelie <pcd@delphix.com> (@pcd1193182)

The error in question (dsl_destroy_head() return EBUSY since there's a
hold on the dataset) is now tolerated, which should avoid interference
with other tests such as ztest_dmu_snapshot_hold().

Upstream bug: DLPX-32653