### PR TITLE
7761 bootfs_005_neg's pool destruction must handle EBUSY

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/bootfs/bootfs_005_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/bootfs/bootfs_005_neg.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -53,14 +53,10 @@ function cleanup {
 	typeset pool_name
 	for config in $CONFIGS; do
 		pool_name=$(eval echo \$ZPOOL_VERSION_${config}_NAME)
-		if poolexists $pool_name; then
-			log_must zpool destroy $pool_name
-		fi
+		destroy_pool $pool_name
 	done
 
-	if poolexists $TESTPOOL ; then
-		log_must zpool destroy $TESTPOOL
-	fi
+	destroy_pool $TESTPOOL
 }
 
 log_assert "Boot properties cannot be set on pools with older versions"

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_upgrade/zpool_upgrade.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2017 by Delphix. All rights reserved.
 # Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
 #
 
@@ -93,9 +93,7 @@ function destroy_upgraded_pool
 	typeset -n pool_files=ZPOOL_VERSION_${vers}_FILES
 	typeset -n pool_name=ZPOOL_VERSION_${vers}_NAME
 
-	if poolexists $pool_name; then
-		log_must zpool destroy $pool_name
-	fi
+	destroy_pool $pool_name
 	for file in $pool_files; do
 		rm -f /$TESTPOOL/$file
 	done


### PR DESCRIPTION
This patch updates the pool destruction operations that occur in the
context of the `bootfs_005_neg` test case, to use the `destroy_pool`
function, which handles retrying the `zpool destroy` operation when it
fails.