### PR TITLE
7569 statd support to run on a fixed port

### DIFF
--- a/usr/src/cmd/fs.d/nfs/mountd/mountd.c
+++ b/usr/src/cmd/fs.d/nfs/mountd/mountd.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -146,6 +147,8 @@ static logging_data *logging_tail = NULL;
  */
 static long ngroups_max;	/* _SC_NGROUPS_MAX */
 static long pw_size;		/* _SC_GETPW_R_SIZE_MAX */
+
+#define	PORT_MAX	65535
 
 /* ARGSUSED */
 static void *
@@ -362,6 +365,235 @@ convert_int(int *val, char *str)
 	return (0);
 }
 
+static void
+error(char *errmsg, int sv_errno) {
+	if (t_errno == TSYSERR) {
+		(void) syslog(LOG_ERR, "%s: %s\n", errmsg, t_strerror(t_errno));
+	} else {
+		(void) syslog(LOG_ERR, "%s: %s\n", errmsg, strerror(sv_errno));
+	}
+}
+
+/*
+ * Any number larger than the number of different services we need to register;
+ * one per network devices we're supporting.
+ */
+#define	SVCS_LIST_SIZE	32
+
+SVCXPRT *svcs[SVCS_LIST_SIZE];
+
+/*
+ * This function accomplishes the same thing as svc_create, except that it
+ * allows a port to be specified.  If no port is specified, svc_create is
+ * called directly.  Otherwise, we will loop through every network device in
+ * the given nettype, and register the mountd service on that device, on the
+ * provided port.
+ */
+static int
+create_svc(const rpcprog_t prognum, const rpcvers_t versnum, char *nettype,
+    in_port_t port) {
+	void *handle;
+	struct netconfig *nconf, *tcp6_nconf;
+	struct t_info tinfo;
+	struct t_bind *bind_addr, *reqb;
+	int fd, sv_errno;
+	boolean_t tcp_done = B_FALSE;
+	char error_buf[256];
+	int num_reg = 0;
+
+
+	if (ntohs(port) == 0) {
+		return (svc_create(mnt, prognum, versnum, nettype));
+	}
+
+	handle = (void *)__rpc_setconf(nettype);
+	if (handle == NULL) {
+		syslog(LOG_ERR, "Failed to retrieve rpc conf handle for %s\n",
+		    nettype);
+		return (0);
+	}
+
+	/*
+	 * We loop through every device in the given nettype, registering the
+	 * mountd service on that device.  However, there is a small catch.
+	 * When we register ourselves on the tcp6 device, it registers us for
+	 * both ipv4 and ipv6, preventing us from registering through the tcp
+	 * device.  This causes many machines to not be able to connect to us,
+	 * even though we're presenting an ipv4 mountd address through tcp6.
+	 * The simplest way around this is to register tcp before tcp6; this
+	 * loop does that.  When tcp first comes up, it sets a flag so that we
+	 * know we've completed tcp.  Then, when tcp6 comes up in the list,
+	 * there are two options.  If we've already completed tcp, then when we
+	 * enter the second if statement, we proceed with tcp6.  If not, then
+	 * we store it in tcp6_nconf and continue until we find tcp.  After we
+	 * finish tcp, the next time through the loop, we see that tcp_done is
+	 * set and tcp6_nconf is set, so we execute that, rather than pulling
+	 * another device off the rpc handle.
+	 */
+	while ((tcp_done && (nconf = tcp6_nconf) != NULL) ||
+	    (nconf = (struct netconfig *)__rpc_getconf(handle))) {
+		int i;
+		SVCXPRT *xprt;
+
+		if (strcmp(nconf->nc_netid, "tcp") == 0) {
+			tcp_done = B_TRUE;
+		} else if (strcmp(nconf->nc_netid, "tcp6") == 0) {
+			if (tcp_done) {
+				tcp6_nconf = NULL;
+			} else {
+				tcp6_nconf = nconf;
+				continue;
+			}
+		}
+
+		/*
+		 * We loop through the services we've already registered.
+		 * If we find a service already registered for this device,
+		 * we add our version number to it.  If we instead create a new
+		 * service, some versions of mountd end up being inaccessible.
+		 */
+		for (i = 0; i < SVCS_LIST_SIZE && svcs[i] != NULL; i++) {
+			SVCXPRT *iter_xprt = svcs[i];
+			if (strcmp(iter_xprt->xp_netid, nconf->nc_netid) != 0)
+				continue;
+			/* Found an old one, use it */
+			(void) rpcb_unset(prognum, versnum, nconf);
+			if (svc_reg(iter_xprt, prognum, versnum, mnt, nconf) ==
+			    FALSE) {
+				sv_errno = errno;
+				(void) sprintf(error_buf, "Failed to "
+				    "reregister %s %d: ", nettype, versnum);
+				error(error_buf, sv_errno);
+			} else {
+				num_reg++;
+			}
+			break;
+		}
+
+		if (i < SVCS_LIST_SIZE && svcs[i] != NULL)
+			continue;
+
+		/*
+		 * Intentionally leaked, since closing it terminates the
+		 * transport
+		 */
+		fd = t_open(nconf->nc_device, O_RDWR, &tinfo);
+		if (fd == -1) {
+			sv_errno = errno;
+			(void) sprintf(error_buf, "couldn't register %s %d: "
+			    "Failed open: ", nettype, versnum);
+			error(error_buf, sv_errno);
+			continue;
+		}
+
+		bind_addr = (struct t_bind *)t_alloc(fd, T_BIND, T_ADDR);
+		if ((bind_addr == NULL)) {
+			sv_errno = errno;
+			(void) sprintf(error_buf, "couldn't register %s %d: ",
+			    "Failed allocation: ", nettype, versnum);
+			error(error_buf, sv_errno);
+			(void) t_close(fd);
+			continue;
+		}
+		reqb = (struct t_bind *)t_alloc(fd, T_BIND, T_ADDR);
+		if ((reqb == NULL)) {
+			sv_errno = errno;
+			(void) sprintf(error_buf, "couldn't register %s %d: ",
+			    "Failed allocation: ", nettype, versnum);
+			error(error_buf, sv_errno);
+			(void) t_close(fd);
+			t_free((char *)bind_addr, T_BIND);
+			continue;
+		}
+
+		if (strcmp(nconf->nc_protofmly, NC_INET6) == 0) {
+			struct sockaddr_in6 *sin;
+			reqb->qlen = 1;
+			reqb->addr.len = sizeof (struct sockaddr_in6);
+			sin = (struct sockaddr_in6 *)reqb->addr.buf;
+			(void) memset((void *)sin, 0,
+			    sizeof (struct sockaddr_in6));
+			sin->sin6_family = AF_INET6;
+			sin->sin6_port = port;
+		} else if (strcmp(nconf->nc_protofmly, NC_INET) == 0) {
+			struct sockaddr_in *sin;
+			reqb->qlen = 1;
+			reqb->addr.len = sizeof (struct sockaddr_in);
+			sin = (struct sockaddr_in *)reqb->addr.buf;
+			(void) memset((void *)sin, 0,
+			    sizeof (struct sockaddr_in));
+			sin->sin_family = AF_INET;
+			sin->sin_port = port;
+		} else if (strcmp(nconf->nc_protofmly, NC_LOOPBACK) == 0) {
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+			bind_addr = NULL;
+			reqb = NULL;
+		} else {
+			(void) t_close(fd);
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+			(void) syslog(LOG_ERR, "Unhandled protofmly %s, %s\n",
+				nconf->nc_protofmly, nettype);
+			continue;
+		}
+
+		if (t_bind(fd, reqb, bind_addr) == -1) {
+			error("Bind failed", errno);
+			(void) t_close(fd);
+			if (bind_addr != NULL) {
+				(void) t_free((char *)bind_addr, T_BIND);
+				(void) t_free((char *)reqb, T_BIND);
+			}
+			continue;
+		}
+
+		if ((xprt = svc_tli_create(fd, nconf, bind_addr, 0, 0)) ==
+		    NULL) {
+			error("Service creation failed", errno);
+			(void) t_unbind(fd);
+			(void) t_close(fd);
+			if (bind_addr != NULL) {
+				(void) t_free((char *)bind_addr, T_BIND);
+				(void) t_free((char *)reqb, T_BIND);
+			}
+			continue;
+		}
+		svcs[i] = xprt;
+		(void) rpcb_unset(prognum, versnum, nconf);
+		if (svc_reg(xprt, prognum, versnum, mnt, nconf) == FALSE) {
+			error("Failed to register service", errno);
+			(void) t_unbind(fd);
+			(void) t_close(fd);
+			SVC_DESTROY(xprt);
+			svcs[i] = NULL;
+		} else {
+			num_reg++;
+		}
+
+		if (bind_addr != NULL) {
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+		}
+	}
+	__rpc_endconf(handle);
+	return (num_reg);
+}
+
+static void
+create_svcs(const rpcprog_t prognum, const rpcvers_t versnum, int port) {
+	if (svc_create_port(mnt, prognum, versnum, "datagram_v", htons(port)) == 0) {
+		syslog(LOG_ERR, "couldn't register devices on datagram_v %d\n",
+		    versnum);
+		exit(1);
+	}
+	if (svc_create_port(mnt, prognum, versnum, "circuit_v", htons(port)) == 0) {
+		syslog(LOG_ERR, "couldn't register devices on circuit_v %d\n",
+		    versnum);
+		exit(1);
+	}
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -378,6 +610,7 @@ main(int argc, char *argv[])
 	struct rlimit rl;
 	int listen_backlog = 0;
 	int max_threads = 0;
+	int port = 0;
 	int tmp;
 
 	int	pipe_fd = -1;
@@ -422,7 +655,14 @@ main(int argc, char *argv[])
 		    "failed, using default value");
 	}
 
-	while ((c = getopt(argc, argv, "vrm:")) != EOF) {
+	ret = nfs_smf_get_iprop("mountd_port", &port,
+	    DEFAULT_INSTANCE, SCF_TYPE_INTEGER, NFSD);
+	if (ret != SA_OK) {
+		syslog(LOG_ERR, "Reading of mountd_port from SMF "
+		    "failed, using default value");
+	}
+
+	while ((c = getopt(argc, argv, "vrm:p:")) != EOF) {
 		switch (c) {
 		case 'v':
 			verbose++;
@@ -438,6 +678,15 @@ main(int argc, char *argv[])
 				break;
 			}
 			max_threads = tmp;
+			break;
+		case 'p':
+			if (convert_int(&tmp, optarg) != 0 || tmp < 1 ||
+			    tmp > PORT_MAX) {
+				(void) fprintf(stderr, "%s: invalid port "
+				    "number\n", argv[0]);
+				break;
+			}
+			port = tmp;
 			break;
 		default:
 			fprintf(stderr, "usage: mountd [-v] [-r]\n");
@@ -601,6 +850,11 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
+	if (port < 0 || port > PORT_MAX) {
+		fprintf(stderr, "unable to use specified port\n");
+		exit(1);
+	}
+
 	/*
 	 * Make sure to unregister any previous versions in case the
 	 * user is reconfiguring the server in interesting ways.
@@ -648,44 +902,15 @@ main(int argc, char *argv[])
 	 * Create datagram and connection oriented services
 	 */
 	if (mount_vers_max >= MOUNTVERS) {
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS, "datagram_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register datagram_v MOUNTVERS\n");
-			exit(1);
-		}
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS, "circuit_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register circuit_v MOUNTVERS\n");
-			exit(1);
-		}
+		create_svcs(MOUNTPROG, MOUNTVERS, port);
 	}
 
 	if (mount_vers_max >= MOUNTVERS_POSIX) {
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS_POSIX,
-		    "datagram_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register datagram_v MOUNTVERS_POSIX\n");
-			exit(1);
-		}
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS_POSIX,
-		    "circuit_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register circuit_v MOUNTVERS_POSIX\n");
-			exit(1);
-		}
+		create_svcs(MOUNTPROG, MOUNTVERS_POSIX, port);
 	}
 
 	if (mount_vers_max >= MOUNTVERS3) {
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS3, "datagram_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register datagram_v MOUNTVERS3\n");
-			exit(1);
-		}
-		if (svc_create(mnt, MOUNTPROG, MOUNTVERS3, "circuit_v") == 0) {
-			fprintf(stderr,
-			    "couldn't register circuit_v MOUNTVERS3\n");
-			exit(1);
-		}
+		create_svcs(MOUNTPROG, MOUNTVERS3, port);
 	}
 
 	/*

--- a/usr/src/cmd/fs.d/nfs/statd/Makefile
+++ b/usr/src/cmd/fs.d/nfs/statd/Makefile
@@ -28,24 +28,27 @@
 # Copyright 1990-2003 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2016 by Delphix. All rights reserved.
+#
 
 FSTYPE=		nfs
 TYPEPROG=	statd
 ATTMK=		$(TYPEPROG)
 
 include		../../Makefile.fstype
-CPPFLAGS +=     -D_REENTRANT -DSUN_THREADS
 
 CERRWARN +=	-_gcc=-Wno-unused-variable
+CERRWARN +=	-_gcc=-Wno-switch
 CERRWARN +=	-_gcc=-Wno-parentheses
 CERRWARN +=	-_gcc=-Wno-uninitialized
 
 LOCAL=		sm_svc.o sm_proc.o sm_statd.o
-OBJS= 		$(LOCAL) selfcheck.o daemon.o
+OBJS=		$(LOCAL) selfcheck.o daemon.o smfcfg.o
 
-SRCS=		$(LOCAL:%.o=%.c) ../lib/selfcheck.c ../lib/daemon.c
+SRCS=		$(LOCAL:%.o=%.c) ../lib/selfcheck.c ../lib/daemon.c ../lib/smfcfg.c
 
-LDLIBS +=	-lsocket -lrpcsvc -lnsl
+LDLIBS +=	-lsocket -lrpcsvc -lnsl -lscf
+CPPFLAGS +=     -I../lib
 
 $(TYPEPROG):	$(OBJS)
 		$(LINK.c) -o $@ $(OBJS) $(LDLIBS)
@@ -57,6 +60,9 @@ selfcheck.o:	../lib/selfcheck.c
 
 daemon.o:	../lib/daemon.c
 		$(COMPILE.c) ../lib/daemon.c
+
+smfcfg.o:	../lib/smfcfg.c
+		$(COMPILE.c) ../lib/smfcfg.c
 
 lint:		lint_SRCS
 

--- a/usr/src/cmd/fs.d/nfs/svc/server.xml
+++ b/usr/src/cmd/fs.d/nfs/svc/server.xml
@@ -23,7 +23,7 @@
 
 	Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
 	Copyright 2014 Nexenta Systems, Inc.  All rights reserved
-	Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
+	Copyright (c) 2012, 2014 by Delphix. All rights reserved.
 
 	NOTE:  This service manifest is not editable; its contents will
 	be overwritten by package or patch operations, including
@@ -151,7 +151,7 @@
 		<propval name='ipf_method' type='astring'
 		    value='/lib/svc/method/nfs-server ipfilter' />
 	</property_group>
- 
+
 	<property_group name='firewall_config' type='com.sun,fw_configuration'>
 		<propval name='policy' type='astring' value='use_global' />
 		<propval name='block_policy' type='astring'
@@ -177,6 +177,7 @@
 	   <propval name='servers' type='integer' value='16'/>
 	   <propval name='mountd_listen_backlog' type='integer' value='64'/>
 	   <propval name='mountd_max_threads' type='integer' value='16'/>
+	   <propval name='mountd_port' type='integer' value='0'/>
 	 </property_group>
 	</instance>
 

--- a/usr/src/cmd/fs.d/nfs/svc/server.xml
+++ b/usr/src/cmd/fs.d/nfs/svc/server.xml
@@ -23,6 +23,7 @@
 
 	Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
 	Copyright 2014 Nexenta Systems, Inc.  All rights reserved
+	Copyright 2016 Hans Rosenfeld <rosenfeld@grumpf.hope-2000.org>
 	Copyright (c) 2012, 2014 by Delphix. All rights reserved.
 
 	NOTE:  This service manifest is not editable; its contents will

--- a/usr/src/cmd/fs.d/nfs/svc/status.xml
+++ b/usr/src/cmd/fs.d/nfs/svc/status.xml
@@ -33,16 +33,14 @@
 	$SRC/head/rpcsvc/daemon_utils.h and libnsl:open_daemon_lock().
 -->
 
+<!-- Copyright (c) 2016 by Delphix. All rights reserved. -->
+
 <service_bundle type='manifest' name='SUNWnfscr:nfs-status'>
 
 <service
 	name='network/nfs/status'
 	type='service'
 	version='1'>
-
-	<create_default_instance enabled='false' />
-
-	<single_instance />
 
 	<dependency name='network'
 	    grouping='require_any'
@@ -88,6 +86,12 @@
 		<stability value='Evolving' />
 		<propval name='auto_enable' type='boolean' value='true' />
 	</property_group>
+
+	<instance name='default' enabled='false'>
+		<property_group name='nfs-props' type='com.oracle.nfs,props'>
+			<propval name='statd_port' type='integer' value='0'/>
+		</property_group>
+	</instance>
 
 	<stability value='Stable' />
 

--- a/usr/src/lib/libnsl/common/mapfile-vers
+++ b/usr/src/lib/libnsl/common/mapfile-vers
@@ -21,6 +21,7 @@
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+# Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
 #
@@ -38,6 +39,11 @@
 #
 
 $mapfile_version 2
+
+SYMBOL_VERSION ILLUMOS_0.1 {
+    global:
+        svc_create_port;
+} SUNW_1.10;
 
 SYMBOL_VERSION SUNW_1.10 {	# SunOS 5.11 (Solaris 11)
     global:

--- a/usr/src/lib/libnsl/rpc/svc_generic.c
+++ b/usr/src/lib/libnsl/rpc/svc_generic.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1988 AT&T */
@@ -106,6 +107,221 @@ __svc_free_xprtlist(void)
 	__svc_free_xlist(&_svc_xprtlist, &xprtlist_lock);
 }
 
+static void
+error(char *errmsg, int sv_errno)
+{
+	if (t_errno != TSYSERR) {
+		(void) syslog(LOG_ERR, "%s: %s\n", errmsg, t_strerror(t_errno));
+	} else {
+		(void) syslog(LOG_ERR, "%s: %s\n", errmsg, strerror(sv_errno));
+	}
+}
+
+/*
+ * This function accomplishes the same thing as svc_create, except that it
+ * allows a port to be specified.  If no port is specified, svc_create is
+ * called.  Otherwise, we will loop through every network device in the given
+ * nettype, and register the service on that device, on the provided port.
+ */
+int
+svc_create_port(void (*dispatch)(), const rpcprog_t prognum,
+    const rpcvers_t versnum, const char *nettype, in_port_t port)
+{
+	void *handle;
+	struct netconfig *nconf, *tcp6_nconf = NULL;
+	struct t_info tinfo;
+	struct t_bind *bind_addr, *reqb;
+	int fd, sv_errno;
+	boolean_t tcp_done = B_FALSE;
+	char error_buf[256];
+	int num_reg = 0;
+	SVCXPRT_LIST *l;
+
+	if (ntohs(port) == 0) {
+		return (svc_create(dispatch, prognum, versnum, nettype));
+	}
+
+	handle = __rpc_setconf((char *) nettype);
+	if (handle == NULL) {
+		syslog(LOG_ERR, "Failed to retrieve rpc conf handle for %s\n",
+		    nettype);
+		return (0);
+	}
+
+	/*
+	 * We loop through every device in the given nettype, registering the
+	 * service on that device.  However, there is a small catch. When we
+	 * register the service on the tcp6 device, it registers for both ipv4
+	 * and ipv6, preventing us from registering through the tcp device.
+	 * This causes many machines to not be able to connect to the service
+	 * we're registering, even though an ipv4 address is being presented
+	 * through tcp6. The simplest way around this is to register tcp before
+	 * tcp6; this loop does that. When tcp first comes up, it sets a flag so
+	 * that we know we've completed tcp.  When tcp6 comes up in the list,
+	 * there are two options.  If we've already completed tcp, then we
+	 * proceed with tcp6.  If not, then we store it in tcp6_nconf and
+	 * continue until we find tcp.  After we finish tcp, the next time
+	 * through the loop, we see that tcp_done is set and tcp6_nconf is set,
+	 * so we execute that, rather than pulling another device off the rpc
+	 * handle.
+	 */
+	while ((tcp_done && (nconf = tcp6_nconf) != NULL) ||
+	    (nconf = (struct netconfig *)__rpc_getconf(handle))) {
+		SVCXPRT *xprt;
+
+		if (strcmp(nconf->nc_netid, "tcp") == 0) {
+			tcp_done = B_TRUE;
+		} else if (strcmp(nconf->nc_netid, "tcp6") == 0) {
+			if (tcp_done) {
+				tcp6_nconf = NULL;
+			} else {
+				tcp6_nconf = nconf;
+				continue;
+			}
+		}
+
+		/*
+		 * We loop through the services we've already registered.
+		 * If we find a service already registered for this device,
+		 * we add our version number to it.  If we were to instead
+		 * create a new service, some of the versions might be
+		 * inaccessible.
+		 */
+		for (l = _svc_xprtlist; l; l = l->next) {
+			if (strcmp(l->xprt->xp_netid, nconf->nc_netid) == 0) {
+				/* Found an old one, use it */
+				(void) rpcb_unset(prognum, versnum, nconf);
+				if (svc_reg(l->xprt, prognum, versnum,
+				    dispatch, nconf) == FALSE)
+					(void) syslog(LOG_ERR,
+					    "svc_create_port: could not "
+					    "register prog %d vers %d on %s",
+					    prognum, versnum, nconf->nc_netid);
+				else
+					num_reg++;
+				break;
+			}
+		}
+		(void) mutex_unlock(&xprtlist_lock);
+		if (l != NULL)
+			continue;
+
+		/*
+		 * Intentionally leaked, since closing it terminates the
+		 * transport
+		 */
+		fd = t_open(nconf->nc_device, O_RDWR, &tinfo);
+		if (fd == -1) {
+			sv_errno = errno;
+			(void) snprintf(error_buf, 256, "couldn't register %s "
+			    "%lu: Failed open", nettype, versnum);
+			error(error_buf, sv_errno);
+			continue;
+		}
+
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
+		bind_addr = (struct t_bind *)t_alloc(fd, T_BIND, T_ADDR);
+		if ((bind_addr == NULL)) {
+			sv_errno = errno;
+			(void) snprintf(error_buf,  256, "couldn't register %s "
+			    "%lu: Failed allocation", nettype, versnum);
+			error(error_buf, sv_errno);
+			(void) t_close(fd);
+			continue;
+		}
+		/* LINTED E_BAD_PTR_CAST_ALIGN */
+		reqb = (struct t_bind *)t_alloc(fd, T_BIND, T_ADDR);
+		if ((reqb == NULL)) {
+			sv_errno = errno;
+			(void) snprintf(error_buf,  256, "couldn't register %s "
+			    "%lu: Failed allocation", nettype, versnum);
+			error(error_buf, sv_errno);
+			(void) t_close(fd);
+			(void) t_free((char *)bind_addr, T_BIND);
+			continue;
+		}
+
+		if (strcmp(nconf->nc_protofmly, NC_INET6) == 0) {
+			struct sockaddr_in6 *sin;
+			reqb->qlen = 1;
+			reqb->addr.len = sizeof (struct sockaddr_in6);
+			/* LINTED E_BAD_PTR_CAST_ALIGN */
+			sin = (struct sockaddr_in6 *)reqb->addr.buf;
+			(void) memset((void *)sin, 0,
+			    sizeof (struct sockaddr_in6));
+			sin->sin6_family = AF_INET6;
+			sin->sin6_port = port;
+		} else if (strcmp(nconf->nc_protofmly, NC_INET) == 0) {
+			struct sockaddr_in *sin;
+			reqb->qlen = 1;
+			reqb->addr.len = sizeof (struct sockaddr_in);
+			/* LINTED E_BAD_PTR_CAST_ALIGN */
+			sin = (struct sockaddr_in *)reqb->addr.buf;
+			(void) memset((void *)sin, 0,
+			    sizeof (struct sockaddr_in));
+			sin->sin_family = AF_INET;
+			sin->sin_port = port;
+		} else if (strcmp(nconf->nc_protofmly, NC_LOOPBACK) == 0) {
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+			bind_addr = NULL;
+			reqb = NULL;
+		} else {
+			(void) t_close(fd);
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+			(void) syslog(LOG_ERR, "Unhandled protofmly %s, %s\n",
+				nconf->nc_protofmly, nettype);
+			continue;
+		}
+
+		if (t_bind(fd, reqb, bind_addr) == -1) {
+			error("Bind failed", errno);
+			(void) t_close(fd);
+			if (bind_addr != NULL) {
+				(void) t_free((char *)bind_addr, T_BIND);
+				(void) t_free((char *)reqb, T_BIND);
+			}
+			continue;
+		}
+
+		if ((xprt = svc_tli_create(fd, nconf, bind_addr, 0, 0)) ==
+		    NULL) {
+			error("Service creation failed", errno);
+			(void) t_unbind(fd);
+			(void) t_close(fd);
+			if (bind_addr != NULL) {
+				(void) t_free((char *)bind_addr, T_BIND);
+				(void) t_free((char *)reqb, T_BIND);
+			}
+			continue;
+		}
+		(void) rpcb_unset(prognum, versnum, nconf);
+		if (svc_reg(xprt, prognum, versnum, dispatch, nconf) == FALSE) {
+			error("Failed to register service", errno);
+			(void) t_unbind(fd);
+			(void) t_close(fd);
+			SVC_DESTROY(xprt);
+			xprt = NULL;
+		} else {
+			num_reg++;
+		}
+
+		if (xprt && !__svc_add_to_xlist(&_svc_xprtlist, xprt,
+		    &xprtlist_lock)) {
+			(void) syslog(LOG_ERR, "svc_create_port: no memory");
+			return (0);
+		}
+
+		if (bind_addr != NULL) {
+			(void) t_free((char *)bind_addr, T_BIND);
+			(void) t_free((char *)reqb, T_BIND);
+		}
+	}
+	__rpc_endconf(handle);
+	return (num_reg);
+}
+
 int
 svc_create(void (*dispatch)(), const rpcprog_t prognum, const rpcvers_t versnum,
 							const char *nettype)
@@ -151,18 +367,19 @@ svc_create(void (*dispatch)(), const rpcprog_t prognum, const rpcvers_t versnum,
 			}
 		}
 		(void) mutex_unlock(&xprtlist_lock);
-		if (l == NULL) {
-			/* It was not found. Now create a new one */
-			xprt = svc_tp_create(dispatch, prognum, versnum, nconf);
-			if (xprt) {
-				if (!__svc_add_to_xlist(&_svc_xprtlist, xprt,
-				    &xprtlist_lock)) {
-					(void) syslog(LOG_ERR,
-					    "svc_create: no memory");
-					return (0);
-				}
-				num++;
+		if (l != NULL)
+			continue;
+
+		/* It was not found. Now create a new one */
+		xprt = svc_tp_create(dispatch, prognum, versnum, nconf);
+		if (xprt) {
+			if (!__svc_add_to_xlist(&_svc_xprtlist, xprt,
+				&xprtlist_lock)) {
+				(void) syslog(LOG_ERR,
+					"svc_create: no memory");
+				return (0);
 			}
+			num++;
 		}
 	}
 	__rpc_endconf(handle);

--- a/usr/src/lib/libshare/nfs/libshare_nfs.c
+++ b/usr/src/lib/libshare/nfs/libshare_nfs.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2562,6 +2563,14 @@ struct proto_option_defs {
 	{"mountd_max_threads",
 	    "mountd_max_threads", PROTO_OPT_MOUNTD_MAX_THREADS,
 	    OPT_TYPE_NUMBER, 16, SVC_NFSD|SVC_MOUNTD, 1, INT32_MAX},
+#define	PROTO_OPT_MOUNTD_PORT			17
+	{"mountd_port",
+	    "mountd_port", PROTO_OPT_MOUNTD_PORT,
+	    OPT_TYPE_NUMBER, 0, SVC_MOUNTD, 1, UINT16_MAX},
+#define	PROTO_OPT_STATD_PORT			18
+	{"statd_port",
+	    "statd_port", PROTO_OPT_STATD_PORT,
+	    OPT_TYPE_NUMBER, 0, SVC_STATD, 1, UINT16_MAX},
 	{NULL}
 };
 

--- a/usr/src/uts/common/rpc/svc.h
+++ b/usr/src/uts/common/rpc/svc.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /* Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
 /* All Rights Reserved */
@@ -917,6 +918,17 @@ extern int	svc_create(void (*)(struct svc_req *, SVCXPRT *),
 	 *	const char *nettype;		-- network type
 	 */
 
+extern int	svc_create_port(void (*)(struct svc_req *, SVCXPRT *),
+				const rpcprog_t, const rpcvers_t,
+				const char *, in_port_t port);
+	/*
+	 *	void (*dispatch)();		-- dispatch routine
+	 *	const rpcprog_t prognum;	-- program number
+	 *	const rpcvers_t versnum;	-- version number
+	 *	const char *nettype;		-- network type
+	 *	in_port_t port			-- port to allow connections to
+	 */
+
 /*
  * Generic server creation routine. It takes a netconfig structure
  * instead of a nettype.
@@ -1007,6 +1019,7 @@ extern	bool_t	svc_control(SVCXPRT *, const uint_t, void *);
 extern int svc_dg_enablecache(SVCXPRT *, const uint_t);
 #else	/* __STDC__ */
 extern int	svc_create();
+extern int	svc_create_port();
 extern SVCXPRT	*svc_tp_create();
 extern SVCXPRT	*svc_tli_create();
 extern SVCXPRT	*svc_vc_create();


### PR DESCRIPTION
7569 statd support to run on a fixed port
7577 mountd support to run on a fixed port

Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Matt Amdur <matt.amdur@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

A documented list of fixed network ports is needed when configuring
firewall and IDS bypass rules. statd uses a random port which makes it
difficult to configure the firewall rules. Some firewalls cannot
dynamically bypass a port-mapper allocated port number. This provides a
configuration option to run statd and mountd on a fixed port.

Upstream bugs: DLPX-31658, DLPX-28482, DLPX-45566