### PR TITLE
7400 Enhance sysevents

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_pool.c
+++ b/usr/src/lib/libzfs/common/libzfs_pool.c
@@ -231,9 +231,9 @@ zpool_pool_state_to_name(pool_state_t state)
 		return (gettext("UNAVAIL"));
 	case POOL_STATE_POTENTIALLY_ACTIVE:
 		return (gettext("POTENTIALLY_ACTIVE"));
+	default:
+		return (gettext("UNKNOWN"));
 	}
-
-	return (gettext("UNKNOWN"));
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/spa_history.c
+++ b/usr/src/uts/common/fs/zfs/spa_history.c
@@ -455,6 +455,7 @@ log_internal(nvlist_t *nvl, const char *operation, spa_t *spa,
 	fnvlist_add_string(nvl, ZPOOL_HIST_INT_NAME, operation);
 	fnvlist_add_uint64(nvl, ZPOOL_HIST_TXG, tx->tx_txg);
 
+	zfs_ereport_spa_history(spa, nvl);
 	if (dmu_tx_is_syncing(tx)) {
 		spa_history_log_sync(nvl, tx);
 	} else {

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -852,6 +852,7 @@ extern void zfs_ereport_post(const char *class, spa_t *spa, vdev_t *vd,
 extern void zfs_post_remove(spa_t *spa, vdev_t *vd);
 extern void zfs_post_state_change(spa_t *spa, vdev_t *vd);
 extern void zfs_post_autoreplace(spa_t *spa, vdev_t *vd);
+extern void zfs_ereport_spa_history(spa_t *spa, nvlist_t *nvl);
 extern uint64_t spa_get_errlog_size(spa_t *spa);
 extern int spa_get_errlog(spa_t *spa, void *uaddr, size_t *count);
 extern void spa_errlog_rotate(spa_t *spa);

--- a/usr/src/uts/common/sys/fm/fs/zfs.h
+++ b/usr/src/uts/common/sys/fm/fs/zfs.h
@@ -55,6 +55,7 @@ extern "C" {
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_GUID	"vdev_guid"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_TYPE	"vdev_type"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_PATH	"vdev_path"
+#define	FM_EREPORT_PAYLOAD_ZFS_VDEV_PHYSPATH	"vdev_physpath"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_DEVID	"vdev_devid"
 #define	FM_EREPORT_PAYLOAD_ZFS_VDEV_FRU		"vdev_fru"
 #define	FM_EREPORT_PAYLOAD_ZFS_PARENT_GUID	"parent_guid"

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -673,7 +673,8 @@ typedef enum pool_state {
 	POOL_STATE_L2CACHE,		/* Level 2 ARC device		*/
 	POOL_STATE_UNINITIALIZED,	/* Internal spa_t state		*/
 	POOL_STATE_UNAVAIL,		/* Internal libzfs state	*/
-	POOL_STATE_POTENTIALLY_ACTIVE	/* Internal libzfs state	*/
+	POOL_STATE_POTENTIALLY_ACTIVE,	/* Internal libzfs state	*/
+	POOL_STATE_STATES
 } pool_state_t;
 
 /*
@@ -960,6 +961,7 @@ typedef enum {
 #define	ZFS_EV_POOL_NAME	"pool_name"
 #define	ZFS_EV_POOL_GUID	"pool_guid"
 #define	ZFS_EV_VDEV_PATH	"vdev_path"
+#define	ZFS_EV_VDEV_PHYSPATH	"vdev_physpath"
 #define	ZFS_EV_VDEV_GUID	"vdev_guid"
 
 #ifdef	__cplusplus

--- a/usr/src/uts/common/sys/sysevent/eventdefs.h
+++ b/usr/src/uts/common/sys/sysevent/eventdefs.h
@@ -253,6 +253,8 @@ extern "C" {
 #define	ESC_ZFS_VDEV_REMOVE_DEV		"ESC_ZFS_vdev_remove_dev"
 #define	ESC_ZFS_POOL_CREATE		"ESC_ZFS_pool_create"
 #define	ESC_ZFS_POOL_DESTROY		"ESC_ZFS_pool_destroy"
+#define	ESC_ZFS_POOL_EXPORT		"ESC_ZFS_pool_export"
+#define	ESC_ZFS_POOL_UNINITIALIZE	"ESC_ZFS_pool_uninitialize"
 #define	ESC_ZFS_POOL_IMPORT		"ESC_ZFS_pool_import"
 #define	ESC_ZFS_VDEV_ADD		"ESC_ZFS_vdev_add"
 #define	ESC_ZFS_VDEV_ATTACH		"ESC_ZFS_vdev_attach"
@@ -265,6 +267,8 @@ extern "C" {
 #define	ESC_ZFS_VDEV_SPARE		"ESC_ZFS_vdev_spare"
 #define	ESC_ZFS_BOOTFS_VDEV_ATTACH	"ESC_ZFS_bootfs_vdev_attach"
 #define	ESC_ZFS_POOL_REGUID		"ESC_ZFS_pool_reguid"
+#define	ESC_ZFS_POOL_HISTORY		"ESC_ZFS_pool_history"
+#define	ESC_ZFS_VDEV_ADD		"ESC_ZFS_vdev_add"
 
 /*
  * datalink subclass definitions.


### PR DESCRIPTION
- Add a dedicated sysevent (ESC_ZFS_POOL_EXPORT) for exporting a pool,
  instead of overloading the ESC_ZFS_POOL_DESTROY sysevent.
- Send a sysevent (ESC_ZFS_VDEV_ADD) whenever expanding a pool
- Add physical path information to every vdev-related sysevent, when
  possible.
- Emit sysevents for zpool history messages
- Differentiate pool creation from filesystem creation in zpool history
  messages
