### PR TITLE
7730 libzfs`add_config() leaks config nvl when reading spare/l2cache devices

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -237,9 +237,12 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 			free(ne);
 			return (-1);
 		}
+
 		ne->ne_guid = vdev_guid;
 		ne->ne_next = pl->names;
 		pl->names = ne;
+
+		nvlist_free(config);
 		return (0);
 	}
 


### PR DESCRIPTION
Free config nvl in the spare/l2cache case as we got everything we needed from it and it won't be freed back in the zpool_find_import_impl().