### PR TITLE
7581 merge vmxnet3s changes from open-vm-tools stable-10.0.x

### DIFF
--- a/usr/src/uts/intel/io/vmxnet3s/README.txt
+++ b/usr/src/uts/intel/io/vmxnet3s/README.txt
@@ -1,4 +1,6 @@
 #
+# CDDL HEADER START
+#
 # This file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
@@ -8,24 +10,25 @@
 # source.  A copy of the CDDL is also available via the Internet at
 # http://www.illumos.org/license/CDDL.
 #
-
+# CDDL HEADER END
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 #
 
 The vmxnet3s driver is a paravirtualized GLDv3 NIC driver designed to
-be used on VMware virtual machines version 7 and later.
-
-This version of the driver was initially based on the "stable-8.6.x" branch
-of the VMware open-vm-tools which can be obtained from:
+be used on VMware virtual machines version 7 and later.  This version
+of the driver is based on the "stable-10.0.x" branch of the VMware
+open-vm-tools which can be obtained from:
 
 https://github.com/vmware/open-vm-tools
 
-Current changes include:
+Changes from stable-10.0.x include:
 
-* cstyle and lint cleanup: the driver is lint clean with two categorical
+* add support for VLANs
+* enable building in the illumos gate
+* enable building with the Sun Studio compiler
+* lint cleanup: the driver is lint clean with two categorical
   exceptions for which warnings are disabled in the Makefile
 
-* added support for dladm mtu property
-* added support for VLANs
-* LSO fix contributed by Michael Tsymbalyuk <mtzaurus@gmail.com>
+The driver remains in the original C style to facilitate potential
+future synchronization with upstream.

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3.h
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007 VMware, Inc. All rights reserved.
+ * Copyright (C) 2007-2014 VMware, Inc. All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common
  * Development and Distribution License (the "License") version 1.0
@@ -127,6 +127,7 @@ typedef struct vmxnet3_softc_t {
 	boolean_t	devEnabled;
 	uint8_t		macaddr[6];
 	uint32_t	cur_mtu;
+	boolean_t	allow_jumbo;
 	link_state_t	linkState;
 	uint64_t	linkSpeed;
 	vmxnet3_dmabuf_t sharedData;
@@ -192,13 +193,14 @@ extern ddi_device_acc_attr_t vmxnet3_dev_attr;
 
 extern int vmxnet3s_debug;
 
-#define	VMXNET3_MODNAME "vmxnet3s"
+#define	VMXNET3_MODNAME	"vmxnet3s"
+#define	VMXNET3_DRIVER_VERSION_STRING	"1.1.0.0"
 
 /* Logging stuff */
 #define	VMXNET3_WARN(Device, ...) vmxnet3_log(CE_WARN, Device, __VA_ARGS__)
 
 #ifdef	DEBUG
-#define	VMXNET3_DEBUG(Device, Level, ...) {	 		\
+#define	VMXNET3_DEBUG(Device, Level, ...) {			\
 	if (Level <= vmxnet3s_debug) {				\
 		vmxnet3_log(CE_CONT, Device, "?" __VA_ARGS__);	\
 	}							\

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3_defs.h
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3_defs.h
@@ -31,7 +31,7 @@
 #define	VMXNET3_REG_UVRS	0x8	/* UPT Version Report Selection */
 #define	VMXNET3_REG_DSAL	0x10	/* Driver Shared Address Low */
 #define	VMXNET3_REG_DSAH	0x18	/* Driver Shared Address High */
-#define	VMXNET3_REG_CMD		0x20 	/* Command */
+#define	VMXNET3_REG_CMD		0x20	/* Command */
 #define	VMXNET3_REG_MACL	0x28	/* MAC Address Low */
 #define	VMXNET3_REG_MACH	0x30	/* MAC Address High */
 #define	VMXNET3_REG_ICR		0x38	/* Interrupt Cause Register */

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3_rx.c
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3_rx.c
@@ -12,26 +12,20 @@
  * See the License for the specific language governing permissions
  * and limitations under the License.
  */
-
 /*
  * Copyright (c) 2013 by Delphix. All rights reserved.
  */
 
 #include <vmxnet3.h>
 
-static void vmxnet3_put_rxbuf(vmxnet3_rxbuf_t *rxBuf);
+static void vmxnet3_put_rxbuf(vmxnet3_rxbuf_t *);
 
 /*
- * vmxnet3_alloc_rxbuf --
+ * Allocate a new rxBuf from memory. All its fields are set except
+ * for its associated mblk which has to be allocated later.
  *
- *    Allocate a new rxBuf from memory. All its fields are set except
- *    for its associated mblk which has to be allocated later.
- *
- * Results:
- *    A new rxBuf or NULL.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	A new rxBuf or NULL.
  */
 static vmxnet3_rxbuf_t *
 vmxnet3_alloc_rxbuf(vmxnet3_softc_t *dp, boolean_t canSleep)
@@ -65,17 +59,6 @@ vmxnet3_alloc_rxbuf(vmxnet3_softc_t *dp, boolean_t canSleep)
 	return (rxBuf);
 }
 
-/*
- * vmxnet3_free_rxbuf --
- *
- *    Free a rxBuf.
- *
- * Results:
- *    None.
- *
- * Side effects:
- *    None.
- */
 static void
 vmxnet3_free_rxbuf(vmxnet3_softc_t *dp, vmxnet3_rxbuf_t *rxBuf)
 {
@@ -93,16 +76,11 @@ vmxnet3_free_rxbuf(vmxnet3_softc_t *dp, vmxnet3_rxbuf_t *rxBuf)
 }
 
 /*
- * vmxnet3_put_rxpool_buf --
+ * Return a rxBuf to the pool.
  *
- *    Return a rxBuf to the pool.
- *
- * Results:
- *    B_TRUE if there was room in the pool and the rxBuf was returned,
- *    B_FALSE otherwise.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	B_TRUE if there was room in the pool and the rxBuf was returned,
+ *	B_FALSE otherwise.
  */
 static boolean_t
 vmxnet3_put_rxpool_buf(vmxnet3_softc_t *dp, vmxnet3_rxbuf_t *rxBuf)
@@ -125,15 +103,7 @@ vmxnet3_put_rxpool_buf(vmxnet3_softc_t *dp, vmxnet3_rxbuf_t *rxBuf)
 }
 
 /*
- * vmxnet3_put_rxbuf --
- *
- *    Return a rxBuf to the pool or free it.
- *
- * Results:
- *    None.
- *
- * Side effects:
- *    None.
+ * Return a rxBuf to the pool or free it.
  */
 static void
 vmxnet3_put_rxbuf(vmxnet3_rxbuf_t *rxBuf)
@@ -147,15 +117,10 @@ vmxnet3_put_rxbuf(vmxnet3_rxbuf_t *rxBuf)
 }
 
 /*
- * vmxnet3_get_rxpool_buf --
+ * Get an unused rxBuf from the pool.
  *
- *    Get an unused rxBuf from the pool.
- *
- * Results:
- *    A rxBuf or NULL if there are no buffers in the pool.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	A rxBuf or NULL if there are no buffers in the pool.
  */
 static vmxnet3_rxbuf_t *
 vmxnet3_get_rxpool_buf(vmxnet3_softc_t *dp)
@@ -176,16 +141,11 @@ vmxnet3_get_rxpool_buf(vmxnet3_softc_t *dp)
 }
 
 /*
- * vmxnet3_get_rxbuf --
+ * Get an unused rxBuf from either the pool or from memory.
+ * The returned rxBuf has a mblk associated with it.
  *
- *    Get an unused rxBuf from either the pool or from memory.
- *    The returned rxBuf has a mblk associated with it.
- *
- * Results:
- *    A rxBuf or NULL.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	A rxBuf or NULL.
  */
 static vmxnet3_rxbuf_t *
 vmxnet3_get_rxbuf(vmxnet3_softc_t *dp, boolean_t canSleep)
@@ -212,15 +172,10 @@ vmxnet3_get_rxbuf(vmxnet3_softc_t *dp, boolean_t canSleep)
 }
 
 /*
- * vmxnet3_rx_populate --
+ * Populate a Rx descriptor with a new rxBuf.
  *
- *    Populate a Rx descriptor with a new rxBuf.
- *
- * Results:
- *    DDI_SUCCESS or DDI_FAILURE.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	DDI_SUCCESS or DDI_FAILURE.
  */
 static int
 vmxnet3_rx_populate(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq, uint16_t idx,
@@ -247,15 +202,10 @@ vmxnet3_rx_populate(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq, uint16_t idx,
 }
 
 /*
- * vmxnet3_rxqueue_init --
+ * Initialize a RxQueue by populating the whole Rx ring with rxBufs.
  *
- *    Initialize a RxQueue by populating the whole Rx ring with rxBufs.
- *
- * Results:
- *    DDI_SUCCESS or DDI_FAILURE.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	DDI_SUCCESS or DDI_FAILURE.
  */
 int
 vmxnet3_rxqueue_init(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq)
@@ -285,15 +235,7 @@ error:
 }
 
 /*
- * vmxnet3_rxqueue_fini --
- *
- *    Finish a RxQueue by freeing all the related rxBufs.
- *
- * Results:
- *    DDI_SUCCESS.
- *
- * Side effects:
- *    None.
+ * Finish a RxQueue by freeing all the related rxBufs.
  */
 void
 vmxnet3_rxqueue_fini(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq)
@@ -322,16 +264,8 @@ vmxnet3_rxqueue_fini(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq)
 }
 
 /*
- * vmxnet3_rx_hwcksum --
- *
- *    Determine if a received packet was checksummed by the Vmxnet3
- *    device and tag the mp appropriately.
- *
- * Results:
- *    None.
- *
- * Side effects:
- *    The mp may get tagged.
+ * Determine if a received packet was checksummed by the Vmxnet3
+ * device and tag the mp appropriately.
  */
 static void
 vmxnet3_rx_hwcksum(vmxnet3_softc_t *dp, mblk_t *mp,
@@ -355,16 +289,11 @@ vmxnet3_rx_hwcksum(vmxnet3_softc_t *dp, mblk_t *mp,
 }
 
 /*
- * vmxnet3_rx_intr --
+ * Interrupt handler for Rx. Look if there are any pending Rx and
+ * put them in mplist.
  *
- *    Interrupt handler for Rx. Look if there are any pending Rx and
- *    put them in mplist.
- *
- * Results:
- *    A list of messages to pass to the MAC subystem.
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	A list of messages to pass to the MAC subystem.
  */
 mblk_t *
 vmxnet3_rx_intr(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq)
@@ -419,8 +348,8 @@ vmxnet3_rx_intr(vmxnet3_softc_t *dp, vmxnet3_rxqueue_t *rxq)
 			 * descriptor. Grab it only if we achieve to replace
 			 * it with a fresh buffer.
 			 */
-			if (vmxnet3_rx_populate(dp, rxq, rxdIdx,
-			    B_FALSE) == DDI_SUCCESS) {
+			if (vmxnet3_rx_populate(dp, rxq, rxdIdx, B_FALSE) ==
+			    DDI_SUCCESS) {
 				/* Success, we can chain the mblk with the mp */
 				mblk->b_wptr = mblk->b_rptr + compDesc->rcd.len;
 				*mpTail = mblk;

--- a/usr/src/uts/intel/io/vmxnet3s/vmxnet3_utils.c
+++ b/usr/src/uts/intel/io/vmxnet3s/vmxnet3_utils.c
@@ -71,15 +71,10 @@ static ddi_dma_attr_t vmxnet3_dma_attrs_512 = {
 };
 
 /*
- * vmxnet3_alloc_dma_mem --
+ * Allocate /size/ bytes of contiguous DMA-ble memory.
  *
- *    Allocate /size/ bytes of contiguous DMA-ble memory.
- *
- * Results:
+ * Returns:
  *    DDI_SUCCESS or DDI_FAILURE.
- *
- * Side effects:
- *    None.
  */
 static int
 vmxnet3_alloc_dma_mem(vmxnet3_softc_t *dp, vmxnet3_dmabuf_t *dma, size_t size,
@@ -161,15 +156,7 @@ vmxnet3_alloc_dma_mem_128(vmxnet3_softc_t *dp, vmxnet3_dmabuf_t *dma,
 }
 
 /*
- * vmxnet3_free_dma_mem --
- *
- *    Free DMA-ble memory.
- *
- * Results:
- *    None.
- *
- * Side effects:
- *    None.
+ * Free DMA-ble memory.
  */
 void
 vmxnet3_free_dma_mem(vmxnet3_dmabuf_t *dma)
@@ -184,18 +171,13 @@ vmxnet3_free_dma_mem(vmxnet3_dmabuf_t *dma)
 }
 
 /*
- * vmxnet3_getprop --
+ * Get the numeric value of the property "name" in vmxnet3s.conf for
+ * the corresponding device instance.
+ * If the property isn't found or if it doesn't satisfy the conditions,
+ * "def" is returned.
  *
- *    Get the numeric value of the property "name" in vmxnet3s.conf for
- *    the corresponding device instance.
- *    If the property isn't found or if it doesn't satisfy the conditions,
- *    "def" is returned.
- *
- * Results:
- *    The value of the property or "def".
- *
- * Side effects:
- *    None.
+ * Returns:
+ *	The value of the property or "def".
  */
 int
 vmxnet3_getprop(vmxnet3_softc_t *dp, char *name, int min, int max, int def)


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

The latest version of open-vm-tools has some of the same features
that we added to our version of vmxnet3s: support for jumbo-frames,
and some LSO fixes. We should merge these changes into our driver
(preferring the upstream version of the code in order to reduce
future merge pain).

Upstream bugs: DLPX-43227, DLPX-44800