### PR TITLE
7535 need test for resumed send of top most filesystem

### DIFF
--- a/usr/src/test/zfs-tests/include/default.cfg
+++ b/usr/src/test/zfs-tests/include/default.cfg
@@ -65,42 +65,47 @@ export FIO_SCRIPTS=$STF_SUITE/tests/perf/fio
 export PERF_SCRIPTS=$STF_SUITE/tests/perf/scripts
 
 # some test pool names
-export TESTPOOL=testpool.$$
-export TESTPOOL1=testpool1.$$
-export TESTPOOL2=testpool2.$$
-export TESTPOOL3=testpool3.$$
+export TESTPOOL=testpool
+export TESTPOOL1=testpool1
+export TESTPOOL2=testpool2
+export TESTPOOL3=testpool3
 export PERFPOOL=perfpool
 
 # some test file system names
-export TESTFS=testfs.$$
-export TESTFS1=testfs1.$$
-export TESTFS2=testfs2.$$
-export TESTFS3=testfs3.$$
+export TESTFS=testfs
+export TESTFS1=testfs1
+export TESTFS2=testfs2
+export TESTFS3=testfs3
 
 # some test directory names
-export TESTDIR=${TEST_BASE_DIR%%/}/testdir$$
-export TESTDIR0=${TEST_BASE_DIR%%/}/testdir0$$
-export TESTDIR1=${TEST_BASE_DIR%%/}/testdir1$$
-export TESTDIR2=${TEST_BASE_DIR%%/}/testdir2$$
+export TESTDIR=${TEST_BASE_DIR%%/}/testdir
+export TESTDIR0=${TEST_BASE_DIR%%/}/testdir0
+export TESTDIR1=${TEST_BASE_DIR%%/}/testdir1
+export TESTDIR2=${TEST_BASE_DIR%%/}/testdir2
+
+# some test sub file system names
+export TESTSUBFS=subfs
+export TESTSUBFS1=subfs1
+export TESTSUBFS2=subfs2
 
 export ZFSROOT=
 
-export TESTSNAP=testsnap$$
-export TESTSNAP1=testsnap1$$
-export TESTSNAP2=testsnap2$$
-export TESTCLONE=testclone$$
-export TESTCLONE1=testclone1$$
-export TESTCLONE2=testclone2$$
-export TESTCLCT=testclct$$
-export TESTCTR=testctr$$
-export TESTCTR1=testctr1$$
-export TESTCTR2=testctr2$$
-export TESTVOL=testvol$$
-export TESTVOL1=testvol1$$
-export TESTVOL2=testvol2$$
-export TESTFILE0=testfile0.$$
-export TESTFILE1=testfile1.$$
-export TESTFILE2=testfile2.$$
+export TESTSNAP=testsnap
+export TESTSNAP1=testsnap1
+export TESTSNAP2=testsnap2
+export TESTCLONE=testclone
+export TESTCLONE1=testclone1
+export TESTCLONE2=testclone2
+export TESTCLCT=testclct
+export TESTCTR=testctr
+export TESTCTR1=testctr1
+export TESTCTR2=testctr2
+export TESTVOL=testvol
+export TESTVOL1=testvol1
+export TESTVOL2=testvol2
+export TESTFILE0=testfile0
+export TESTFILE1=testfile1
+export TESTFILE2=testfile2
 
 export LONGPNAME="poolname50charslong_012345678901234567890123456789"
 export LONGFSNAME="fsysname50charslong_012345678901234567890123456789"

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_aclmode_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_chmod_aclmode_001_pos.ksh
@@ -476,8 +476,6 @@ typeset acl
 typeset target
 typeset -i passthrough=0
 typeset -i flag=0
-cwd=$PWD
-cd $TESTDIR
 
 for mode in "${aclmode_flag[@]}"; do
 	log_must zfs set aclmode=$mode $TESTPOOL/$TESTFS

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_007_pos.ksh
@@ -42,7 +42,7 @@ function cleanup
 	zfs destroy -rf $TESTPOOL/recvfs
 	rm $streamfile
 	rm $vdev
-	zpool destroy testpool
+	zpool destroy tmp_pool
 }
 
 
@@ -88,12 +88,11 @@ test_pool ()
 
 test_pool $TESTPOOL
 log_must truncate --size=1G $vdev
-log_must zpool create -o version=1 testpool $vdev
-test_pool testpool
-log_must zpool destroy testpool
-log_must zpool create -d testpool $vdev
-test_pool testpool
-log_must zpool destroy testpool
-
+log_must zpool create -o version=1 tmp_pool $vdev
+test_pool tmp_pool
+log_must zpool destroy tmp_pool
+log_must zpool create -d tmp_pool $vdev
+test_pool tmp_pool
+log_must zpool destroy tmp_pool
 
 log_pass "'zfs send' drills appropriate holes"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import_rename_001_pos.ksh
@@ -164,10 +164,11 @@ done
 VDEV_FILE=$(mktemp /tmp/tmp.XXXXXX)
 
 log_must mkfile -n 128M $VDEV_FILE
-log_must zpool create testpool $VDEV_FILE
-log_must zfs create testpool/testfs
-ID=$(zpool get -Ho value guid testpool)
-log_must zpool export testpool
-log_mustnot zpool import $(echo id) $(printf "%*s\n" 250 "" | tr ' ' 'c')
+log_must zpool create overflow $VDEV_FILE
+log_must zfs create overflow/testfs
+ID=$(zpool get -Ho value guid overflow)
+log_must zpool export overflow
+log_mustnot zpool import -d /tmp $(echo id) \
+    $(printf "%*s\n" 250 "" | tr ' ' 'c')
 
 log_pass "Successfully imported and renamed a ZPOOL"

--- a/usr/src/test/zfs-tests/tests/functional/rsend/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/cleanup.ksh
@@ -36,9 +36,11 @@ verify_runnable "both"
 if is_global_zone ; then
 	destroy_pool $POOL
 	destroy_pool $POOL2
+	poolexists $POOL3 && destroy_pool $POOL3
 else
 	cleanup_pool $POOL
 	cleanup_pool $POOL2
+	poolexists $POOL3 && cleanup_pool $POOL3
 fi
 log_must rm -rf $BACKDIR $TESTDIR
 

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend.cfg
@@ -31,7 +31,9 @@ export BACKDIR=${TEST_BASE_DIR%%/}/backdir-rsend
 
 export DISK1=$(echo $DISKS | awk '{print $1}')
 export DISK2=$(echo $DISKS | awk '{print $2}')
+export DISK3=$(echo $DISKS | awk '{print $3}')
 
 export POOL=$TESTPOOL
 export POOL2=$TESTPOOL1
+export POOL3=$TESTPOOL2
 export FS=$TESTFS

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -118,7 +118,7 @@ function cleanup_pool
 	if is_global_zone ; then
 		log_must zfs destroy -Rf $pool
 	else
-		typeset list=$(zfs list -H -r -t filesystem,snapshot,volume -o name $pool)
+		typeset list=$(zfs list -H -r -t all -o name $pool)
 		for ds in $list ; do
 			if [[ $ds != $pool ]] ; then
 				if datasetexists $ds ; then
@@ -138,10 +138,16 @@ function cleanup_pool
 		log_must zfs mount $pool
 	fi
 	if [[ -d $mntpnt ]]; then
-		log_must rm -rf $mntpnt/*
+		rm -rf $mntpnt/*
 	fi
 
 	return 0
+}
+
+function cleanup_pools
+{
+	cleanup_pool $POOL2
+	destroy_pool $POOL3
 }
 
 #
@@ -155,8 +161,8 @@ function cmp_ds_subs
 	typeset src_fs=$1
 	typeset dst_fs=$2
 
-	zfs list -r -H -t filesystem,snapshot,volume -o name $src_fs > $BACKDIR/src1
-	zfs list -r -H -t filesystem,snapshot,volume -o name $dst_fs > $BACKDIR/dst1
+	zfs list -r -H -t all -o name $src_fs > $BACKDIR/src1
+	zfs list -r -H -t all -o name $dst_fs > $BACKDIR/dst1
 
 	eval sed -e 's:^$src_fs:PREFIX:g' < $BACKDIR/src1 > $BACKDIR/src
 	eval sed -e 's:^$dst_fs:PREFIX:g' < $BACKDIR/dst1 > $BACKDIR/dst
@@ -322,8 +328,7 @@ function getds_with_suffix
 	typeset ds=$1
 	typeset suffix=$2
 
-	typeset list=$(zfs list -r -H -t filesystem,snapshot,volume -o name $ds \
-	    | grep "$suffix$")
+	typeset list=$(zfs list -r -H -t all -o name $ds | grep "$suffix$")
 
 	echo $list
 }
@@ -485,7 +490,7 @@ function resume_test
 
 	for ((i=0; i<2; i=i+1)); do
 		mess_file /$streamfs/$stream_num
-		log_mustnot zfs recv -sv $recvfs </$streamfs/$stream_num
+		log_mustnot zfs recv -suv $recvfs </$streamfs/$stream_num
 		stream_num=$((stream_num+1))
 
 		token=$(zfs get -Hp -o value receive_resume_token $recvfs)
@@ -493,31 +498,26 @@ function resume_test
 		[[ -f /$streamfs/$stream_num ]] || \
 		    log_fail "NO FILE /$streamfs/$stream_num"
 	done
-	log_must zfs recv -sv $recvfs </$streamfs/$stream_num
+	log_must zfs recv -suv $recvfs </$streamfs/$stream_num
 }
 
 #
 # Setup filesystems for the resumable send/receive tests
 #
-# $1 The pool to set up with the "send" filesystems
-# $2 The pool for receive
+# $1 The "send" filesystem
+# $2 The "recv" filesystem
 #
 function test_fs_setup
 {
-	sendpool=$1
-	recvpool=$2
+	typeset sendfs=$1
+	typeset recvfs=$2
+	typeset sendpool=${sendfs%%/*}
+	typeset recvpool=${recvfs%%/*}
 
-	sendfs=$sendpool/sendfs
-	recvfs=$recvpool/recvfs
-	streamfs=$sendpool/stream
+	datasetexists $sendfs && log_must $ZFS destroy -r $sendpool
+	datasetexists $recvfs && log_must $ZFS destroy -r $recvpool
 
-	if datasetexists $recvfs; then
-		log_must zfs destroy -r $recvfs
-	fi
-	if datasetexists $sendfs; then
-		log_must zfs destroy -r $sendfs
-	fi
-	if $(zfs create -o compress=lz4 $sendfs); then
+	if $(datasetexists $sendfs || zfs create -o compress=lz4 $sendfs); then
 		mk_files 1000 256 0 $sendfs &
 		mk_files 1000 131072 0 $sendfs &
 		mk_files 100 1048576 0 $sendfs &

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
@@ -30,22 +30,24 @@
 # 4. ZFS send to the stream state file again using the receive_resume_token
 # 5. ZFS receieve and verify the receive completes successfully
 # 6. Repeat steps on an incremental ZFS send
+# 7. Repeat the entire procedure for a dataset at the pool root
 #
 
 verify_runnable "both"
 
 log_assert "Verify resumability of a full and incremental ZFS send/receive " \
     "in the presence of a corrupted stream"
-log_onexit cleanup_pool $POOL2
+log_onexit cleanup_pools $POOL2 $POOL3
 
-sendfs=$POOL/sendfs
-recvfs=$POOL2/recvfs
-streamfs=$POOL/stream
+recvfs=$POOL3/recvfs
+streamfs=$POOL2/stream
 
-test_fs_setup $POOL $POOL2
-resume_test "zfs send -v $sendfs@a" $streamfs $recvfs
-resume_test "zfs send -v -i @a $sendfs@b" $streamfs $recvfs
-file_check $sendfs $recvfs
+for sendfs in $POOL2/sendfs $POOL2; do
+	test_fs_setup $sendfs $recvfs
+	resume_test "zfs send -v $sendfs@a" $streamfs $recvfs
+	resume_test "zfs send -v -i @a $sendfs@b" $streamfs $recvfs
+	file_check $sendfs $recvfs
+done
 
 log_pass "Verify resumability of a full and incremental ZFS send/receive " \
     "in the presence of a corrupted stream"

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
@@ -41,7 +41,7 @@ sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 streamfs=$POOL/stream
 
-test_fs_setup $POOL $POOL2
+test_fs_setup $sendfs $recvfs
 resume_test "zfs send -D -v $sendfs@a" $streamfs $recvfs
 file_check $sendfs $recvfs
 

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
@@ -43,7 +43,7 @@ sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 streamfs=$POOL/stream
 
-test_fs_setup $POOL $POOL2
+test_fs_setup $sendfs $recvfs
 resume_test "zfs send -v -e $sendfs@a" $streamfs $recvfs
 resume_test "zfs send -v -e -i @a $sendfs@b" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
@@ -46,7 +46,7 @@ sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 streamfs=$POOL/stream
 
-test_fs_setup $POOL $POOL2
+test_fs_setup $sendfs $recvfs
 log_must zfs bookmark $sendfs@a $sendfs#bm_a
 log_must zfs destroy $sendfs@a
 log_must zfs receive -v $recvfs </$POOL/initial.zsend

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -43,7 +43,7 @@ sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 streamfs=$POOL/stream
 
-test_fs_setup $POOL $POOL2
+test_fs_setup $sendfs $recvfs
 log_must zfs unmount $sendfs
 resume_test "zfs send $sendfs" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/usr/src/test/zfs-tests/tests/functional/rsend/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/setup.ksh
@@ -37,6 +37,7 @@ verify_disk_count "$DISKS" 2
 if is_global_zone ; then
 	log_must zpool create $POOL $DISK1
 	log_must zpool create $POOL2 $DISK2
+	log_must zpool create $POOL3 $DISK3
 fi
 log_must mkdir $BACKDIR $TESTDIR
 


### PR DESCRIPTION
Reviewed by: George Wilson <george.wilson@delphix.com> ( @grwilson )
Reviewed by: Matthew Ahrens <mahrens@delphix.com> ( @ahrens )

Expand test coverage to include resumed send from the root of a pool.

Upstream bugs: QA-5943, QA-6028