### PR TITLE
6428 set canmount=off on unmounted filesystem tries to unmount children

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -1597,8 +1597,9 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 		 * its canmount property to 'on' or 'noauto'.  We only use
 		 * the changelist logic to unmount when setting canmount=off.
 		 */
-		if (!(prop == ZFS_PROP_CANMOUNT &&
-		    fnvpair_value_uint64(elem) != ZFS_CANMOUNT_OFF)) {
+		if (prop != ZFS_PROP_CANMOUNT ||
+		    (fnvpair_value_uint64(elem) == ZFS_CANMOUNT_OFF &&
+		     zfs_is_mounted(zhp, NULL))) {
 			cls[cl_idx] = changelist_gather(zhp, prop, 0, 0);
 			if (cls[cl_idx] == NULL)
 				goto error;

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -1594,11 +1594,17 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 		assert(cl_idx < nvl_len);
 		/*
 		 * We don't want to unmount & remount the dataset when changing
-		 * its canmount property to 'on' or 'noauto'.  We only use
-		 * the changelist logic to unmount when setting canmount=off.
+		 * its canmount property.  We only use the changelist logic to
+		 * unmount when setting canmount=off for a mounted filesystem
+		 * or when setting canmount=on for an unmounted filesystem.
+		 * For all other changes to canmount property the filesystem
+		 * remains the same.
 		 */
-		if (!(prop == ZFS_PROP_CANMOUNT &&
-		    fnvpair_value_uint64(elem) != ZFS_CANMOUNT_OFF)) {
+		if (prop != ZFS_PROP_CANMOUNT ||
+		    (fnvpair_value_uint64(elem) == ZFS_CANMOUNT_OFF &&
+		     zfs_is_mounted(zhp, NULL)) ||
+		    (fnvpair_value_uint64(elem) == ZFS_CANMOUNT_ON &&
+		     !zfs_is_mounted(zhp, NULL))) {
 			cls[cl_idx] = changelist_gather(zhp, prop, 0, 0);
 			if (cls[cl_idx] == NULL)
 				goto error;

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -1594,17 +1594,11 @@ zfs_prop_set_list(zfs_handle_t *zhp, nvlist_t *props)
 		assert(cl_idx < nvl_len);
 		/*
 		 * We don't want to unmount & remount the dataset when changing
-		 * its canmount property.  We only use the changelist logic to
-		 * unmount when setting canmount=off for a mounted filesystem
-		 * or when setting canmount=on for an unmounted filesystem.
-		 * For all other changes to canmount property the filesystem
-		 * remains the same.
+		 * its canmount property to 'on' or 'noauto'.  We only use
+		 * the changelist logic to unmount when setting canmount=off.
 		 */
-		if (prop != ZFS_PROP_CANMOUNT ||
-		    (fnvpair_value_uint64(elem) == ZFS_CANMOUNT_OFF &&
-		     zfs_is_mounted(zhp, NULL)) ||
-		    (fnvpair_value_uint64(elem) == ZFS_CANMOUNT_ON &&
-		     !zfs_is_mounted(zhp, NULL))) {
+		if (!(prop == ZFS_PROP_CANMOUNT &&
+		    fnvpair_value_uint64(elem) != ZFS_CANMOUNT_OFF)) {
 			cls[cl_idx] = changelist_gather(zhp, prop, 0, 0);
 			if (cls[cl_idx] == NULL)
 				goto error;


### PR DESCRIPTION
This change is in FreeBSD already:
- https://svnweb.freebsd.org/base?view=revision&revision=297521
- https://svnweb.freebsd.org/base?view=revision&revision=304520