### PR TITLE
7502 ztest should run zdb with -G (debug mode)

### DIFF
--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -5259,7 +5259,7 @@ ztest_run_zdb(char *pool)
 	isa = strdup(isa);
 	/* LINTED */
 	(void) sprintf(bin,
-	    "/usr/sbin%.*s/zdb -bcc%s%s -d -U %s %s",
+	    "/usr/sbin%.*s/zdb -bcc%s%s -G -d -U %s %s",
 	    isalen,
 	    isa,
 	    ztest_opts.zo_verbose >= 3 ? "s" : "",


### PR DESCRIPTION
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Dan Kimmel dan.kimmel@delphix.com

Whenever ztest runs zdb, it will run it in debug mode, meaning that
zfs_dbgmsg buffer will be output before exiting zdb. This is currently
useful to debug problems opening the pool, but could be used for more
stuff in the future.

Upstream bugs: DLPX-43693
