### PR TITLE
7291 Attempting to destroy ZFS filesystem and create ZFS volume with the same name caused system panic

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -2241,6 +2241,8 @@ file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg \
     mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos \
     mode=0555
+file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/setup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap.cfg \

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -548,7 +548,8 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -548,7 +548,8 @@ tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
+    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -548,7 +548,8 @@ tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',
-    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos']
+    'zvol_swap_004_pos', 'zvol_swap_005_pos', 'zvol_swap_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/Makefile
@@ -25,7 +25,8 @@ PROGS = cleanup \
 	zvol_misc_003_neg \
 	zvol_misc_004_pos \
 	zvol_misc_005_neg \
-	zvol_misc_006_pos
+	zvol_misc_006_pos \
+	zvol_misc_007_pos
 
 CMDS = $(PROGS:%=$(TESTDIR)/%)
 $(CMDS) := FILEMODE = 0555

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos.ksh
@@ -1,0 +1,47 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+
+#
+# DESCRIPTION:
+# Verify name collision occurs when an attempt to destroy ZFS filesystem
+# and create ZFS volume with the same name cannot cause system panic
+#
+# STRATEGY:
+# 1. Create ZFS filesystems
+# 2. Create nested ZFS volume
+# 3. Read and displays information about the ZFS volume
+# 4. Recursive destroy ZFS filesystems
+# 5. Create ZFS volume with the same name as ZFS filesystem
+# 6. Read and displays information about the ZFS volume
+# 7. Verify the system continued work
+#
+
+verify_runnable "global"
+log_assert "zfs can handle race volume create operation."
+log_onexit cleanup
+
+log_must $ZFS create $TESTPOOL/$TESTFS
+log_must $ZFS create -V 1M $TESTPOOL/$TESTFS/$TESTVOL
+log_must $STAT /dev/zvol/rdsk/$TESTPOOL/$TESTFS/$TESTVOL
+log_must $ZFS destroy -r $TESTPOOL/$TESTFS
+log_must $ZFS create -V 1M $TESTPOOL/$TESTFS
+log_must $STAT /dev/zvol/rdsk/$TESTPOOL/$TESTFS
+
+log_pass "zfs handle race volume create operation."

--- a/usr/src/uts/common/fs/dev/sdev_subr.c
+++ b/usr/src/uts/common/fs/dev/sdev_subr.c
@@ -2170,6 +2170,9 @@ found:
 				rw_exit(&ddv->sdev_contents);
 				rw_enter(&ddv->sdev_contents, RW_WRITER);
 			}
+			/* Clean out the stalled directory contents */
+			if (SDEVTOV(dv)->v_type == VDIR)
+				(void) sdev_cleandir(dv, NULL, SDEV_ENFORCE);
 			sdev_cache_update(ddv, &dv, nm, SDEV_CACHE_DELETE);
 			rw_downgrade(&ddv->sdev_contents);
 			SDEV_RELE(dv);


### PR DESCRIPTION
Please see https://www.illumos.org/issues/7291 for details.

1. In case of ZFS filesystem with nested child datasets we have _**/dev/zvol/{r,}dsk**_ directories hierarchy: _**/dev/zvol/{r,}dsk/pool/filesystem/child1/child2/child3**_

2. When _**pool/filesystem/child1**_ filesystem and its child datasets are destroyed, all _**/dev/zvol/{r,}dsk**_ directories hierarchy for _**pool/filesystem/child1**_ and sdev cache still exists (by design of _**usr/src/uts/common/fs/dev**_)

3. After re-creation of _**pool/filesystem/child1**_ with another dataset type (volume instead of filesystem) and accessing this new ZFS volume (_**devzvol_lookup -> devname_lookup_func**_)
 _**sdev_cache_update(ddv, &dv, nm, SDEV_CACHE_DELETE)**_ call updates the in-core directory cache ONLY.

4. Therefore all _**/dev/zvol/{r,}dsk/pool/filesystem/child1**_ directories hierarchy still exists. 
So we have _**dv->sdev_nlink == number_of_child_datasets + 2**_ for _**/dev/zvol/{r,}dsk/pool/filesystem/child1**_ and system panic on VERIFY:

http://src.illumos.org/source/xref/illumos-gate/usr/src/uts/common/fs/dev/sdev_subr.c#3133

Proposed patch: _**sdev_cleandir**_ for stalled directory path.

Reviewed by: Sanjay Nadkarni <sanjay.nadkarni@nexenta.com>
Reviewed by: Saso Kiselkov <saso.kiselkov@nexenta.com>
Reviewed by: Roman Strashkin <roman.strashkin@nexenta.com>
Reviewed by: Alek Pinchuk <alek.pinchuk@nexenta.com>

Patch was successfully tested and using internally at Nexenta and already included into the upcoming release NexentaStor 5.0.

Thank you!