### PR TITLE
7605 we should not attempt to write to ZFS while panicing

### DIFF
--- a/usr/src/uts/common/fs/vfs.c
+++ b/usr/src/uts/common/fs/vfs.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2014, Joyent, Inc. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -4038,9 +4039,6 @@ vfs_unrefvfssw(struct vfssw *vswp)
 	mutex_exit(&vswp->vsw_lock);
 }
 
-int sync_timeout = 30;		/* timeout for syncing a page during panic */
-int sync_timeleft;		/* portion of sync_timeout remaining */
-
 static int sync_retries = 20;	/* number of retries when not making progress */
 static int sync_triesleft;	/* portion of sync_retries remaining */
 
@@ -4051,23 +4049,13 @@ static int new_bufcnt, old_bufcnt;
  * Sync all of the mounted filesystems, and then wait for the actual i/o to
  * complete.  We wait by counting the number of dirty pages and buffers,
  * pushing them out using bio_busy() and page_busy(), and then counting again.
- * This routine is used during both the uadmin A_SHUTDOWN code as well as
- * the SYNC phase of the panic code (see comments in panic.c).  It should only
+ * This routine is used during the uadmin A_SHUTDOWN code.  It should only
  * be used after some higher-level mechanism has quiesced the system so that
  * new writes are not being initiated while we are waiting for completion.
  *
- * To ensure finite running time, our algorithm uses two timeout mechanisms:
- * sync_timeleft (a timer implemented by the omnipresent deadman() cyclic), and
- * sync_triesleft (a progress counter used by the vfs_syncall() loop below).
- * Together these ensure that syncing completes if our i/o paths are stuck.
- * The counters are declared above so they can be found easily in the debugger.
- *
- * The sync_timeleft counter is reset by bio_busy() and page_busy() using the
- * vfs_syncprogress() subroutine whenever we make progress through the lists of
- * pages and buffers.  It is decremented and expired by the deadman() cyclic.
- * When vfs_syncall() decides it is done, we disable the deadman() counter by
- * setting sync_timeleft to zero.  This timer guards against vfs_syncall()
- * deadlocking or hanging inside of a broken filesystem or driver routine.
+ * To ensure finite running time, our algorithm uses sync_triesleft (a progress
+ * counter used by the vfs_syncall() loop below). It is declared above so
+ * it can be found easily in the debugger.
  *
  * The sync_triesleft counter is updated by vfs_syncall() itself.  If we make
  * sync_retries consecutive calls to bio_busy() and page_busy() without
@@ -4081,13 +4069,11 @@ void
 vfs_syncall(void)
 {
 	if (rootdir == NULL && !modrootloaded)
-		return; /* panic during boot - no filesystems yet */
+		return; /* no filesystems have been loaded yet */
 
 	printf("syncing file systems...");
-	vfs_syncprogress();
 	sync();
 
-	vfs_syncprogress();
 	sync_triesleft = sync_retries;
 
 	old_bufcnt = new_bufcnt = INT_MAX;
@@ -4099,7 +4085,6 @@ vfs_syncall(void)
 
 		new_bufcnt = bio_busy(B_TRUE);
 		new_pgcnt = page_busy(B_TRUE);
-		vfs_syncprogress();
 
 		if (new_bufcnt == 0 && new_pgcnt == 0)
 			break;
@@ -4122,25 +4107,7 @@ vfs_syncall(void)
 	else
 		printf(" done\n");
 
-	sync_timeleft = 0;
 	delay(hz);
-}
-
-/*
- * If we are in the middle of the sync phase of panic, reset sync_timeleft to
- * sync_timeout to indicate that we are making progress and the deadman()
- * omnipresent cyclic should not yet time us out.  Note that it is safe to
- * store to sync_timeleft here since the deadman() is firing at high-level
- * on top of us.  If we are racing with the deadman(), either the deadman()
- * will decrement the old value and then we will reset it, or we will
- * reset it and then the deadman() will immediately decrement it.  In either
- * case, correct behavior results.
- */
-void
-vfs_syncprogress(void)
-{
-	if (panicstr)
-		sync_timeleft = sync_timeout;
 }
 
 /*

--- a/usr/src/uts/common/os/bio.c
+++ b/usr/src/uts/common/os/bio.c
@@ -24,6 +24,10 @@
  * Copyright 2011 Joyent, Inc.  All rights reserved.
  */
 
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
+
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
 
@@ -293,7 +297,7 @@ breada(dev_t dev, daddr_t blkno, daddr_t rablkno, long bsize)
  */
 void
 bwrite_common(void *arg, struct buf *bp, int force_wait,
-				int do_relse, int clear_flags)
+    int do_relse, int clear_flags)
 {
 	register int do_wait;
 	struct ufsvfs *ufsvfsp = (struct ufsvfs *)arg;
@@ -528,7 +532,6 @@ bio_busy(int cleanit)
 	kmutex_t *hmp;
 
 	for (i = 0; i < v.v_hbuf; i++) {
-		vfs_syncprogress();
 		dp = (struct buf *)&hbuf[i];
 		hmp = &hbuf[i].b_lock;
 
@@ -887,7 +890,6 @@ bflush(dev_t dev)
 	 * candidates on the delwri_list and then drop the hash locks.
 	 */
 	for (i = 0; i < v.v_hbuf; i++) {
-		vfs_syncprogress();
 		hmp = &hbuf[i].b_lock;
 		dp = (struct buf *)&dwbuf[i];
 		mutex_enter(hmp);
@@ -908,7 +910,6 @@ bflush(dev_t dev)
 	 * and write back all the buffers that have B_DELWRI set.
 	 */
 	while (delwri_list != EMPTY_LIST) {
-		vfs_syncprogress();
 		bp = delwri_list;
 
 		sema_p(&bp->b_sem);	/* may block */

--- a/usr/src/uts/common/os/clock.c
+++ b/usr/src/uts/common/os/clock.c
@@ -24,6 +24,7 @@
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -1957,13 +1958,7 @@ deadman(void)
 				panic("panic dump timeout");
 				/*NOTREACHED*/
 			}
-		} else if (panic_sync) {
-			if (sync_timeleft && (--sync_timeleft == 0)) {
-				panic("panic sync timeout");
-				/*NOTREACHED*/
-			}
 		}
-
 		return;
 	}
 

--- a/usr/src/uts/common/sys/dumphdr.h
+++ b/usr/src/uts/common/sys/dumphdr.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_DUMPHDR_H
@@ -178,8 +179,6 @@ extern char *dumppath;
 extern int dump_timeout;
 extern int dump_timeleft;
 extern int dump_ioerr;
-extern int sync_timeout;
-extern int sync_timeleft;
 
 extern int dumpinit(struct vnode *, char *, int);
 extern void dumpfini(void);

--- a/usr/src/uts/common/sys/panic.h
+++ b/usr/src/uts/common/sys/panic.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_PANIC_H
@@ -142,7 +143,6 @@ extern int do_polled_io;
 extern int obpdebug;
 extern int in_sync;
 extern int panic_quiesce;
-extern int panic_sync;
 extern int panic_dump;
 extern int64_t panic_lbolt64;
 extern label_t panic_regs;

--- a/usr/src/uts/common/sys/vfs.h
+++ b/usr/src/uts/common/sys/vfs.h
@@ -22,6 +22,7 @@
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -513,7 +514,6 @@ int	vfs_optionisset(const struct vfs *, const char *, char **);
 int	vfs_settag(uint_t, uint_t, const char *, const char *, cred_t *);
 int	vfs_clrtag(uint_t, uint_t, const char *, const char *, cred_t *);
 void	vfs_syncall(void);
-void	vfs_syncprogress(void);
 void	vfsinit(void);
 void	vfs_unmountall(void);
 void	vfs_make_fsid(fsid_t *, dev_t, int);

--- a/usr/src/uts/common/vm/vm_page.c
+++ b/usr/src/uts/common/vm/vm_page.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 1986, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
- * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989  AT&T	*/
@@ -4299,8 +4299,6 @@ retry:
 	return (pp);
 }
 
-#define	SYNC_PROGRESS_NPAGES	1000
-
 /*
  * Returns a count of dirty pages that are in the process
  * of being written out.  If 'cleanit' is set, try to push the page.
@@ -4311,21 +4309,10 @@ page_busy(int cleanit)
 	page_t *page0 = page_first();
 	page_t *pp = page0;
 	pgcnt_t nppbusy = 0;
-	int counter = 0;
 	u_offset_t off;
 
 	do {
 		vnode_t *vp = pp->p_vnode;
-
-		/*
-		 * Reset the sync timeout. The page list is very long
-		 * on large memory systems.
-		 */
-		if (++counter > SYNC_PROGRESS_NPAGES) {
-			counter = 0;
-			vfs_syncprogress();
-		}
-
 		/*
 		 * A page is a candidate for syncing if it is:
 		 *
@@ -4365,7 +4352,6 @@ page_busy(int cleanit)
 		}
 	} while ((pp = page_next(pp)) != page0);
 
-	vfs_syncprogress();
 	return (nppbusy);
 }
 


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

When we panic, we should not attempt to write dirty pages to ZFS. This
is ineffective (since we don't wait for the txg to sync), and can cause
a subsequent panic if ZFS is not in a good state (or we are short on
stack space).

Upstream bugs: DLPX-32631