### PR TITLE
7399 Endianness bugs with "zdb -R"

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -3164,8 +3164,8 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 	for (i = 0; i < nwords; i += 2) {
 		(void) printf("%06llx:  %016llx  %016llx  ",
 		    (u_longlong_t)(i * sizeof (uint64_t)),
-		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i]) : d[i]),
-		    (u_longlong_t)(do_bswap ? BSWAP_64(d[i + 1]) : d[i + 1]));
+		    (u_longlong_t)BE_64(d[i]),
+		    (u_longlong_t)BE_64(d[i + 1]));
 
 		c = (char *)&d[i];
 		for (j = 0; j < 2 * sizeof (uint64_t); j++)


### PR DESCRIPTION
cddl/contrib/opensolaris/cmd/zdb/zdb.c
    Fix zdb_dump_block (invoked by "zdb -R <dataset> <V:B:S>)
    on little endian machines.  Also, fix the display of
    foreign-endian blocks on big endian machines.  It's only
    necessary to byteswap the legend, not both the legend
    and the contents.
