### PR TITLE
7497 prefetch_io.d performance monitoring script has an error

### DIFF
--- a/usr/src/test/zfs-tests/tests/perf/scripts/prefetch_io.d
+++ b/usr/src/test/zfs-tests/tests/perf/scripts/prefetch_io.d
@@ -12,16 +12,16 @@
  */
 
 /*
- * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  */
 
 /*
  * prefetch_ios: Number of IOs the prefetcher issued
- * @pf["prefetched_demand_reads"]: Number of demand reads already prefetched
- * @pf["sync_wait_for_async"]: Number of times sync IO waited for prefetch IO
- * @pf["demand"]: Number of non-prefetch read IOs
- * @pf["logical"]: Logical (uncompressed) bytes read per interval
- * @pf["physical"]: Physical (compressed) bytes read per interval
+ * @c["prefetched_demand_reads"]: Number of demand reads already prefetched
+ * @c["sync_wait_for_async"]: Number of times sync IO waited for prefetch IO
+ * @s["demand"]: Number of non-prefetch read IOs
+ * @s["logical"]: Logical (uncompressed) bytes read per interval
+ * @s["physical"]: Physical (compressed) bytes read per interval
  */
 
 #pragma D option aggsortkey
@@ -36,33 +36,33 @@ BEGIN
 {
 	prefetch_ios = `arc_stats.arcstat_prefetch_data_misses.value.ui64;
 	prefetch_ios += `arc_stats.arcstat_prefetch_metadata_misses.value.ui64;
-	@pf["demand"] = sum(0);
-	@pf["logical"] = sum(0);
-	@pf["physical"] = sum(0);
-	@pf["prefetched_demand_reads"] = count();
-	@pf["sync_wait_for_async"] = count();
-	clear(@pf);
+	@s["demand"] = sum(0);
+	@s["logical"] = sum(0);
+	@s["physical"] = sum(0);
+	@c["prefetched_demand_reads"] = count();
+	@c["sync_wait_for_async"] = count();
+	clear(@s);
+	clear(@c);
 }
 
 arc_read:arc-demand-hit-predictive-prefetch
 {
-	@pf["prefetched_demand_reads"] = count();
+	@c["prefetched_demand_reads"] = count();
 }
 
 arc_read:arc-sync-wait-for-async
 {
-	@pf["sync_wait_for_async"] = count();
+	@c["sync_wait_for_async"] = count();
 }
 
 arc_read_done:entry
 / args[0]->io_spa->spa_name == $$1 /
 {
 	this->zio = args[0];
-	this->buf = (arc_buf_t *)this->zio->io_private;
-	this->hdr = this->buf->b_hdr;
-	@pf["demand"] = sum(this->hdr->b_flags & ARC_FLAGS_PREFETCH ? 0 : 1);
-	@pf["logical"] = sum(HDR_GET_LSIZE(this->hdr));
-	@pf["physical"] = sum(HDR_GET_PSIZE(this->hdr));
+	this->hdr = (arc_buf_hdr_t *)this->zio->io_private;
+	@s["demand"] = sum(this->hdr->b_flags & ARC_FLAGS_PREFETCH ? 0 : 1);
+	@s["logical"] = sum(HDR_GET_LSIZE(this->hdr));
+	@s["physical"] = sum(HDR_GET_PSIZE(this->hdr));
 }
 
 tick-$2s
@@ -72,9 +72,11 @@ tick-$2s
 	    `arc_stats.arcstat_prefetch_metadata_misses.value.ui64;
 	printf("%u\n%-24s\t%u\n", `time, "prefetch_ios",
 	    this->new_prefetch_ios - prefetch_ios);
-	printa("%-24s\t%@u\n", @pf);
+	printa("%-24s\t%@u\n", @s);
+	printa("%-24s\t%@u\n", @c);
 	prefetch_ios = this->new_prefetch_ios;
-	clear(@pf);
+	clear(@s);
+	clear(@c);
 }
 
 ERROR


### PR DESCRIPTION
Reviewed by: Dan Kimmel dan.kimmel@delphix.com
Reviewed by: Prakash Surya prakash.surya@delphix.com

Running the "prefetch_io.d" dtrace script found in the zfs-test suite
would result in the following error:

```
dtrace: failed to compile script /opt/zfs-tests/tests/perf/scripts/prefetch_io.d: line 42: aggregation redefined: @pf
current: @pf = count( )
previous: @pf = sum( ) : line 39
```

This is because the "pf" variable is being used for two different types
of aggregators. This patch simply modifies the script to use two different
variables for the two different types of aggregations being collected.

Upstream bugs: QA-5004
