### PR TITLE
7575 mdb autoformatter emits an unexpected leading \n when printing l…

### DIFF
--- a/usr/src/cmd/mdb/common/mdb/mdb_io.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_io.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1513,7 +1514,17 @@ iob_doprnt(mdb_iob_t *iob, const char *format, varglist_t *ap)
 		/*
 		 * If the string and the option altstr won't fit on this line
 		 * and auto-wrap is set (default), skip to the next line.
+		 * If the string contains \n, and the \n terminated substring
+		 * + altstr is shorter than the above, use the shorter lf_len.
 		 */
+		if (u.str != NULL) {
+			char *np = strchr(u.str, '\n');
+			if (np != NULL) {
+				int lf_len = (np - u.str) + altlen;
+				if (lf_len < width)
+					width = lf_len;
+			}
+		}
 		if (IOB_WRAPNOW(iob, width))
 			mdb_iob_nl(iob);
 


### PR DESCRIPTION
…arge, formatted strings

Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>

Added code to check large, formatted strings for an embedded \n to
suppress the leading \n if it is not needed.

Upstream bug: DLPX-44630, DLPX-45117