### PR TITLE
7496 cmp_ds_cont has never worked

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -185,7 +185,7 @@ function cmp_ds_cont
 	dstdir=$(get_prop mountpoint $dst_fs)
 
 	$DIFF -r $srcdir $dstdir > /dev/null 2>&1
-	echo $?
+	return $?
 }
 
 #

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_007_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -76,7 +76,6 @@ log_must eval "$ZFS send -R $POOL@final > $BACKDIR/pool-final-R"
 log_must eval "$ZFS receive -d -F $POOL2 < $BACKDIR/pool-final-R"
 dstds=$(get_dst_ds $POOL $POOL2)
 log_must cmp_ds_subs $POOL $dstds
-log_must cmp_ds_cont $POOL $dstds
 
 #
 # Verify zfs send -R -I should succeed
@@ -94,6 +93,5 @@ else
 	$ZFS receive -d -F $dstds < $BACKDIR/pool-init-final-IR
 fi
 log_must cmp_ds_subs $POOL $dstds
-log_must cmp_ds_cont $POOL $dstds
 
 log_pass "Rename parent filesystem name will not change the dependent order."

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_011_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_011_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2013 by Delphix. All rights reserved.
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -116,9 +116,7 @@ fi
 log_must cmp_ds_subs $POOL $dstds
 typeset -i i=0
 while ((i < ${#pair[@]})); do
-	log_must cmp_ds_cont ${pair[$i]} ${pair[((i+1))]}
 	log_must cmp_ds_prop ${pair[$i]} ${pair[((i+1))]}
-
 	((i += 2))
 done
 


### PR DESCRIPTION
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Paul Dagnelie pcd@delphix.com

The "cmp_ds_cont" function in the zfs-test suite ends with a call to
"echo". As a result, any consumers of this function interpreting its
return code to mean "success" or "failure" would have been flawed
(i.e. if it was used in conjunction with "log_must"), as the return
code of the function would have been the return code of the "echo"
command; i.e. it would almost always report success.

This patch modifies this function so that its return code can be
properly used to convey "success" or "failure", and then its usage
was removed from a few tests where it shouldn't have been used to
begin with.

Upstream Bugs: QA-6101
