### PR TITLE
Port hole birth tests from zfsonlinux #5675 to openzfs

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -101,6 +101,7 @@ dir path=opt/zfs-tests/tests/functional/grow_pool
 dir path=opt/zfs-tests/tests/functional/grow_replicas
 dir path=opt/zfs-tests/tests/functional/history
 dir path=opt/zfs-tests/tests/functional/holes
+dir path=opt/zfs-tests/tests/functional/hole_birth
 dir path=opt/zfs-tests/tests/functional/inheritance
 dir path=opt/zfs-tests/tests/functional/inuse
 dir path=opt/zfs-tests/tests/functional/large_files

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -100,8 +100,8 @@ dir path=opt/zfs-tests/tests/functional/features/async_destroy
 dir path=opt/zfs-tests/tests/functional/grow_pool
 dir path=opt/zfs-tests/tests/functional/grow_replicas
 dir path=opt/zfs-tests/tests/functional/history
-dir path=opt/zfs-tests/tests/functional/holes
 dir path=opt/zfs-tests/tests/functional/hole_birth
+dir path=opt/zfs-tests/tests/functional/holes
 dir path=opt/zfs-tests/tests/functional/inheritance
 dir path=opt/zfs-tests/tests/functional/inuse
 dir path=opt/zfs-tests/tests/functional/large_files
@@ -1795,6 +1795,15 @@ file path=opt/zfs-tests/tests/functional/history/sparc.migratedpool.DAT.Z \
 file path=opt/zfs-tests/tests/functional/history/sparc.orig_history.txt \
     mode=0444
 file path=opt/zfs-tests/tests/functional/history/zfs-pool-v4.dat.Z mode=0444
+file path=opt/zfs-tests/tests/functional/hole_birth/cleanup mode=0555
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth.cfg mode=0444
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib \
+    mode=0444
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth_4809 mode=0555
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth_4996 mode=0555
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth_5030 mode=0555
+file path=opt/zfs-tests/tests/functional/hole_birth/hole_birth_7176 mode=0555
+file path=opt/zfs-tests/tests/functional/hole_birth/setup mode=0555
 file path=opt/zfs-tests/tests/functional/holes/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/holes/holes.shlib mode=0444
 file path=opt/zfs-tests/tests/functional/holes/holes_sanity mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -261,6 +261,9 @@ tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
 [/opt/zfs-tests/tests/functional/cli_root/zpool_history]
 tests = ['zpool_history_001_neg', 'zpool_history_002_pos']
 
+[tests/functional/hole_birth]
+tests = ['hole_birth_7176', 'hole_birth_4809', 'hole_birth_4996']
+
 [/opt/zfs-tests/tests/functional/cli_root/zpool_import]
 tests = ['zpool_import_001_pos', 'zpool_import_002_pos',
     'zpool_import_003_pos', 'zpool_import_004_pos', 'zpool_import_005_pos',

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -261,7 +261,7 @@ tests = ['zpool_get_001_pos', 'zpool_get_002_pos', 'zpool_get_003_pos',
 [/opt/zfs-tests/tests/functional/cli_root/zpool_history]
 tests = ['zpool_history_001_neg', 'zpool_history_002_pos']
 
-[tests/functional/hole_birth]
+[/opt/zfs-tests/tests/functional/hole_birth]
 tests = ['hole_birth_7176', 'hole_birth_4809', 'hole_birth_4996']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_import]

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/hole_birth
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/cleanup.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+
+if is_global_zone ; then
+	destroy_pool $POOL
+	destroy_pool $POOL2
+else
+	cleanup_pool $POOL
+	cleanup_pool $POOL2
+fi
+log_must $RM -rf $BACKDIR $TESTDIR
+
+log_pass

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/cleanup.ksh
@@ -40,6 +40,6 @@ else
 	cleanup_pool $POOL
 	cleanup_pool $POOL2
 fi
-log_must $RM -rf $BACKDIR $TESTDIR
+log_must rm -rf $BACKDIR $TESTDIR
 
 log_pass

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
@@ -1,0 +1,37 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+export BACKDIR=${TEST_BASE_DIR%%/}/backdir-hole_birth
+
+export DISK1=$($ECHO $DISKS | $AWK '{print $1}')
+export DISK2=$($ECHO $DISKS | $AWK '{print $2}')
+
+export POOL=$TESTPOOL
+export POOL2=$TESTPOOL1
+export FS=$TESTFS

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.cfg
@@ -29,8 +29,8 @@
 
 export BACKDIR=${TEST_BASE_DIR%%/}/backdir-hole_birth
 
-export DISK1=$($ECHO $DISKS | $AWK '{print $1}')
-export DISK2=$($ECHO $DISKS | $AWK '{print $2}')
+export DISK1=$(echo $DISKS | awk '{print $1}')
+export DISK2=$(echo $DISKS | awk '{print $2}')
 
 export POOL=$TESTPOOL
 export POOL2=$TESTPOOL1

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
@@ -77,16 +77,16 @@ function setup_test_model
 function cleanup_pool
 {
 	typeset pool=$1
-	log_must $RM -rf $BACKDIR/*
+	log_must rm -rf $BACKDIR/*
 
 	if is_global_zone ; then
-		log_must $ZFS destroy -Rf $pool
+		log_must zfs destroy -Rf $pool
 	else
-		typeset list=$($ZFS list -H -r -t filesystem,snapshot,volume -o name $pool)
+		typeset list=$(zfs list -H -r -t filesystem,snapshot,volume -o name $pool)
 		for ds in $list ; do
 			if [[ $ds != $pool ]] ; then
 				if datasetexists $ds ; then
-					log_must $ZFS destroy -Rf $ds
+					log_must zfs destroy -Rf $ds
 				fi
 			fi
 		done
@@ -96,13 +96,13 @@ function cleanup_pool
 	if ! ismounted $pool ; then
 		# Make sure mountpoint directory is empty
 		if [[ -d $mntpnt ]]; then
-			log_must $RM -rf $mntpnt/*
+			log_must rm -rf $mntpnt/*
 		fi
 
-		log_must $ZFS mount $pool
+		log_must zfs mount $pool
 	fi
 	if [[ -d $mntpnt ]]; then
-		log_must $RM -rf $mntpnt/*
+		log_must rm -rf $mntpnt/*
 	fi
 
 	return 0
@@ -114,13 +114,12 @@ function cmp_md5s {
 
 	eval md5sum $file1 | awk '{ print $1 }'	> $BACKDIR/md5_file1
 	eval md5sum $file2 | awk '{ print $1 }'	> $BACKDIR/md5_file2
-	$DIFF $BACKDIR/md5_file1 $BACKDIR/md5_file2
-        typeset -i ret=$?
+	diff $BACKDIR/md5_file1 $BACKDIR/md5_file2
+	typeset -i ret=$?
 
-        $RM -f $BACKDIR/md5_file1 $BACKDIR/md5_file2
+	rm -f $BACKDIR/md5_file1 $BACKDIR/md5_file2
 
-        return $ret
-
+	return $ret
 }
 
 #
@@ -134,16 +133,16 @@ function cmp_ds_subs
 	typeset src_fs=$1
 	typeset dst_fs=$2
 
-	$ZFS list -r -H -t filesystem,snapshot,volume -o name $src_fs > $BACKDIR/src1
-	$ZFS list -r -H -t filesystem,snapshot,volume -o name $dst_fs > $BACKDIR/dst1
+	zfs list -r -H -t filesystem,snapshot,volume -o name $src_fs > $BACKDIR/src1
+	zfs list -r -H -t filesystem,snapshot,volume -o name $dst_fs > $BACKDIR/dst1
 
-	eval $SED -e 's:^$src_fs:PREFIX:g' < $BACKDIR/src1 > $BACKDIR/src
-	eval $SED -e 's:^$dst_fs:PREFIX:g' < $BACKDIR/dst1 > $BACKDIR/dst
+	eval sed -e 's:^$src_fs:PREFIX:g' < $BACKDIR/src1 > $BACKDIR/src
+	eval sed -e 's:^$dst_fs:PREFIX:g' < $BACKDIR/dst1 > $BACKDIR/dst
 
-	$DIFF $BACKDIR/src $BACKDIR/dst
+	diff $BACKDIR/src $BACKDIR/dst
 	typeset -i ret=$?
 
-	$RM -f $BACKDIR/src $BACKDIR/dst $BACKDIR/src1 $BACKDIR/dst1
+	rm -f $BACKDIR/src $BACKDIR/dst $BACKDIR/src1 $BACKDIR/dst1
 
 	return $ret
 }
@@ -163,7 +162,7 @@ function cmp_ds_cont
 	srcdir=$(get_prop mountpoint $src_fs)
 	dstdir=$(get_prop mountpoint $dst_fs)
 
-	$DIFF -r $srcdir $dstdir > /dev/null 2>&1
+	diff -r $srcdir $dstdir > /dev/null 2>&1
 	echo $?
 }
 
@@ -184,19 +183,19 @@ function cmp_ds_prop
 	    "setuid" "snapdir" "version" "volsize" "xattr" "zoned" \
 	    "mountpoint";
 	do
-		$ZFS get -H -o property,value,source $item $dtst1 >> \
+		zfs get -H -o property,value,source $item $dtst1 >> \
 		    $BACKDIR/dtst1
-		$ZFS get -H -o property,value,source $item $dtst2 >> \
+		zfs get -H -o property,value,source $item $dtst2 >> \
 		    $BACKDIR/dtst2
 	done
 
-	eval $SED -e 's:$dtst1:PREFIX:g' < $BACKDIR/dtst1 > $BACKDIR/dtst1
-	eval $SED -e 's:$dtst2:PREFIX:g' < $BACKDIR/dtst2 > $BACKDIR/dtst2
+	eval sed -e 's:$dtst1:PREFIX:g' < $BACKDIR/dtst1 > $BACKDIR/dtst1
+	eval sed -e 's:$dtst2:PREFIX:g' < $BACKDIR/dtst2 > $BACKDIR/dtst2
 
-	$DIFF $BACKDIR/dtst1 $BACKDIR/dtst2
+	diff $BACKDIR/dtst1 $BACKDIR/dtst2
 	typeset -i ret=$?
 
-	$RM -f $BACKDIR/dtst1 $BACKDIR/dtst2
+	rm -f $BACKDIR/dtst1 $BACKDIR/dtst2
 
 	return $ret
 
@@ -212,16 +211,16 @@ function random_tree
 	typeset dir=$1
 
 	if [[ -d $dir ]]; then
-		$RM -rf $dir
+		rm -rf $dir
 	fi
-	$MKDIR -p $dir
+	mkdir -p $dir
 	typeset -i ret=$?
 
 	typeset -i nl nd nf
 	((nl = RANDOM % 6 + 1))
 	((nd = RANDOM % 3 ))
 	((nf = RANDOM % 5 ))
-	$MKTREE -b $dir -l $nl -d $nd -f $nf
+	mktree -b $dir -l $nl -d $nd -f $nf
 	((ret |= $?))
 
 	return $ret
@@ -250,7 +249,7 @@ function snapshot_tree
 	fi
 
 	if ((ret == 0)) ; then
-		$ZFS snapshot $snap
+		zfs snapshot $snap
 		((ret |= $?))
 	fi
 
@@ -267,7 +266,7 @@ function destroy_tree
 	typeset -i ret=0
 	typeset snap
 	for snap in "$@" ; do
-		$ZFS destroy $snap
+		zfs destroy $snap
 		ret=$?
 
 		typeset ds=${snap%%@*}
@@ -277,7 +276,7 @@ function destroy_tree
 			((ret |= $?))
 
 			if ((ret != 0)); then
-				$RM -r $mntpnt/$snap
+				rm -r $mntpnt/$snap
 				((ret |= $?))
 			fi
 		fi
@@ -305,18 +304,18 @@ function test_fs_setup_4809
 	recvfs=$recvpool/recvfs
 
 	if datasetexists $recvfs; then
-		log_must $ZFS destroy -r $recvfs
+		log_must zfs destroy -r $recvfs
 	fi
 	if datasetexists $sendfs; then
-		log_must $ZFS destroy -r $sendfs
+		log_must zfs destroy -r $sendfs
 	fi
-	if $($ZFS create -o recordsize=4k $sendfs); then
+	if $(zfs create -o recordsize=4k $sendfs); then
 		# initial create
 		log_must truncate -s 1G /$sendfs/file1
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap1
+		log_must zfs snapshot $sendfs@snap1
 
 		# permute
 		log_must truncate -s 4194304 /$sendfs/file1
@@ -325,12 +324,11 @@ function test_fs_setup_4809
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap2
-		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
-		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		log_must zfs snapshot $sendfs@snap2
+		log_must eval "zfs send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "zfs send -v -i @snap1 $sendfs@snap2 " \
 		    ">/$sendpool/incremental.zsend"
 	fi
-
 }
 
 function test_fs_setup_4809_1
@@ -342,29 +340,28 @@ function test_fs_setup_4809_1
 	recvfs=$recvpool/recvfs
 
 	if datasetexists $recvfs; then
-		log_must $ZFS destroy -r $recvfs
+		log_must zfs destroy -r $recvfs
 	fi
 	if datasetexists $sendfs; then
-		log_must $ZFS destroy -r $sendfs
+		log_must zfs destroy -r $sendfs
 	fi
-	if $($ZFS create -o recordsize=4k $sendfs); then
+	if $(zfs create -o recordsize=4k $sendfs); then
 		# initial create
 		log_must truncate -s 1G /$sendfs/file1
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
 
-		log_must $ZFS snapshot $sendfs@snap1
+		log_must zfs snapshot $sendfs@snap1
 
 		# permute
 		log_must truncate -s 4194304 /$sendfs/file1
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
 
-		log_must $ZFS snapshot $sendfs@snap2
-		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
-		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		log_must zfs snapshot $sendfs@snap2
+		log_must eval "zfs send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "zfs send -v -i @snap1 $sendfs@snap2 " \
 		    ">/$sendpool/incremental.zsend"
 	fi
-
 }
 
 #
@@ -382,17 +379,17 @@ function test_fs_setup_4996
 	recvfs=$recvpool/recvfs
 
 	if datasetexists $recvfs; then
-		log_must $ZFS destroy -r $recvfs
+		log_must zfs destroy -r $recvfs
 	fi
 	if datasetexists $sendfs; then
-		log_must $ZFS destroy -r $sendfs
+		log_must zfs destroy -r $sendfs
 	fi
-	if $($ZFS create -o recordsize=512 $sendfs); then
+	if $(zfs create -o recordsize=512 $sendfs); then
 		# initial create
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=1
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap1
+		log_must zfs snapshot $sendfs@snap1
 
 		# permute
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1
@@ -400,12 +397,11 @@ function test_fs_setup_4996
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=3
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap2
-		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
-		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		log_must zfs snapshot $sendfs@snap2
+		log_must eval "zfs send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "zfs send -v -i @snap1 $sendfs@snap2 " \
 		    ">/$sendpool/incremental.zsend"
 	fi
-
 }
 
 #
@@ -423,18 +419,18 @@ function test_fs_setup_5030
 	recvfs=$recvpool/recvfs
 
 	if datasetexists $recvfs; then
-		log_must $ZFS destroy -r $recvfs
+		log_must zfs destroy -r $recvfs
 	fi
 	if datasetexists $sendfs; then
-		log_must $ZFS destroy -r $sendfs
+		log_must zfs destroy -r $sendfs
 	fi
-	if $($ZFS create -o recordsize=4k $sendfs); then
+	if $(zfs create -o recordsize=4k $sendfs); then
 		# initial create
 		log_must truncate -s 1G /$sendfs/file1
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap1
+		log_must zfs snapshot $sendfs@snap1
 
 		# permute
 		log_must truncate -s 4194304 /$sendfs/file1
@@ -443,12 +439,11 @@ function test_fs_setup_5030
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap2
-		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
-		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		log_must zfs snapshot $sendfs@snap2
+		log_must eval "zfs send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "zfs send -v -i @snap1 $sendfs@snap2 " \
 		    ">/$sendpool/incremental.zsend"
 	fi
-
 }
 
 #
@@ -466,18 +461,18 @@ function test_fs_setup_7176
 	recvfs=$recvpool/recvfs
 
 	if datasetexists $recvfs; then
-		log_must $ZFS destroy -r $recvfs
+		log_must zfs destroy -r $recvfs
 	fi
 	if datasetexists $sendfs; then
-		log_must $ZFS destroy -r $sendfs
+		log_must zfs destroy -r $sendfs
 	fi
-	if $($ZFS create -o recordsize=512 $sendfs); then
+	if $(zfs create -o recordsize=512 $sendfs); then
 		# initial create
 		log_must truncate --size=300M /$sendfs/file1
 #		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=128k conv=notrunc
 #		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap1
+		log_must zfs snapshot $sendfs@snap1
 
 		log_must truncate --size=10M /$sendfs/file1
 		sleep 5
@@ -486,10 +481,9 @@ function test_fs_setup_7176
 		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=1 seek=96k conv=notrunc
 		sleep 5
 
-		log_must $ZFS snapshot $sendfs@snap2
-		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
-		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		log_must zfs snapshot $sendfs@snap2
+		log_must eval "zfs send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "zfs send -v -i @snap1 $sendfs@snap2 " \
 		    ">/$sendpool/incremental.zsend"
 	fi
-
 }

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth.kshlib
@@ -1,0 +1,495 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.cfg
+
+#
+# Set up test model which includes various datasets
+#
+#               @final
+#               @snapB
+#               @init
+#               |
+#   ______ pclone
+#  |      /
+#  |@psnap
+#  ||                         @final
+#  ||@final       @final      @snapC
+#  ||@snapC       @snapC      @snapB
+#  ||@snapA       @snapB      @snapA
+#  ||@init        @init       @init
+#  |||            |           |
+# $pool -------- $FS ------- fs1 ------- fs2
+#    \             \\_____     \          |
+#     vol           vol   \____ \         @fsnap
+#      |              |        \ \              \
+#      @init          @vsnap   |  ------------ fclone
+#      @snapA         @init \  |                    |
+#      @final         @snapB \ |                    @init
+#                     @snapC  vclone                @snapA
+#                     @final       |                @final
+#                                 @init
+#                                 @snapC
+#                                 @final
+#
+# $1 pool name
+#
+function setup_test_model
+{
+	typeset pool=$1
+
+	return 0
+}
+
+#
+# Cleanup the BACKDIR and given pool content and all the sub datasets
+#
+# $1 pool name
+#
+function cleanup_pool
+{
+	typeset pool=$1
+	log_must $RM -rf $BACKDIR/*
+
+	if is_global_zone ; then
+		log_must $ZFS destroy -Rf $pool
+	else
+		typeset list=$($ZFS list -H -r -t filesystem,snapshot,volume -o name $pool)
+		for ds in $list ; do
+			if [[ $ds != $pool ]] ; then
+				if datasetexists $ds ; then
+					log_must $ZFS destroy -Rf $ds
+				fi
+			fi
+		done
+	fi
+
+	typeset mntpnt=$(get_prop mountpoint $pool)
+	if ! ismounted $pool ; then
+		# Make sure mountpoint directory is empty
+		if [[ -d $mntpnt ]]; then
+			log_must $RM -rf $mntpnt/*
+		fi
+
+		log_must $ZFS mount $pool
+	fi
+	if [[ -d $mntpnt ]]; then
+		log_must $RM -rf $mntpnt/*
+	fi
+
+	return 0
+}
+
+function cmp_md5s {
+	typeset file1=$1
+	typeset file2=$2
+
+	eval md5sum $file1 | awk '{ print $1 }'	> $BACKDIR/md5_file1
+	eval md5sum $file2 | awk '{ print $1 }'	> $BACKDIR/md5_file2
+	$DIFF $BACKDIR/md5_file1 $BACKDIR/md5_file2
+        typeset -i ret=$?
+
+        $RM -f $BACKDIR/md5_file1 $BACKDIR/md5_file2
+
+        return $ret
+
+}
+
+#
+# Detect if the given two filesystems have same sub-datasets
+#
+# $1 source filesystem
+# $2 destination filesystem
+#
+function cmp_ds_subs
+{
+	typeset src_fs=$1
+	typeset dst_fs=$2
+
+	$ZFS list -r -H -t filesystem,snapshot,volume -o name $src_fs > $BACKDIR/src1
+	$ZFS list -r -H -t filesystem,snapshot,volume -o name $dst_fs > $BACKDIR/dst1
+
+	eval $SED -e 's:^$src_fs:PREFIX:g' < $BACKDIR/src1 > $BACKDIR/src
+	eval $SED -e 's:^$dst_fs:PREFIX:g' < $BACKDIR/dst1 > $BACKDIR/dst
+
+	$DIFF $BACKDIR/src $BACKDIR/dst
+	typeset -i ret=$?
+
+	$RM -f $BACKDIR/src $BACKDIR/dst $BACKDIR/src1 $BACKDIR/dst1
+
+	return $ret
+}
+
+#
+# Compare all the directores and files in two filesystems
+#
+# $1 source filesystem
+# $2 destination filesystem
+#
+function cmp_ds_cont
+{
+	typeset src_fs=$1
+	typeset dst_fs=$2
+
+	typeset srcdir dstdir
+	srcdir=$(get_prop mountpoint $src_fs)
+	dstdir=$(get_prop mountpoint $dst_fs)
+
+	$DIFF -r $srcdir $dstdir > /dev/null 2>&1
+	echo $?
+}
+
+#
+# Compare the given two dataset properties
+#
+# $1 dataset 1
+# $2 dataset 2
+#
+function cmp_ds_prop
+{
+	typeset dtst1=$1
+	typeset dtst2=$2
+
+	for item in "type" "origin" "volblocksize" "aclinherit" "acltype" \
+	    "atime" "canmount" "checksum" "compression" "copies" "devices" \
+	    "dnodesize" "exec" "quota" "readonly" "recordsize" "reservation" \
+	    "setuid" "snapdir" "version" "volsize" "xattr" "zoned" \
+	    "mountpoint";
+	do
+		$ZFS get -H -o property,value,source $item $dtst1 >> \
+		    $BACKDIR/dtst1
+		$ZFS get -H -o property,value,source $item $dtst2 >> \
+		    $BACKDIR/dtst2
+	done
+
+	eval $SED -e 's:$dtst1:PREFIX:g' < $BACKDIR/dtst1 > $BACKDIR/dtst1
+	eval $SED -e 's:$dtst2:PREFIX:g' < $BACKDIR/dtst2 > $BACKDIR/dtst2
+
+	$DIFF $BACKDIR/dtst1 $BACKDIR/dtst2
+	typeset -i ret=$?
+
+	$RM -f $BACKDIR/dtst1 $BACKDIR/dtst2
+
+	return $ret
+
+}
+
+#
+# Random create directories and files
+#
+# $1 directory
+#
+function random_tree
+{
+	typeset dir=$1
+
+	if [[ -d $dir ]]; then
+		$RM -rf $dir
+	fi
+	$MKDIR -p $dir
+	typeset -i ret=$?
+
+	typeset -i nl nd nf
+	((nl = RANDOM % 6 + 1))
+	((nd = RANDOM % 3 ))
+	((nf = RANDOM % 5 ))
+	$MKTREE -b $dir -l $nl -d $nd -f $nf
+	((ret |= $?))
+
+	return $ret
+}
+
+#
+# Put data in filesystem and take snapshot
+#
+# $1 snapshot name
+#
+function snapshot_tree
+{
+	typeset snap=$1
+	typeset ds=${snap%%@*}
+	typeset type=$(get_prop "type" $ds)
+
+	typeset -i ret=0
+	if [[ $type == "filesystem" ]]; then
+		typeset mntpnt=$(get_prop mountpoint $ds)
+		((ret |= $?))
+
+		if ((ret == 0)) ; then
+			eval random_tree $mntpnt/${snap##$ds}
+			((ret |= $?))
+		fi
+	fi
+
+	if ((ret == 0)) ; then
+		$ZFS snapshot $snap
+		((ret |= $?))
+	fi
+
+	return $ret
+}
+
+#
+# Destroy the given snapshot and stuff
+#
+# $1 snapshot
+#
+function destroy_tree
+{
+	typeset -i ret=0
+	typeset snap
+	for snap in "$@" ; do
+		$ZFS destroy $snap
+		ret=$?
+
+		typeset ds=${snap%%@*}
+		typeset type=$(get_prop "type" $ds)
+		if [[ $type == "filesystem" ]]; then
+			typeset mntpnt=$(get_prop mountpoint $ds)
+			((ret |= $?))
+
+			if ((ret != 0)); then
+				$RM -r $mntpnt/$snap
+				((ret |= $?))
+			fi
+		fi
+
+		if ((ret != 0)); then
+			return $ret
+		fi
+	done
+
+	return 0
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_4809
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+function test_fs_setup_4809_1
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_4996
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=512 $sendfs); then
+		# initial create
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=1
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=128k count=1 seek=3
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_5030
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=4k $sendfs); then
+		# initial create
+		log_must truncate -s 1G /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=11264 seek=1152
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		# permute
+		log_must truncate -s 4194304 /$sendfs/file1
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=152 seek=384 conv=notrunc
+		sleep 5
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=4k count=10 seek=1408 conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}
+
+#
+# Setup filesystems for the resumable send/receive tests
+#
+# $1 The pool to set up with the "send" filesystems
+# $2 The pool for receive
+#
+function test_fs_setup_7176
+{
+	sendpool=$1
+	recvpool=$2
+
+	sendfs=$sendpool/sendfs
+	recvfs=$recvpool/recvfs
+
+	if datasetexists $recvfs; then
+		log_must $ZFS destroy -r $recvfs
+	fi
+	if datasetexists $sendfs; then
+		log_must $ZFS destroy -r $sendfs
+	fi
+	if $($ZFS create -o recordsize=512 $sendfs); then
+		# initial create
+		log_must truncate --size=300M /$sendfs/file1
+#		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=128k conv=notrunc
+#		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap1
+
+		log_must truncate --size=10M /$sendfs/file1
+		sleep 5
+
+		# permute
+		log_must dd if=/dev/urandom of=/$sendfs/file1 bs=512 count=1 seek=96k conv=notrunc
+		sleep 5
+
+		log_must $ZFS snapshot $sendfs@snap2
+		log_must eval "$ZFS send -v $sendfs@snap1 >/$sendpool/initial.zsend"
+		log_must eval "$ZFS send -v -i @snap1 $sendfs@snap2 " \
+		    ">/$sendpool/incremental.zsend"
+	fi
+
+}

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #4809 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_4809_1 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #4809 test"

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4809.ksh
@@ -52,11 +52,11 @@ test_fs_setup_4809_1 $POOL $POOL2
 sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 
-log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
-log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+log_must eval "zfs send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "zfs receive -F $recvfs < $BACKDIR/pool-snap1"
 
-log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
-log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs receive $recvfs < $BACKDIR/pool-snap1-snap2"
 
 log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
 

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #4996 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_4996 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #4996 test"

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_4996.ksh
@@ -52,11 +52,11 @@ test_fs_setup_4996 $POOL $POOL2
 sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 
-log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
-log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+log_must eval "zfs send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "zfs receive -F $recvfs < $BACKDIR/pool-snap1"
 
-log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
-log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs receive $recvfs < $BACKDIR/pool-snap1-snap2"
 
 log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
 

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug ZoL #5030 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_5030 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug ZoL #5030 test"

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_5030.ksh
@@ -52,11 +52,11 @@ test_fs_setup_5030 $POOL $POOL2
 sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 
-log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
-log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+log_must eval "zfs send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "zfs receive -F $recvfs < $BACKDIR/pool-snap1"
 
-log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
-log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs receive $recvfs < $BACKDIR/pool-snap1-snap2"
 
 log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
 

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
@@ -1,0 +1,66 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+#
+# DESCRIPTION:
+#	zfs send -R send replication stream up to the named snap.
+#
+# STRATEGY:
+#	1. Back up all the data from POOL/FS
+#	2. Verify all the datasets and data can be recovered in POOL2
+#	3. Back up all the data from root filesystem POOL2
+#	4. Verify all the data can be recovered, too
+#
+
+verify_runnable "both"
+
+log_assert "hole_birth bug illumos #7176 test"
+log_onexit cleanup_pool $POOL2
+
+test_fs_setup_7176 $POOL $POOL2
+
+sendfs=$POOL/sendfs
+recvfs=$POOL2/recvfs
+
+log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+
+log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+
+log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
+
+# Cleanup POOL2
+log_must cleanup_pool $POOL2
+
+log_pass "hole_birth bug illumos #7176 test"

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/hole_birth_7176.ksh
@@ -52,11 +52,11 @@ test_fs_setup_7176 $POOL $POOL2
 sendfs=$POOL/sendfs
 recvfs=$POOL2/recvfs
 
-log_must eval "$ZFS send $sendfs@snap1 > $BACKDIR/pool-snap1"
-log_must eval "$ZFS receive -F $recvfs < $BACKDIR/pool-snap1"
+log_must eval "zfs send $sendfs@snap1 > $BACKDIR/pool-snap1"
+log_must eval "zfs receive -F $recvfs < $BACKDIR/pool-snap1"
 
-log_must eval "$ZFS send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
-log_must eval "$ZFS receive $recvfs < $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs send -i $sendfs@snap1 $sendfs@snap2 > $BACKDIR/pool-snap1-snap2"
+log_must eval "zfs receive $recvfs < $BACKDIR/pool-snap1-snap2"
 
 log_must cmp_md5s /$sendfs/file1 /$recvfs/file1
 

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/setup.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+# Copyright (c) 2013, 2014 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/hole_birth/hole_birth.kshlib
+
+verify_runnable "both"
+verify_disk_count "$DISKS" 2
+
+if is_global_zone ; then
+	log_must $ZPOOL create $POOL $DISK1
+	log_must $ZPOOL create $POOL2 $DISK2
+fi
+log_must $MKDIR $BACKDIR $TESTDIR
+
+log_must setup_test_model $POOL
+
+log_pass

--- a/usr/src/test/zfs-tests/tests/functional/hole_birth/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/hole_birth/setup.ksh
@@ -35,10 +35,10 @@ verify_runnable "both"
 verify_disk_count "$DISKS" 2
 
 if is_global_zone ; then
-	log_must $ZPOOL create $POOL $DISK1
-	log_must $ZPOOL create $POOL2 $DISK2
+	log_must zpool create $POOL $DISK1
+	log_must zpool create $POOL2 $DISK2
 fi
-log_must $MKDIR $BACKDIR $TESTDIR
+log_must mkdir $BACKDIR $TESTDIR
 
 log_must setup_test_model $POOL
 


### PR DESCRIPTION
This is intended to be a follow on for the openzfs PR #273, and pulls in
the new test cases added in the zfsonlinux PR #5675.

I haven't built or tested this patch yet, so there's a good chance it's
broken, but I wanted to open a PR so I can run this through the automated
system.

I generated this patch by configuring git to allow cherry-picking the
zfsonlinx commit directly; i.e.

    $ git config merge.renameLimit 999999
    $ git cherry-pick -X ours 29031d3660991b446c6fd7dfbf49c7c58ee211ae

and then I had to manually fix up a few files due to differences in the
build system for two repositories (e.g. remove Makefile.am, etc).

Here's a link to the zfsonlinx PR: https://github.com/zfsonlinux/zfs/pull/5675