### PR TITLE
7736 ZFS Performance tests should log FIO summary output

### DIFF
--- a/usr/src/test/zfs-tests/tests/perf/perf.shlib
+++ b/usr/src/test/zfs-tests/tests/perf/perf.shlib
@@ -60,8 +60,9 @@ function do_fio_run
 	for threads in $PERF_NTHREADS; do
 		for sync in $PERF_SYNC_TYPES; do
 			for iosize in $PERF_IOSIZES; do
+				typeset sync_str=$(get_sync_str $sync)
 				log_note "Running with $threads" \
-				    "$(get_sync_str $sync) threads, $iosize ios"
+				    "$sync_str threads, $iosize ios"
 
 				if $do_recreate; then
 					recreate_perfpool
@@ -85,8 +86,16 @@ function do_fio_run
 				# Start the data collection
 				do_collect_scripts $threads $sync $iosize
 
+				# This will be part of the output filename.
+				typeset suffix="$sync_str.$iosize-ios.$threads-threads"
+
+				# Define output file
+				typeset logbase="$(get_perf_output_dir)/$($BASENAME \
+				    $SUDO_COMMAND)"
+				typeset outfile="$logbase.fio.$suffix"
+
 				# Start the load
-				log_must fio $FIO_SCRIPTS/$script
+				log_must fio --output $outfile $FIO_SCRIPTS/$script
 			done
 		done
 	done


### PR DESCRIPTION
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Stephen Blinick <stephen.blinick@delphix.com>

Current zfs performance tests don't store the FIO summary output to
discrete files along-side the output from the monitoring scripts. A
single log file of stdout of all tests is created in the root
directory but it includes numerous other data and no clear
delineation about which test type produced which output.

This is a small change proposed to have each ZFS performance test also
create a 'fio' output log for each run in the:

    test_results/<testid>/perf_data

directory. The output is obtained using the `--output` parameter of FIO.

Upstream bugs: DLPX-45327