### PR TITLE
7200 7199 dsl_dataset_rollback_sync should not leave a dirty dataset

### DIFF
--- a/usr/src/uts/common/fs/zfs/dsl_dataset.c
+++ b/usr/src/uts/common/fs/zfs/dsl_dataset.c
@@ -2191,11 +2191,15 @@ dsl_dataset_rollback_check(void *arg, dmu_tx_t *tx)
 		return (SET_ERROR(EINVAL));
 	}
 
-	/* XXX No rollback to a snapshot created in the current txg. */
+	/*
+	 * No rollback to a snapshot created in the current txg, because
+	 * the rollback may dirty the dataset and create blocks that are
+	 * not reachable from the rootbp while having a birth txg that
+	 * falls into the snapshot's range.
+	 */
 	if (dmu_tx_is_syncing(tx) &&
 	    dsl_dataset_phys(ds)->ds_prev_snap_txg >= tx->tx_txg) {
 		dsl_dataset_rele(ds, FTAG);
-		/* not sure if this is the best error here */
 		return (SET_ERROR(EAGAIN));
 	}
 

--- a/usr/src/uts/common/fs/zfs/dsl_pool.c
+++ b/usr/src/uts/common/fs/zfs/dsl_pool.c
@@ -424,14 +424,6 @@ dsl_pool_mos_diduse_space(dsl_pool_t *dp,
 	mutex_exit(&dp->dp_lock);
 }
 
-static int
-deadlist_enqueue_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
-{
-	dsl_deadlist_t *dl = arg;
-	dsl_deadlist_insert(dl, bp, tx);
-	return (0);
-}
-
 static void
 dsl_pool_sync_mos(dsl_pool_t *dp, dmu_tx_t *tx)
 {
@@ -532,11 +524,7 @@ dsl_pool_sync(dsl_pool_t *dp, uint64_t txg)
 	 *  - release hold from dsl_dataset_dirty()
 	 */
 	while ((ds = list_remove_head(&synced_datasets)) != NULL) {
-		objset_t *os = ds->ds_objset;
-		bplist_iterate(&ds->ds_pending_deadlist,
-		    deadlist_enqueue_cb, &ds->ds_deadlist, tx);
-		ASSERT(!dmu_objset_is_dirty(os, txg));
-		dmu_buf_rele(ds->ds_dbuf, ds);
+		dsl_dataset_sync_done(ds, tx);
 	}
 	while ((dd = txg_list_remove(&dp->dp_dirty_dirs, txg)) != NULL) {
 		dsl_dir_sync(dd, tx);

--- a/usr/src/uts/common/fs/zfs/sys/dsl_dataset.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_dataset.h
@@ -274,6 +274,7 @@ boolean_t dsl_dataset_modified_since_snap(dsl_dataset_t *ds,
     dsl_dataset_t *snap);
 
 void dsl_dataset_sync(dsl_dataset_t *os, zio_t *zio, dmu_tx_t *tx);
+void dsl_dataset_sync_done(dsl_dataset_t *os, dmu_tx_t *tx);
 
 void dsl_dataset_block_born(dsl_dataset_t *ds, const blkptr_t *bp,
     dmu_tx_t *tx);


### PR DESCRIPTION
Sync-tasks that operate on existing datasets should not leave them
dirty, because there could be other sync-tasks for the same dataset
that do not expect to encounter a dirty dataset.
It's not a problem to leave a new dataset dirty as there can not be
any other sync-tasks for it.

Typically sync-tasks do not modify the dataset's objset as they
dirty only the MOS.  A single exception from this rule is when
a clone is created from a snapshot.  In that case we need to zero out
a ZIL header that could point to a ZIL chain that existed when
the snapshot was taken.
The only case when that exception is problematic is
dsl_dataset_rollback_sync() which creates a clone from a snapshot
and then performs the clone swap.

A sample of problems caused by the dirty datasets:
- if a dirty dataset is snapshotted, then there will be blocks that
  are not reachable from the root BP, but with birth txg equal to
  the snapshot txg
- if a dirty dataset is destroyed, then there will be a crash when
  attempting to sync out the dataset
- if a rolled back dataset is rolled back again, then the dirty
  intermediate dataset may have a non-zero ZIL header pointing to
  a ZIL chain captured by the snapshot, when the intermediate dataset
  is destroyed the stale chain would be walked