### PR TITLE
7545 zdb should disable reference tracking

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -75,10 +75,12 @@
 	DMU_OT_ZAP_OTHER : DMU_OT_NUMTYPES))
 
 #ifndef lint
+extern int reference_tracking_enable;
 extern boolean_t zfs_recover;
 extern uint64_t zfs_arc_max, zfs_arc_meta_limit;
 extern int zfs_vdev_async_read_max_active;
 #else
+int reference_tracking_enable;
 boolean_t zfs_recover;
 uint64_t zfs_arc_max, zfs_arc_meta_limit;
 int zfs_vdev_async_read_max_active;
@@ -3665,6 +3667,11 @@ main(int argc, char **argv)
 	 * For good performance, let several of them be active at once.
 	 */
 	zfs_vdev_async_read_max_active = 10;
+
+	/*
+	 * Disable reference tracking for better performance.
+	 */
+	reference_tracking_enable = B_FALSE;
 
 	kernel_init(FREAD);
 	g_zfs = libzfs_init();


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

When evicting from the ARC, we manipulate some refcount_t's, e.g.
arcs_size. When using zdb to examine a large amount of data (e.g.
zdb -bb on a large pool with small blocks), the ARC may have a large
number of entries. If reference tracking is enabled, there will be ~1
reference for each block in the ARC. When evicting, we decrement the
refcount and have to search all the references to find the one that we
are removing, which is very slow.

Since zdb is typically used to find problems with the on-disk format,
and not with the code it is running, we should disable reference
tracking in zdb.

Upstream bugs: DLPX-43439