### PR TITLE
7504 kmem_reap hangs spa_sync and administrative tasks

### DIFF
--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -3748,7 +3748,6 @@ arc_reclaim_thread(void)
 
 	mutex_enter(&arc_reclaim_lock);
 	while (!arc_reclaim_thread_exit) {
-		int64_t free_memory = arc_available_memory();
 		uint64_t evicted = 0;
 
 		/*
@@ -3767,6 +3766,14 @@ arc_reclaim_thread(void)
 
 		mutex_exit(&arc_reclaim_lock);
 
+		/*
+		 * We call arc_adjust() before (possibly) calling
+		 * arc_kmem_reap_now(), so that we can wake up
+		 * arc_get_data_buf() sooner.
+		 */
+		evicted = arc_adjust();
+
+		int64_t free_memory = arc_available_memory();
 		if (free_memory < 0) {
 
 			arc_no_grow = B_TRUE;
@@ -3799,8 +3806,6 @@ arc_reclaim_thread(void)
 		} else if (gethrtime() >= growtime) {
 			arc_no_grow = B_FALSE;
 		}
-
-		evicted = arc_adjust();
 
 		mutex_enter(&arc_reclaim_lock);
 


### PR DESCRIPTION
Reviewed by: George Wilson george.wilson@delphix.com
Reviewed by: Prakash Surya prakash.surya@delphix.com

arc_reclaim_thread calls arc_adjust (which signals arc_get_data_buf
to indicate that we may no longer be arc_is_overflowing) after calling
arc_kmem_reap_now (which can take several seconds, and has no impact
on arc_is_overflowing).

A good fix for this would be to use 2 separate threads to:

```
1. keep arc_c under arc_size, by calling arc_adjust, (which improves
   arc_is_overflowing)

2. keep enough free memory in the system, by calling
   arc_kmem_reap_now + arc_shrink (which improves arc_available_memory)
```

A simpler improvement is to call arc_adjust before calling arc_kmem_reap_now,
so that arc_get_data_buf has low latency (at least when arc_reclaim_thread
is not already in the middle of arc_kmem_reap_now).

For expediency, this fix is doing the simpler implementation.

Upstream bugs: DLPX-44232
