### PR TITLE
7402 Create tunable to ignore hole_birth feature

### DIFF
--- a/usr/src/uts/common/fs/zfs/dmu_traverse.c
+++ b/usr/src/uts/common/fs/zfs/dmu_traverse.c
@@ -39,6 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
+boolean_t ignore_hole_birth = B_TRUE;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;
@@ -253,7 +254,7 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		 *
 		 * Note that the meta-dnode cannot be reallocated.
 		 */
-		if ((!td->td_realloc_possible ||
+		if (!ignore_hole_birth && (!td->td_realloc_possible ||
 		    zb->zb_object == DMU_META_DNODE_OBJECT) &&
 		    td->td_hole_birth_enabled_txg <= td->td_min_txg)
 			return (0);

--- a/usr/src/uts/common/fs/zfs/dmu_traverse.c
+++ b/usr/src/uts/common/fs/zfs/dmu_traverse.c
@@ -39,7 +39,7 @@
 #include <sys/zfeature.h>
 
 int32_t zfs_pd_bytes_max = 50 * 1024 * 1024;	/* 50MB */
-boolean_t ignore_hole_birth = B_TRUE;
+boolean_t send_holes_without_birth_time = B_TRUE;
 
 typedef struct prefetch_data {
 	kmutex_t pd_mtx;
@@ -254,7 +254,8 @@ traverse_visitbp(traverse_data_t *td, const dnode_phys_t *dnp,
 		 *
 		 * Note that the meta-dnode cannot be reallocated.
 		 */
-		if (!ignore_hole_birth && (!td->td_realloc_possible ||
+		if (!send_holes_without_birth_time &&
+		    (!td->td_realloc_possible ||
 		    zb->zb_object == DMU_META_DNODE_OBJECT) &&
 		    td->td_hole_birth_enabled_txg <= td->td_min_txg)
 			return (0);


### PR DESCRIPTION
Until we can resolve the numerous hole_birth bugs that have cropped up recently, and come up with a way going forwards to protect users from corruption, we should disable the hole_birth feature.  Using a tunable allows those who are confident that their data is correct to continue to take advantage of the feature.