### PR TITLE
7572 vioif panic: qe->qe_indirect_next < qe->qe_queue->vq_indirect_num

### DIFF
--- a/usr/src/uts/common/io/virtio/virtio.c
+++ b/usr/src/uts/common/io/virtio/virtio.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2012 Alexey Zaytsev <alexey.zaytsev@gmail.com>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /* Based on the NetBSD virtio driver by Minoura Makoto. */
@@ -644,7 +645,7 @@ virtio_ve_set(struct vq_entry *qe, uint64_t paddr, uint32_t len,
 unsigned int
 virtio_ve_indirect_available(struct vq_entry *qe)
 {
-	return (qe->qe_queue->vq_indirect_num - (qe->qe_indirect_next - 1));
+	return (qe->qe_queue->vq_indirect_num - qe->qe_indirect_next);
 }
 
 void

--- a/usr/src/uts/i86pc/os/cpuid.c
+++ b/usr/src/uts/i86pc/os/cpuid.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2014 Josef "Jeff" Sipek <jeffpc@josefsipek.net>
  */
@@ -423,9 +423,8 @@ static struct cpuid_info cpuid_info0;
  * (loosely defined as "pre-Pentium-4"):
  * P6, PII, Mobile PII, PII Xeon, PIII, Mobile PIII, PIII Xeon
  */
-
 #define	IS_LEGACY_P6(cpi) (			\
-	cpi->cpi_family == 6 && 		\
+	cpi->cpi_family == 6 &&			\
 		(cpi->cpi_model == 1 ||		\
 		cpi->cpi_model == 3 ||		\
 		cpi->cpi_model == 5 ||		\
@@ -1465,7 +1464,13 @@ cpuid_pass1(cpu_t *cpu, uchar_t *featureset)
 	xcpuid = 0;
 	switch (cpi->cpi_vendor) {
 	case X86_VENDOR_Intel:
-		if (IS_NEW_F6(cpi) || cpi->cpi_family >= 0xf)
+		/*
+		 * On KVM we know we will have proper support for extended
+		 * cpuid.
+		 */
+		if (IS_NEW_F6(cpi) || cpi->cpi_family >= 0xf ||
+		    (get_hwenv() == HW_KVM && cpi->cpi_family == 6 &&
+		    (cpi->cpi_model == 6 || cpi->cpi_model == 2)))
 			xcpuid++;
 		break;
 	case X86_VENDOR_AMD:


### PR DESCRIPTION
7574 boot slowness followed by panic while booting on KVM when no cpu tag is specified in virsh XML

Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Prachetaa Raghavan <prachetaa.raghavan@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Robert Mustacchi <rm@joyent.com>
Reviewed by: Igor Kozhukhov <ikozhukhov@gmail.com>

These are 2 fixes for running illumos on KVM:

The first is a panic where we access beyond the end of an array because
the calculation in virtio_ve_indirect_available() is off by one.

The second handles the case where KVM is not provided with a processor
tag in the XML file used to describe the VM to libvirt. Today this
results in the guest misunderstanding the processor type, which causes
the VM to be very slow. The fix recognizes this case based on the
processor family / model numbers and the fact that we're running
inside KVM, and compensates for the issue by incrementing xcpuid.

Upstream bugs: DLPX-43963, DLPX-44110