### PR TITLE
7602 minor issues with zfs manpage

### DIFF
--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -748,7 +748,7 @@ or a user who has been granted the
 privilege with
 .Nm zfs Cm allow ,
 can access all groups' usage.
-.It Sy volblocksize Ns = Ns Em blocksize
+.It Sy volblocksize
 For volumes, specifies the block size of the volume. The
 .Sy blocksize
 cannot be changed once the volume has been written, so it should be set at
@@ -3027,7 +3027,7 @@ Recursively remove the permissions from this file system and all descendents.
 .Nm
 .Cm unallow
 .Op Fl r
-.Fl s @ Ns Ar setname
+.Fl s No @ Ns Ar setname
 .Oo Ar perm Ns | Ns @ Ns Ar setname Ns Oo , Ns Ar perm Ns | Ns @ Ns
 .Ar setname Oc Ns ... Oc
 .Ar filesystem Ns | Ns Ar volume


### PR DESCRIPTION
The zfs.1m man page renders one variant of unallow as

    zfs unallow [-r] -s -@setname [perm|@setname[,perm|@setname]...]
             filesystem|volume

There is an extra dash preceeding @setname that should not be there.

Also, The line "volblocksize=blocksize" should just read "volblocksize"
in the same rendering as the other properties in the same section.

Upstream bugs: DLPX-44542, DLPX-44545