### PR TITLE
6412 zfs receive: -u can be ignored sometimes

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_sendrecv.c
+++ b/usr/src/lib/libzfs/common/libzfs_sendrecv.c
@@ -3533,7 +3533,8 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 	}
 
 	if (clp) {
-		err |= changelist_postfix(clp);
+		if (!flags->nomount)
+			err |= changelist_postfix(clp);
 		changelist_free(clp);
 	}
 


### PR DESCRIPTION
This change is in FreeBSD:
https://svnweb.freebsd.org/base?view=revision&revision=297520