### PR TITLE
7490 real checksum errors are silenced when zinject is on

### DIFF
--- a/usr/src/uts/common/fs/zfs/zio_checksum.c
+++ b/usr/src/uts/common/fs/zfs/zio_checksum.c
@@ -388,12 +388,13 @@ zio_checksum_error(zio_t *zio, zio_bad_cksum_t *info)
 
 	error = zio_checksum_error_impl(spa, bp, checksum, data, size,
 	    offset, info);
-	if (error != 0 && zio_injection_enabled && !zio->io_error &&
-	    (error = zio_handle_fault_injection(zio, ECKSUM)) != 0) {
 
-		info->zbc_injected = 1;
-		return (error);
+	if (zio_injection_enabled && error == 0 && zio->io_error == 0) {
+		error = zio_handle_fault_injection(zio, ECKSUM);
+		if (error != 0)
+			info->zbc_injected = 1;
 	}
+
 	return (error);
 }
 


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com ( @grwilson )
Reviewed by: Paul Dagnelie pcd@delphix.com ( @pcd1193182 )
Reviewed by: Dan Kimmel dan.kimmel@delphix.com ( @dankimmel)
Reviewed by: Matthew Ahrens mahrens@delphix.com ( @ahrens )

When zinject is on, error codes from `zfs_checksum_error()` can be
overwritten due to an incorrect and overly-complex `if` condition.

Fix by @pzakha.
