### PR TITLE
7591 New "zloop" command for running ztest indfinitely

### DIFF
--- a/usr/src/cmd/Makefile.targ
+++ b/usr/src/cmd/Makefile.targ
@@ -22,6 +22,8 @@
 # Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
+# Copyright (c) 2015 by Delphix. All rights reserved.
+#
 # cmd/Makefile.targ
 # common target definitions for command builds
 #
@@ -62,6 +64,11 @@ $(ROOTMANIFESTDIR)/%: %
 $(KSHPROG): $(KSHPROG).ksh
 	$(RM) $@
 	sed -e "s/TEXT_DOMAIN/${TEXT_DOMAIN}/g" $(KSHPROG).ksh > $@
+	$(CHMOD) +x $@
+
+$(BASHPROG): $(BASHPROG).bash
+	$(RM) $@
+	sed -e "s/TEXT_DOMAIN/${TEXT_DOMAIN}/g" $(BASHPROG).bash > $@
 	$(CHMOD) +x $@
 
 #

--- a/usr/src/cmd/ztest/Makefile
+++ b/usr/src/cmd/ztest/Makefile
@@ -22,10 +22,12 @@
 # Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
+# Copyright (c) 2015 by Delphix. All rights reserved.
 #
 
 PROG:sh=	basename `pwd`
+BASHPROG=	zloop
+ROOTBASHPROG=	$(ROOTBIN)/$(BASHPROG)
 
 include ../Makefile.cmd
 
@@ -40,9 +42,11 @@ lint	:=	TARGET = lint
 
 .KEEP_STATE:
 
-all clean clobber lint:	$(SUBDIRS)
+all lint:	$(SUBDIRS) $(BASHPROG)
 
-install:	$(SUBDIRS)
+clean clobber:	$(SUBDIRS)
+
+install:	$(SUBDIRS) $(ROOTBASHPROG)
 	-$(RM) $(ROOTPROG)
 	-$(LN) $(ISAEXEC) $(ROOTPROG)
 

--- a/usr/src/cmd/ztest/zloop.bash
+++ b/usr/src/cmd/ztest/zloop.bash
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
+#
+
+set -x
+export BITS=64
+export UMEM_DEBUG=default,verbose
+export UMEM_LOGGING=transaction,contents
+set +x
+
+sparc_32=sparc
+sparc_64=sparcv9
+i386_32=i86
+i386_64=amd64
+ARCH=`uname -p`
+eval 'ARCHBITS=${'"${ARCH}_${BITS}"'}'
+BIN=$ROOT/usr/bin/${ARCHBITS}
+SBIN=$ROOT/usr/sbin/${ARCHBITS}
+DEFAULTWORKDIR=/var/tmp
+DEFAULTCOREDIR=/var/tmp/zloop
+
+function usage
+{
+	echo -e "\n$0 [-t <timeout>] [-c <dump directory>]" \
+	    "[ -- [extra ztest parameters]]\n" \
+	    "\n" \
+	    "  This script runs ztest repeatedly with randomized arguments.\n" \
+	    "  If a crash is encountered, the ztest logs, any associated\n" \
+	    "  vdev files, and core file (if one exists) are moved to the\n" \
+	    "  output directory ($DEFAULTCOREDIR by default). Any options\n" \
+	    "  after the -- end-of-options marker will be passed to ztest.\n" \
+	    "\n" \
+	    "  Options:\n" \
+	    "    -t  Total time to loop for, in seconds. If not provided,\n" \
+	    "        zloop runs forever.\n" \
+	    "    -f  Specify working directory for ztest vdev files.\n" \
+	    "    -c  Specify a core dump directory to use.\n" \
+	    "    -h  Print this help message.\n" \
+	    "" >&2
+}
+
+function or_die
+{
+	$@
+	if [[ $? -ne 0 ]]; then
+		echo "Command failed: $@"
+		exit 1
+	fi
+}
+
+function store_core
+{
+	if [[ $ztrc -ne 0 ]] || [[ -f core ]]; then
+		coreid=$(/bin/date "+zloop-%y%m%d-%H%M%S")
+		foundcrashes=$(($foundcrashes + 1))
+
+		dest=$coredir/$coreid
+		or_die /bin/mkdir $dest
+		or_die /bin/mkdir $dest/vdev
+
+		echo "*** ztest crash found - moving logs to $coredir/$coreid"
+
+		or_die /bin/mv ztest.history $dest/
+		or_die /bin/mv ztest.out $dest/
+		or_die /bin/mv $workdir/ztest* $dest/vdev/
+		or_die /bin/mv $workdir/zpool.cache $dest/vdev/
+
+		# check for core
+		if [[ -f core ]]; then
+			corestatus=$(mdb -e "::status" core)
+			corestack=$(mdb -e "::stack" core)
+
+			# Dump core + logs to stored directory
+			echo "$corestatus" >>$dest/status
+			echo "$corestack" >>$dest/status
+			or_die /bin/mv core $dest/
+
+			# Record info in cores logfile
+			echo "*** core @ $coredir/$coreid/core:" | /bin/tee -a ztest.cores
+			echo "$corestatus" | /bin/tee -a ztest.cores
+			echo "$corestack" | /bin/tee -a ztest.cores
+			echo "" | /bin/tee -a ztest.cores
+		fi
+		echo "continuing..."
+	fi
+}
+
+set -x
+export PATH=${BIN}:${SBIN}
+export LD_LIBRARY_PATH=$ROOT/lib/$BITS:$ROOT/usr/lib/$BITS
+set +x
+
+# parse arguments
+# expected format: zloop [-t timeout] [-c coredir] [-- extra ztest args]
+coredir=$DEFAULTCOREDIR
+workdir=$DEFAULTWORKDIR
+timeout=0
+while getopts ":ht:c:f:" opt; do
+	case $opt in
+		t ) [[ $OPTARG -gt 0 ]] && timeout=$OPTARG ;;
+		c ) [[ $OPTARG ]] && coredir=$OPTARG ;;
+		f ) [[ $OPTARG ]] && workdir=$(/usr/bin/readlink -f $OPTARG) ;;
+		h ) usage
+		    exit 2
+		    ;;
+		* ) echo "Invalid argument: -$OPTARG";
+		    usage
+		    exit 1
+	esac
+done
+# pass remaining arguments on to ztest
+shift $((OPTIND - 1))
+
+if [[ -f core ]]; then
+	echo "There's a core dump here you might want to look at first."
+	exit 1
+fi
+
+if [[ ! -d $coredir ]]; then
+	echo "core dump directory ($coredir) does not exist, creating it."
+	or_die /bin/mkdir -p $coredir
+fi
+
+if [[ ! -w $coredir ]]; then
+	echo "core dump directory ($coredir) is not writable."
+	exit 1
+fi
+
+or_die /bin/rm -f ztest.history
+or_die /bin/rm -f ztest.cores
+
+ztrc=0		# ztest return value
+foundcrashes=0	# number of crashes found so far
+starttime=$(/bin/date +%s)
+curtime=$starttime
+
+# if no timeout was specified, loop forever.
+while [[ $timeout -eq 0 ]] || [[ $curtime -le $(($starttime + $timeout)) ]]; do
+	zopt="-VVVVV"
+
+	# switch between common arrangements & fully randomized
+	if [[ $((RANDOM % 2)) -eq 0 ]]; then
+		mirrors=2
+		raidz=0
+		parity=1
+		vdevs=2
+	else
+		mirrors=$(((RANDOM % 3) * 1))
+		parity=$(((RANDOM % 3) + 1))
+		raidz=$((((RANDOM % 9) + parity + 1) * (RANDOM % 2)))
+		vdevs=$(((RANDOM % 3) + 3))
+	fi
+	align=$(((RANDOM % 2) * 3 + 9))
+	runtime=$((RANDOM % 100))
+	passtime=$((RANDOM % (runtime / 3 + 1) + 10))
+	size=128m
+
+	zopt="$zopt -m $mirrors"
+	zopt="$zopt -r $raidz"
+	zopt="$zopt -R $parity"
+	zopt="$zopt -v $vdevs"
+	zopt="$zopt -a $align"
+	zopt="$zopt -T $runtime"
+	zopt="$zopt -P $passtime"
+	zopt="$zopt -s $size"
+	zopt="$zopt -f $workdir"
+
+	cmd="ztest $zopt $@"
+	desc="$(/bin/date '+%m/%d %T') $cmd"
+	echo "$desc" | /bin/tee -a ztest.history
+	echo "$desc" >>ztest.out
+	$BIN/$cmd >>ztest.out 2>&1
+	ztrc=$?
+	/bin/egrep '===|WARNING' ztest.out >>ztest.history
+
+	store_core
+
+	curtime=$(/bin/date +%s)
+done
+
+echo "zloop finished, $foundcrashes crashes found"
+
+/bin/uptime >>ztest.out
+
+if [[ $foundcrashes -gt 0 ]]; then
+	exit 1
+fi

--- a/usr/src/pkg/manifests/system-file-system-zfs-tests.mf
+++ b/usr/src/pkg/manifests/system-file-system-zfs-tests.mf
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2015 by Delphix. All rights reserved.
 #
 
 set name=pkg.fmri value=pkg:/system/file-system/zfs/tests@$(PKGVERS)
@@ -54,6 +54,7 @@ $(i386_ONLY)file path=usr/bin/$(ARCH32)/zlook mode=0555
 $(i386_ONLY)file path=usr/bin/$(ARCH32)/ztest mode=0555
 file path=usr/bin/$(ARCH64)/zlook mode=0555
 file path=usr/bin/$(ARCH64)/ztest mode=0555
+file path=usr/bin/zloop mode=0555
 file path=usr/include/sys/fs/zut.h
 file path=usr/lib/devfsadm/linkmod/SUNW_zut_link.so group=sys
 $(i386_ONLY)file path=usr/sbin/$(ARCH32)/zhack mode=0555


### PR DESCRIPTION
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

This change adds a new "zloop" command which is used to execute the
ztest command continually in a loop, using random arguments for each
invocation. When any given invocation of ztest terminates (either
successfully, or via a crash), a new invocation of ztest will be
started (again, using random arguments), until the desired runtime for
zloop is reached (or indefinitely, if no timeout value is specified); at
which point zloop will terminate and it's return code will reflect
whether any of the underlying invocations of ztest had crashed.

Additionally, when ztest crashes and produces a core dump, zloop will
copy this dump to a known, but configurable, location such that it can
be manually inspected later. Likewise, the vdev files that ztest uses
are also stored in a known, but configurable, location.

In addition to copying the ztest core dumps to a known location, the
status and stack trace from each dump will be automatically extracted
and inserted into the zloop log file.

And lastly, this new script has been added to the manifest of the
"pkg:/system/file-system/zfs/tests" package.

Upstream bugs: DLPX-40214, DLPX-40595, DLPX-41203, DLPX-41222, DLPX-41410, DLPX-41429