### PR TITLE
7739 zfs_inherit_003_pos fails due to improperly generated random strings

### DIFF
--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -855,7 +855,7 @@ function get_prop # property dataset
 		return 1
 	fi
 
-	echo $prop_val
+	echo "$prop_val"
 	return 0
 }
 


### PR DESCRIPTION
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

The problem is that get_prop (in libtest.sh) does not faithfully print the
property value. It needs to enclose $prop_val in double-quotes.

Upstream bugs: QA-870