### PR TITLE
7762 avoid division by zero in property_alias_001_pos

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_set/property_alias_001_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -111,7 +111,7 @@ for ds in $pool $fs $vol; do
 			done
 			;;
 		reservation|reserv )
-			(( reservsize = $avail_space % $RANDOM ))
+			(( reservsize = $avail_space % (( $RANDOM + 1 )) ))
 			for val in "0" "$reservsize" "none"; do
 				set_and_check $ds ${rw_prop[i]} $val ${chk_prop[i]}
 			done


### PR DESCRIPTION
The `property_alias_001_pos` test case of the zfstest suite attempts
to perform division using `$RANDOM` as the divisor. Thus, if `$RANDOM`
happens to evaluate to zero, the test will fail. We need to update the
test to avoid this potential failure mode, which can be done by simply
adding one to the value of `$RANDOM` prior to performing the division.