### PR TITLE
7604 if volblocksize property is the default, it displays as "-" rather than 8K

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -2032,9 +2032,12 @@ get_numeric_property(zfs_handle_t *zhp, zfs_prop_t prop, zprop_source_t *src,
 			/*
 			 * If we tried to use a default value for a
 			 * readonly property, it means that it was not
-			 * present.
+			 * present.  Note this only applies to "truly"
+			 * readonly properties, not set-once properties
+			 * like volblocksize.
 			 */
 			if (zfs_prop_readonly(prop) &&
+			    !zfs_prop_setonce(prop) &&
 			    *source != NULL && (*source)[0] == '\0') {
 				*source = NULL;
 				return (-1);


### PR DESCRIPTION
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

If a zvol has the default setting for the "volblocksize" property, it is
8KB.  However, it is displayed as "-" (not present), rather than "8K".

The problem was introduced by:

    7571 non-present readonly numeric ZFS props do not have default value

which changed changed get_numeric_property() to indicate that readonly
default properties are not present.  However, zfs_prop_readonly() returns
TRUE for both readonly and set-once properties (e.g. volblocksize).

Amusingly, that commit essentially reverted:

    6900484 default volblocksize is no longer being reported correctly

from November 2009.  However, that change was not correct either; the
correct solution is to only do this check for "truly readonly" (i.e. not
setonce) properties.

Upstream bugs: DLPX-45214