### PR TITLE
7542 zfs_unmount failed with EZFS_UNSHARENFSFAILED

### DIFF
--- a/usr/src/lib/libshare/common/libsharecore.c
+++ b/usr/src/lib/libshare/common/libsharecore.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2170,7 +2171,7 @@ sa_delete_sharetab(sa_handle_t handle, char *path, char *proto)
 /*
  * sa_needs_refresh(handle)
  *
- * Returns B_TRUE if the internal cache needs to be refreshed do to a
+ * Returns B_TRUE if the internal cache needs to be refreshed due to a
  * change by another process.  B_FALSE returned otherwise.
  */
 boolean_t

--- a/usr/src/lib/libzfs/common/libzfs_impl.h
+++ b/usr/src/lib/libzfs/common/libzfs_impl.h
@@ -72,7 +72,6 @@ struct libzfs_handle {
 	int libzfs_printerr;
 	int libzfs_storeerr; /* stuff error messages into buffer */
 	void *libzfs_sharehdl; /* libshare handle */
-	uint_t libzfs_shareflags;
 	boolean_t libzfs_mnttab_enable;
 	avl_tree_t libzfs_mnttab_cache;
 	int libzfs_pool_iter;
@@ -81,8 +80,6 @@ struct libzfs_handle {
 	libzfs_fru_t *libzfs_fru_list;
 	char libzfs_chassis_id[256];
 };
-
-#define	ZFSSHARE_MISS	0x01	/* Didn't find entry in cache */
 
 struct zfs_handle {
 	libzfs_handle_t *zfs_hdl;

--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  */
 
@@ -658,35 +658,30 @@ _zfs_init_libshare(void)
 int
 zfs_init_libshare(libzfs_handle_t *zhandle, int service)
 {
-	int ret = SA_OK;
-
 	if (_sa_init == NULL)
-		ret = SA_CONFIG_ERR;
+		return (SA_CONFIG_ERR);
 
-	if (ret == SA_OK && zhandle->libzfs_shareflags & ZFSSHARE_MISS) {
-		/*
-		 * We had a cache miss. Most likely it is a new ZFS
-		 * dataset that was just created. We want to make sure
-		 * so check timestamps to see if a different process
-		 * has updated any of the configuration. If there was
-		 * some non-ZFS change, we need to re-initialize the
-		 * internal cache.
-		 */
-		zhandle->libzfs_shareflags &= ~ZFSSHARE_MISS;
-		if (_sa_needs_refresh != NULL &&
-		    _sa_needs_refresh(zhandle->libzfs_sharehdl)) {
-			zfs_uninit_libshare(zhandle);
-			zhandle->libzfs_sharehdl = _sa_init(service);
-		}
+	/*
+	 * Attempt to refresh libshare. This is necessary if there was a cache
+	 * miss for a new ZFS dataset that was just created, or if state of the
+	 * sharetab file has changed since libshare was last initialized. We
+	 * want to make sure so check timestamps to see if a different process
+	 * has updated any of the configuration. If there was some non-ZFS
+	 * change, we need to re-initialize the internal cache.
+	 */
+	if (_sa_needs_refresh != NULL &&
+	    _sa_needs_refresh(zhandle->libzfs_sharehdl)) {
+		zfs_uninit_libshare(zhandle);
+		zhandle->libzfs_sharehdl = _sa_init(service);
 	}
 
-	if (ret == SA_OK && zhandle && zhandle->libzfs_sharehdl == NULL)
+	if (zhandle && zhandle->libzfs_sharehdl == NULL)
 		zhandle->libzfs_sharehdl = _sa_init(service);
 
-	if (ret == SA_OK && zhandle->libzfs_sharehdl == NULL)
-		ret = SA_NO_MEMORY;
+	if (zhandle->libzfs_sharehdl == NULL)
+		return (SA_NO_MEMORY);
 
-	return (ret);
+	return (SA_OK);
 }
 
 /*
@@ -832,7 +827,6 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 				    zfs_get_name(zhp));
 				return (-1);
 			}
-			hdl->libzfs_shareflags |= ZFSSHARE_MISS;
 			share = zfs_sa_find_share(hdl->libzfs_sharehdl,
 			    mountpoint);
 		}


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Matt Amdur <matt.amdur@delphix.com>

libshare keeps a cached copy of the sharetab listing in memory, which
can become out of date if shares are destroyed or created while leaving
a libzfs handle open. This results in a spurious unmounting failure
when an NFS share exists but isn't in the stale libshare cache. To solve
this, zfs_init_libshare has been modified to always check if libshare
needs to be reinitialized rather than only doing so in a specific
flagged case.

Upstream bugs: DLPX-44291