### PR TITLE
7498 snprintf is incorrectly annotated with PRINTFLIKE1

### DIFF
--- a/usr/src/common/util/string.c
+++ b/usr/src/common/util/string.c
@@ -25,6 +25,10 @@
  */
 
 /*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
+
+/*
  * Implementations of the functions described in vsnprintf(3C) and string(3C),
  * for use by the kernel, the standalone, and kmdb.  Unless otherwise specified,
  * these functions match the section 3C manpages.
@@ -313,7 +317,7 @@ next_fmt:
 	return (bufp - buf);
 }
 
-/*PRINTFLIKE1*/
+/*PRINTFLIKE3*/
 size_t
 snprintf(char *buf, size_t buflen, const char *fmt, ...)
 {

--- a/usr/src/common/util/string.h
+++ b/usr/src/common/util/string.h
@@ -24,6 +24,10 @@
  * Use is subject to license terms.
  */
 
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
+
 #ifndef	_COMMON_UTIL_STRING_H
 #define	_COMMON_UTIL_STRING_H
 
@@ -36,7 +40,7 @@ extern "C" {
 #if !defined(_KMDB) && (!defined(_BOOT) || defined(__sparc))
 
 extern size_t vsnprintf(char *, size_t, const char *, va_list);
-/*PRINTFLIKE1*/
+/*PRINTFLIKE3*/
 extern size_t snprintf(char *, size_t, const char *, ...);
 
 #if defined(_BOOT) && defined(__sparc)


### PR DESCRIPTION
Reviewed by: Sebastien Roy sebastien.roy@delphix.com
Reviewed by: George Wilson george.wilson@delphix.com

snprintf() is incorrectly annotated to be printf-like, because the first
argument is indicated to be the format string, when in fact the 3rd
argument is the format string. This annotation is used by lint to detect
improper improper arguments passed to printf (when the format string is
a string literal).

Thankfully, this mistake hasn't caused any errors to be introduced into
the codebase, because the compiler (gcc -Wformat) also checks the
arguments to snprintf (using a different, unknown mechanism to determine
that the 3rd argument is the format string).

Upstream bugs: DLPX-43275
