### PR TITLE
xxxx Disable zvol_swap tests until they're stabilized

### DIFF
--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -549,10 +549,6 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
 
-[/opt/zfs-tests/tests/functional/zvol/zvol_swap]
-tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
-
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']
 pre =


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>

These tests commonly cause zfs-test failures, so until these failures are
investigated and fix, we might as well disable them so they don't cause
headache for folks submitting PRs and hitting these false negatives.

Upstream Bugs: QA-6711