### PR TITLE
7764 vioif norcvbuf kstat goes up for each receive interrupt

### DIFF
--- a/usr/src/uts/common/io/vioif/vioif.c
+++ b/usr/src/uts/common/io/vioif/vioif.c
@@ -712,23 +712,10 @@ static uint_t
 vioif_add_rx(struct vioif_softc *sc, int kmflag)
 {
 	uint_t num_added = 0;
+	struct vq_entry *ve;
 
-	for (;;) {
-		struct vq_entry *ve;
-		struct vioif_rx_buf *buf;
-
-		ve = vq_alloc_entry(sc->sc_rx_vq);
-		if (!ve) {
-			/*
-			 * Out of free descriptors - ring already full.
-			 * It would be better to update sc_norxdescavail
-			 * but MAC does not ask for this info, hence we
-			 * update sc_norecvbuf.
-			 */
-			sc->sc_norecvbuf++;
-			break;
-		}
-		buf = sc->sc_rxbufs[ve->qe_index];
+	while ((ve = vq_alloc_entry(sc->sc_rx_vq)) != NULL) {
+		struct vioif_rx_buf *buf = sc->sc_rxbufs[ve->qe_index];
 
 		if (!buf) {
 			/* First run, allocate the buffer. */


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>

The mac:norcvbuf kstat is meant to account for dropped received packets
due to memory allocation failures. For vioif, this kstat gets
erroneously bumped by 1 under normal conditions each time a receive
interrupt is received.

This problem is that the loop responsible for allocating new rx
resources terminates only when vq_alloc_entry() returns NULL (when all
entries in the queue have been allocated), which is a normal condition.
This condition shouldn't result in any kstat getting bumped.

Upstream bugs: DLPX-46663