### PR TITLE
7812 Remove gender specific language

### DIFF
--- a/usr/src/cmd/bnu/ct.c
+++ b/usr/src/cmd/bnu/ct.c
@@ -25,7 +25,9 @@
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
-
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 /*
@@ -75,7 +77,7 @@ extern int dkminor();
 #define TRUE	1
 #define FALSE	0
 
-static 
+static
 int	_Status;		/* exit status of child */
 
 static
@@ -92,11 +94,11 @@ char
 	*_Num,			/* pointer to a phone number */
 	*_Flds[7];		/* Filled in as if finds() in uucp did it */
 
-static 
+static
 time_t	_Log_on,
 	_Log_elpsd;
 
-static 
+static
 FILE	*_Fdl;
 
 extern int  optind;
@@ -175,15 +177,15 @@ char   *argv[];
 
     while ((c = getopt (argc, argv, "hvw:s:x:")) != EOF) {
 	switch (c) {
-	    case 'h': 
+	    case 'h':
 		hangup = 0;
 		break;
 
-	    case 'v': 
+	    case 'v':
 		Verbose = 1;
 		break;
 
-	    case 'w': 
+	    case 'w':
 		minutes = atoi (optarg);
 		if (minutes < 1) {
 		    (void) fprintf(stderr,
@@ -194,7 +196,7 @@ char   *argv[];
 		}
 		break;
 
-	    case 's': 
+	    case 's':
 		_Flds[F_CLASS] = optarg;
 		break;
 
@@ -209,7 +211,7 @@ char   *argv[];
 		}
 		break;
 
-	    case '?': 
+	    case '?':
 		(void) fprintf(stderr, "\tusage: %s %s\n", Progname, USAGE);
 		cleanup(101);
 		/* NOTREACHED */
@@ -254,7 +256,7 @@ char   *argv[];
 		fdig(_Flds[F_CLASS]) );
     	    cleanup(101);
 	}
-	    
+
 	if (!first) { /* not the first time in loop */
 	    VERBOSE("%s busy", (found == -1) ? "Dialer is" : "Dialers are");
 	    VERBOSE(" (%d minute(s))\n", count);
@@ -283,7 +285,7 @@ char   *argv[];
 	    cleanup(101);
 	}
 
-	/* Ask user if she/he wants to wait */
+	/* Ask user if they want to wait */
 	(void) fputs("Do you want to wait for dialer? (y for yes): ", stdout);
 	if ((c = getchar ()) == EOF || tolower (c) != 'y')
 	    cleanup(101);

--- a/usr/src/cmd/bnu/permission.c
+++ b/usr/src/cmd/bnu/permission.c
@@ -26,6 +26,9 @@
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
@@ -205,7 +208,7 @@ char *name;
  * this function will find a login name in the LOGNAME
  * field.
  * input:
- *	name	-> who the remote says he/she is
+ *	name	-> who the remote says they are
  * return:
  *	SUCCESS	-> found
  *	FAIL	-> not found
@@ -336,7 +339,7 @@ char *list[];
 	while (*p && num < maxlist) {
 		list[num] = p;
 		if (*p == ':') {	/* null path */
-			*p++ = NULLCHAR; 
+			*p++ = NULLCHAR;
 			continue;
 		}
 		while (*p && *p != ':')
@@ -442,7 +445,7 @@ int type;
 		    continue;
 
 		case U_LOGNAME:
-		    if (EQUALS(arg, name)) 
+		    if (EQUALS(arg, name))
 				break;
 		    continue;
 
@@ -481,7 +484,7 @@ static int
 validateFind(name)
 char *name;
 {
-	
+
 	if ( (Fp = fopen(PERMISSIONS, "r")) == NULL) {
 		DEBUG(5, "can't open %s\n", PERMISSIONS);
 		return(FAIL);
@@ -554,7 +557,7 @@ char *name;
  *
  * return:
  *	0 - OK
- *	EOF - at end of file		
+ *	EOF - at end of file
  */
 int
 parse_tokens(flds, buf)
@@ -626,7 +629,7 @@ struct name_value *pair;
 		string++;
 	if (*string)
 		*string++ = NULLCHAR;
-	
+
 	pair->value = string;
 	while ((*string) && (*string != '\t') && (*string != ' ')
 	    && (*string != '\n'))
@@ -654,7 +657,7 @@ char *line;
 {
 	char *p, *c;
 	char buf[BUFSIZ];
-	
+
 	p = line;
 	for (;fgets(buf, BUFSIZ, fp) != NULL;) {
 		/* remove trailing white space */
@@ -764,7 +767,7 @@ switchRole()
  * rmail
  * Note that the PERMISSIONS file is read once for each system
  * at the time the Rmtname is set in xprocess().
- * Return codes:	
+ * Return codes:
  *	ok: TRUE
  *	fail: FALSE
  */
@@ -813,7 +816,7 @@ char *name, *list[];
 			}
 		    }
 		    if ( _dev[i] == statbuf.st_dev
-		      && _ino[i] == statbuf.st_ino ) {    
+		      && _ino[i] == statbuf.st_ino ) {
 			free(temp);
 			return(TRUE);
 		    }

--- a/usr/src/cmd/bnu/xqt.c
+++ b/usr/src/cmd/bnu/xqt.c
@@ -26,6 +26,9 @@
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -48,8 +51,8 @@ char *rmtname;
 	 */
 	if (fork() == 0) {	/* can't vfork() */
 		/*
-		 * hide the uid of the initiator of this job so that he
-		 * doesn't get notified about things that don't concern him.
+		 * hide the uid of the initiator of this job so that it
+		 * doesn't get notified about things that don't concern it.
 		 */
 		(void) setuid(geteuid());
 		euucico(rmtname);
@@ -124,8 +127,8 @@ char	*rmtname;
 		for (i = 3; i < maxfiles; i++)
 			(void) close(i);
 		/*
-		 * hide the uid of the initiator of this job so that he
-		 * doesn't get notified about things that don't concern him.
+		 * hide the uid of the initiator of this job so that it
+		 * doesn't get notified about things that don't concern it.
 		 */
 		(void) setuid(geteuid());
 		(void) execle(UUXQT, "UUXQT", opt, (char *) 0, Env);

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/ccp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/ccp.c
@@ -27,6 +27,9 @@
  * OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS,
  * OR MODIFICATIONS.
  */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 #define RCSID	"$Id: ccp.c,v 1.30 2000/04/15 01:27:11 masputra Exp $"
@@ -277,7 +280,7 @@ setdeflate(argv, opt)
     if ((rbits != 0 && (rbits <= DEFLATE_MIN_SIZE || rbits > def_rmax))
 	|| (abits != 0 && (abits <= DEFLATE_MIN_SIZE || abits > def_amax))) {
 	option_error("deflate option values must be 0 or {%d,%d} .. {%d,%d}",
-		     DEFLATE_MIN_SIZE+1, DEFLATE_MIN_SIZE+1, 
+		     DEFLATE_MIN_SIZE+1, DEFLATE_MIN_SIZE+1,
 		     def_rmax, def_amax);
 	return 0;
     }
@@ -489,9 +492,9 @@ ccp_codereject(f, code, id, inp, len)
 
     case CCP_RESETACK:
 	/*
-	 * Peer must have sent us CCP Reset-Request but then code-rejected
-	 * when we sent CCP Reset-Ack.  He's a moron, be we have to obey
-	 * his wishes.
+	 * Peer must have sent us CCP Reset-Request but then code-rejected when
+	 * we sent CCP Reset-Ack.  It seems to have changed its mind, and we
+	 * have to obey its wishes.
 	 */
 	ccp_localstate[f->unit] |= RACK_REJECTED;
 	notice("peer has erroneously rejected CCP Reset-Ack");
@@ -786,7 +789,7 @@ ccp_nakci(f, p, len)
 	no.deflate = 1;
 	/*
 	 * Peer wants us to use a different code size or something.
-	 * Stop asking for Deflate if we don't understand his suggestion.
+	 * Stop asking for Deflate if we don't understand its suggestion.
 	 */
 	if (p[1] != CILEN_DEFLATE
 	    || DEFLATE_METHOD(p[2]) != DEFLATE_METHOD_VAL
@@ -805,7 +808,7 @@ ccp_nakci(f, p, len)
 	/*
 	 * Peer wants us to use a different code size or something.
 	 * Stop asking for Deflate using the old algorithm number if
-	 * we don't understand his suggestion.  (Note that this will
+	 * we don't understand its suggestion.  (Note that this will
 	 * happen if the peer is running Magnalink instead of
 	 * old-style Deflate.)
 	 */

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/ipcp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/ipcp.c
@@ -19,6 +19,9 @@
  * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
  * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #define RCSID	"$Id: ipcp.c,v 1.54 2000/04/15 01:27:11 masputra Exp $"
 
@@ -768,14 +771,14 @@ ipcp_nakci(f, p, len)
     }
 
     /*
-     * Accept the peer's idea of {our,his} address, if different
+     * Accept the peer's idea of {our,its} address, if different
      * from our idea, only if the accept_{local,remote} flag is set.
      */
     NAKCIADDRS(CI_ADDRS, !go->neg_addr && go->old_addrs,
 	      if (go->accept_local && ciaddr1) { /* Do we know our address? */
 		  try.ouraddr = ciaddr1;
 	      }
-	      if (go->accept_remote && ciaddr2) { /* Does he know his? */
+	      if (go->accept_remote && ciaddr2) { /* Does it know its? */
 		  try.hisaddr = ciaddr2;
 	      }
 	      );
@@ -1026,12 +1029,12 @@ ipcp_reqci(f, p, lenp, dont_nak)
     nakp = nak_buffer;
 
     /*
-     * Reset all his options.
+     * Reset all its options.
      */
     BZERO(ho, sizeof(*ho));
 
     /*
-     * Process all his options.
+     * Process all its options.
      */
     for (len = *lenp; len > 0; len -= cilen, p = prev + cilen) {
 	if ((len < 2) || p[1] > len) {
@@ -1065,10 +1068,10 @@ ipcp_reqci(f, p, lenp, dont_nak)
 	    } else {
 
 		/*
-		 * If he has no address, or if we both have his
+		 * If it has no address, or if we both have its
 		 * address but disagree about it, then NAK it with our
-		 * idea.  In particular, if we don't know his address,
-		 * but he does, then accept it.
+		 * idea. In particular, if we don't know its address,
+		 * but it does, then accept it.
 		 */
 		GETNLONG(ciaddr1, p);
 		if (ciaddr1 != wo->hisaddr &&
@@ -1146,7 +1149,7 @@ ipcp_reqci(f, p, lenp, dont_nak)
 		    newret = CODE_CONFNAK;
 		    /*
 		     * If this is a dialup line (default_route is
-		     * set), and neither side knows about his address,
+		     * set), and neither side knows about its address,
 		     * suggest an arbitrary rfc1918 address.
 		     */
 		    ciaddr1 = htonl(0xc0a80101 + ifunit);
@@ -1225,7 +1228,7 @@ ipcp_reqci(f, p, lenp, dont_nak)
 		PUTNLONG(ao->winsaddr[d], nakp);
 	    }
             break;
-	
+
 	case CI_COMPRESSTYPE:
 	    if (!ao->neg_vj) {
 		newret = CODE_CONFREJ;
@@ -1334,7 +1337,7 @@ ipcp_reqci(f, p, lenp, dont_nak)
     switch (ret) {
     case CODE_CONFACK:
 	*lenp = p - p0;
-	sys_block_proto(PPP_IP);	
+	sys_block_proto(PPP_IP);
 	break;
     case CODE_CONFNAK:
 	*lenp = nakp - nak_buffer;
@@ -1518,7 +1521,7 @@ ipcp_up(f)
 	    }
 
 	    /* assign a default route through the interface if required */
-	    if (wo->default_route) 
+	    if (wo->default_route)
 		if (sifdefaultroute(f->unit, go->ouraddr, ho->hisaddr))
 		    default_route_set[f->unit] = 1;
 
@@ -1570,7 +1573,7 @@ ipcp_up(f)
 	}
 
 	/* assign a default route through the interface if required */
-	if (wo->default_route) 
+	if (wo->default_route)
 	    if (sifdefaultroute(f->unit, go->ouraddr, ho->hisaddr))
 		default_route_set[f->unit] = 1;
 

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
@@ -1,6 +1,8 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ *
  *
     ipv6cp.c - PPP IPV6 Control Protocol.
     Copyright (C) 1999  Tommi Komulainen <Tommi.Komulainen@iki.fi>
@@ -54,7 +56,7 @@
     between BULL S.A. and INRIA).
 
     This software is available with usual "research" terms
-    with the aim of retain credits of the software. 
+    with the aim of retain credits of the software.
     Permission to use, copy, modify and distribute this software for any
     purpose and without fee is hereby granted, provided that the above
     copyright notice and this permission notice appear in all copies,
@@ -93,13 +95,13 @@
  * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
  * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  *
- * $Id: ipv6cp.c,v 1.9 2000/04/15 01:27:11 masputra Exp $ 
+ * $Id: ipv6cp.c,v 1.9 2000/04/15 01:27:11 masputra Exp $
  */
 
 #define RCSID	"$Id: ipv6cp.c,v 1.9 2000/04/15 01:27:11 masputra Exp $"
 
 /*
- * TODO: 
+ * TODO:
  *
  * Proxy Neighbour Discovery.
  *
@@ -284,16 +286,16 @@ setifaceid(argv, opt)
     char *comma, *arg;
     ipv6cp_options *wo = &ipv6cp_wantoptions[0];
     struct in6_addr addr;
-    
+
 #define VALIDID(a) ( (((a).s6_addr32[0] == 0) && ((a).s6_addr32[1] == 0)) && \
 			(((a).s6_addr32[2] != 0) || ((a).s6_addr32[3] != 0)) )
-    
+
 
     arg = *argv;
 
     comma = strchr(arg, ',');
-    
-    /* 
+
+    /*
      * If comma first character, then no local identifier
      */
     if (comma != arg) {
@@ -304,11 +306,11 @@ setifaceid(argv, opt)
 	    option_error("Illegal interface identifier (local): %s", arg);
 	    return 0;
 	}
-	
+
 	eui64_copy(addr.s6_addr32[2], wo->ourid);
 	wo->opt_local = 1;
     }
-    
+
     /*
      * If comma last character, then no remote identifier
      */
@@ -459,11 +461,11 @@ ipv6cp_resetci(f)
     ipv6cp_options *go = &ipv6cp_gotoptions[f->unit];
 
     wo->req_ifaceid = wo->neg_ifaceid && ipv6cp_allowoptions[f->unit].neg_ifaceid;
-    
+
     if (!wo->opt_local) {
 	eui64_magic_nz(wo->ourid);
     }
-    
+
     *go = *wo;
     eui64_zero(go->hisid);	/* last proposed interface identifier */
 }
@@ -654,12 +656,12 @@ ipv6cp_nakci(f, p, len)
     }
 
     /*
-     * Accept the peer's idea of {our,his} interface identifier, if different
+     * Accept the peer's idea of {our,its} interface identifier, if different
      * from our idea, only if the accept_{local,remote} flag is set.
      */
     NAKCIIFACEID(CI_IFACEID, neg_ifaceid,
 	      if (go->accept_local) {
-		  while (eui64_iszero(ifaceid) || 
+		  while (eui64_iszero(ifaceid) ||
 			 eui64_equals(ifaceid, go->hisid)) /* bad luck */
 		      eui64_magic(ifaceid);
 		  try.ourid = ifaceid;
@@ -711,7 +713,7 @@ ipv6cp_nakci(f, p, len)
 	    try.neg_ifaceid = 1;
 	    eui64_get(ifaceid, p);
 	    if (go->accept_local) {
-		while (eui64_iszero(ifaceid) || 
+		while (eui64_iszero(ifaceid) ||
 		       eui64_equals(ifaceid, go->hisid)) /* bad luck */
 		    eui64_magic(ifaceid);
 		try.ourid = ifaceid;
@@ -840,12 +842,12 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
     nakp = nak_buffer;
 
     /*
-     * Reset all his options.
+     * Reset all its options.
      */
     BZERO(ho, sizeof(*ho));
-    
+
     /*
-     * Process all his options.
+     * Process all its options.
      */
     for (len = *lenp; len > 0; len -= cilen, p = prev + cilen) {
 	newret = CODE_CONFACK;
@@ -881,10 +883,10 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
 	    } else {
 
 		/*
-		 * If he has no interface identifier, or if we both
+		 * If it has no interface identifier, or if we both
 		 * have same identifier then NAK it with new idea.  In
-		 * particular, if we don't know his identifier, but he
-		 * does, then accept it.
+		 * particular, if we don't know his identifier, but it
+		 * does, then accept that identifier.
 		 */
 		eui64_get(ifaceid, p);
 		IPV6CPDEBUG(("(%s)", llv6_ntoa(ifaceid)));
@@ -892,9 +894,9 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
 		    newret = CODE_CONFREJ;		/* Reject CI */
 		    break;
 		}
-		/* If we don't like his ID, then nak it. */
-		if (!eui64_iszero(wo->hisid) && 
-		    !eui64_equals(ifaceid, wo->hisid) && 
+		/* If we don't like its ID, then nak that ID. */
+		if (!eui64_iszero(wo->hisid) &&
+		    !eui64_equals(ifaceid, wo->hisid) &&
 		    eui64_iszero(go->hisid)) {
 		    newret = CODE_CONFNAK;
 		    eui64_copy(wo->hisid, ifaceid);
@@ -904,7 +906,7 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
 		    /* first time, try option */
 		    if (eui64_iszero(go->hisid))
 			eui64_copy(wo->hisid, ifaceid);
-		    while (eui64_iszero(ifaceid) || 
+		    while (eui64_iszero(ifaceid) ||
 			eui64_equals(ifaceid, go->ourid)) /* bad luck */
 			eui64_magic(ifaceid);
 		}
@@ -1006,7 +1008,7 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
     switch (ret) {
     case CODE_CONFACK:
 	*lenp = p - p0;
-	sys_block_proto(PPP_IPV6);	
+	sys_block_proto(PPP_IPV6);
 	break;
     case CODE_CONFNAK:
 	*lenp = nakp - nak_buffer;
@@ -1038,7 +1040,7 @@ ipv6_check_options()
      */
     if ((wo->use_persistent) && (!wo->opt_local) && (!wo->opt_remote)) {
 
-	/* 
+	/*
 	 * On systems where there are no Ethernet interfaces used, there
 	 * may be other ways to obtain a persistent id. Right now, it
 	 * will fall back to using magic [see eui64_magic] below when
@@ -1108,7 +1110,7 @@ ipv6_demand_conf(u)
 #if SIF6UPFIRST
     if (!sif6up(u))
 	return 0;
-#endif    
+#endif
     if (!sif6addr(u, wo->ourid, wo->hisid))
 	return 0;
 #if !SIF6UPFIRST
@@ -1432,7 +1434,7 @@ ipv6cp_printpkt(p, plen, printer, arg)
     if (len < HEADERLEN || len > plen)
 	return 0;
 
-    
+
     printer(arg, " %s id=0x%x", code_name(code, 1), id);
     len -= HEADERLEN;
     switch (code) {

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/lcp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/lcp.c
@@ -7,6 +7,8 @@
  * Copyright (c) 1989 Carnegie Mellon University.
  * All rights reserved.
  *
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ *
  * Redistribution and use in source and binary forms are permitted
  * provided that the above copyright notice and this paragraph are
  * duplicated in all such forms and that any documentation,
@@ -218,12 +220,12 @@ static option_t lcp_option_list[] = {
       "Set FCS type(s) desired; crc16, crc32, null, or number" },
 #endif
 #ifdef MUX_FRAME
-    /* 
+    /*
      * if pppmux option is turned on, then the parameter to this
-     * is time value in microseconds 
+     * is time value in microseconds
      */
     { "pppmux", o_int, &lcp_wantoptions[0].pppmux,
-      "Set PPP Multiplexing option timer", OPT_LLIMIT | OPT_A2COPY, 
+      "Set PPP Multiplexing option timer", OPT_LLIMIT | OPT_A2COPY,
 	&lcp_allowoptions[0].pppmux, 0, 0 },
 #endif
     {NULL}
@@ -685,7 +687,7 @@ lcp_extcode(f, code, id, inp, len)
     case CODE_PROTREJ:
 	lcp_rprotrej(f, inp, len);
 	break;
-    
+
     case CODE_ECHOREQ:
 	if (f->state != OPENED)
 	    break;
@@ -693,7 +695,7 @@ lcp_extcode(f, code, id, inp, len)
 	PUTLONG(lcp_gotoptions[f->unit].magicnumber, magp);
 	fsm_sdata(f, CODE_ECHOREP, id, inp, len);
 	break;
-    
+
     case CODE_ECHOREP:
 	if (!lcp_received_echo_reply(f, id, inp, len)) {
 	    lcp_echo_badreplies++;
@@ -1162,7 +1164,7 @@ lcp_ackci(f, p, len)
 	      go->endpoint.value, go->endpoint.length);
 #ifdef MUX_FRAME
     ACKCIVOID(CI_MUXING, go->pppmux);
-    if (go->pppmux) 
+    if (go->pppmux)
     	go->pppmux = ao->pppmux;
 #endif
     ACKCISHORT(CI_MRRU, go->neg_mrru, go->mrru);
@@ -1356,7 +1358,7 @@ lcp_nakci(f, p, len)
 	    if ((cichar == CHAP_DIGEST_MD5 && wo->neg_chap) ||
 		(cichar == CHAP_MICROSOFT && wo->neg_mschap) ||
 		(cichar == CHAP_MICROSOFT_V2 && wo->neg_mschapv2)) {
-		/* Try his requested algorithm. */
+		/* Try its requested algorithm. */
 		try.chap_mdtype = cichar;
 	    } else {
 		goto try_another;
@@ -1399,11 +1401,11 @@ lcp_nakci(f, p, len)
      * to stop asking for LQR.  We haven't got any other protocol.  If
      * they Nak the reporting period, then the following logic
      * applies:
-     * If he suggests zero and go->neg_fcs is true and
-     * ao->lqr_period isn't zero, then take his suggestion.  If he
-     * suggests zero otherwise, ignore it.  If he suggests a nonzero
-     * value and wo->lqr_period is zero, then take his suggestion.  If
-     * he suggests a nonzero value otherwise that's less than
+     * If it suggests zero and go->neg_fcs is true and
+     * ao->lqr_period isn't zero, then take its suggestion.  If it
+     * suggests zero otherwise, ignore it.  If it suggests a nonzero
+     * value and wo->lqr_period is zero, then take its suggestion.  If
+     * it suggests a nonzero value otherwise that's less than
      * wo->lqr_period, then ignore it.
      */
     NAKCILQR(CI_QUALITY, neg_lqr,
@@ -1440,7 +1442,7 @@ lcp_nakci(f, p, len)
     NAKCIVOID(CI_ACCOMPRESSION, neg_accompression);
 
     /*
-     * Remove any FCS types he doesn't like from our (receive-side)
+     * Remove any FCS types it doesn't like from our (receive-side)
      * FCS list.
      */
     NAKCICHAR(CI_FCSALTERN, neg_fcs, try.fcs_type = go->fcs_type & cichar;);
@@ -1763,7 +1765,7 @@ lcp_rejci(f, p, len)
 	/* Check rejected value. */
 	if (cishort != PPP_CHAP || cichar != go->chap_mdtype)
 	    goto bad;
-	/* Disable the one that he rejected */
+	/* Disable the one that it rejected */
 	switch (cichar) {
 	case CHAP_DIGEST_MD5:
 	    try.neg_chap = 0;
@@ -1882,12 +1884,12 @@ lcp_reqci(f, p, lenp, dont_nak)
     nakp = nak_buffer;
 
     /*
-     * Reset all his options.
+     * Reset all its options.
      */
     BZERO(ho, sizeof(*ho));
 
     /*
-     * Process all his options.
+     * Process all its options.
      */
     for (len = *lenp; len > 0; len -= cilen, p = prev + cilen) {
 	newret = CODE_CONFACK;			/* Assume success */
@@ -1932,10 +1934,10 @@ lcp_reqci(f, p, lenp, dont_nak)
 	    if (newret == CODE_CONFNAK) {
 		PUTCHAR(CI_MRU, nakp);
 		PUTCHAR(CILEN_SHORT, nakp);
-		PUTSHORT(cishort, nakp);	/* Give him a hint */
+		PUTSHORT(cishort, nakp);	/* Give it a hint */
 	    }
 
-	    ho->neg_mru = 1;		/* Remember he sent MRU */
+	    ho->neg_mru = 1;		/* Remember that it sent MRU */
 	    ho->mru = cishort;		/* And remember value */
 	    break;
 
@@ -1961,8 +1963,8 @@ lcp_reqci(f, p, lenp, dont_nak)
 
 	    /*
 	     * Workaround for common broken Microsoft software -- if
-	     * the peer is sending us a nonzero ACCM, then he *needs*
-	     * us to send the same to him.  Adjust our Configure-
+	     * the peer is sending us a nonzero ACCM, then it *needs*
+	     * us to send the same to it.  Adjust our Configure-
 	     * Request message and restart LCP.
 	     */
 	    if (do_msft_workaround && (cilong & ~wo->asyncmap)) {
@@ -2133,10 +2135,10 @@ lcp_reqci(f, p, lenp, dont_nak)
 	    if (cilen < CILEN_LONG) {
 		/*
 		 * If we send Magic-Number, then we must not reject it
-		 * when the peer sends it to us, even if his version
-		 * looks odd to us.  Ack if the cilen is wrong in this
+		 * when the peer sends it to us, even if its version
+		 * looks odd to us.  Ack if the cilent is wrong in this
 		 * case.  If we're not sending Magic-Number, then we don't
-		 * much care what his value is anyway.
+		 * much care what its value is anyway.
 		 */
 		break;
 	    }
@@ -2147,8 +2149,8 @@ lcp_reqci(f, p, lenp, dont_nak)
 		break;
 
 	    /*
-	     * He must have a different magic number.  Make sure we
-	     * give him a good one to use.
+	     * It must have a different magic number.  Make sure we
+	     * give it a good one to use.
 	     */
 	    while (go->neg_magicnumber && cilong == go->magicnumber) {
 		newret = CODE_CONFNAK;
@@ -2204,7 +2206,7 @@ lcp_reqci(f, p, lenp, dont_nak)
 	    } else {
 
 		GETCHAR(cichar, p);
-		/* If he has bits we don't like, tell him to stop. */
+		/* If it has bits we don't like, tell it to stop. */
 		if (cichar & ~ao->fcs_type) {
 		    if ((cichar &= ao->fcs_type) == 0) {
 			newret = CODE_CONFREJ;
@@ -2295,7 +2297,7 @@ lcp_reqci(f, p, lenp, dont_nak)
                 newret = CODE_CONFREJ;
                 break;
             }
-            /* remember his option */
+            /* remember its option */
             ho->pppmux = ao->pppmux;
             break;
 #endif
@@ -2341,7 +2343,7 @@ lcp_reqci(f, p, lenp, dont_nak)
     }
 
     /*
-     * If the peer hasn't negotiated his MRU, and we'd like an MTU
+     * If the peer hasn't negotiated its MRU, and we'd like an MTU
      * that's larger than the default, try sending an unsolicited
      * Nak for what we want.
      */

--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/main.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/main.c
@@ -30,6 +30,9 @@
  * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
  * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #define RCSID	"$Id: main.c,v 1.97 2000/04/24 02:54:16 masputra Exp $"
 
@@ -870,7 +873,7 @@ main(argc, argv)
 	/*
 	 * If we are initiating this connection, wait for a short
 	 * time for something from the peer.  This can avoid bouncing
-	 * our packets off his tty before he has it set up.
+	 * our packets off its tty before it has set up the tty.
 	 */
 	add_fd(fd_ppp);
 	if (connect_delay != 0 && (connector != NULL || ptycommand != NULL)) {
@@ -2092,7 +2095,7 @@ run_program(prog, args, must_exist, done, arg)
 #ifdef BSD
 	/* Force the priority back to zero if pppd is running higher. */
 	if (setpriority (PRIO_PROCESS, 0, 0) < 0)
-	    warn("can't reset priority to 0: %m"); 
+	    warn("can't reset priority to 0: %m");
 #endif
 
 	/* SysV recommends a second fork at this point. */

--- a/usr/src/cmd/cmd-inet/usr.bin/talk/invite.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/talk/invite.c
@@ -36,6 +36,9 @@
  * software developed by the University of California, Berkeley, and its
  * contributors.
  */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
@@ -50,9 +53,9 @@
 #endif /* SYSV */
 
 	/*
-	 * there wasn't an invitation waiting, so send a request containing
-	 * our sockt address to the remote talk daemon so it can invite
-	 * him
+	 * There wasn't an invitation waiting, so send a request containing
+	 * our socket address to the remote talk daemon so it can invite
+	 * the remote.
 	 */
 
 static int local_id, remote_id;

--- a/usr/src/cmd/cmd-inet/usr.bin/telnet/enc_des.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/telnet/enc_des.c
@@ -69,6 +69,9 @@
  */
 
 /* based on @(#)enc_des.c	8.1 (Berkeley) 6/4/93 */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #include <krb5.h>
 #include <stdio.h>
@@ -170,7 +173,7 @@ cfb64_start(int dir)
 	case TELNET_DIR_DECRYPT:
 		/*
 		 * This is simply a request to have the other side
-		 * start output (our input).  He will negotiate an
+		 * start output (our input).  The other side will negotiate an
 		 * IV so we need not look for it.
 		 */
 		state = fbp->state[dir];

--- a/usr/src/cmd/cmd-inet/usr.lib/ilbd/ilbd_main.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/ilbd/ilbd_main.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -71,7 +72,7 @@
  * By default, an user-supplied health check probe process will
  * also run with the same set of privileges as ILB's built-in
  * probes.  If the administrator has an user-supplied health check
- * program that requires a larger privilege set, he/she will have
+ * program that requires a larger privilege set, they will have
  * to implement setuid program.
  *
  * Each health check will have a timeout, such that if the health

--- a/usr/src/cmd/cmd-inet/usr.lib/ilbd/ilbd_sg.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/ilbd/ilbd_sg.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdlib.h>
@@ -742,7 +743,7 @@ ilbd_add_server_to_group(ilb_sg_info_t *sg_info, int ev_port,
 			 * serverid  when processing the next add-server
 			 * command for this servergroup, while connection
 			 * draining is underway. We assume that the user
-			 * will read the man page after he/she encounters
+			 * will read the man page after they encounter
 			 * this failure, and learn to not add any server
 			 * to the servergroup until connection draining of
 			 * all servers in the  servergroup is complete.

--- a/usr/src/cmd/cmd-inet/usr.lib/mdnsd/DNSDigest.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/mdnsd/DNSDigest.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 4 -*-
  *
  * Copyright (c) 2002-2011 Apple Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/usr/src/cmd/cmd-inet/usr.lib/pppoe/options.c
+++ b/usr/src/cmd/cmd-inet/usr.lib/pppoe/options.c
@@ -23,6 +23,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -2213,7 +2214,7 @@ launch_service(int tunfd, poep_t *poep, void *srvp, struct ppptun_control *ptc)
 
 		/*
 		 * Exec failure; attempt to log the problem and send a
-		 * PADT to the client so that he knows the session
+		 * PADT to the client so that it knows the session
 		 * went south.
 		 */
 	bail_out:

--- a/usr/src/cmd/cmd-inet/usr.sbin/in.tftpd.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/in.tftpd.c
@@ -20,6 +20,7 @@
  *
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -730,7 +731,7 @@ delay_exit(int ecode)
 
 	/*
 	 * The most likely cause of an error here is that
-	 * someone has broadcast an RRQ packet because s/he's
+	 * something has broadcast an RRQ packet because it's
 	 * trying to boot and doesn't know who the server is.
 	 * Rather then sending an ERROR packet immediately, we
 	 * wait a while so that the real server has a better chance

--- a/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1998, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1727,7 +1728,7 @@ doaddup(int cmd, int satype, char *argv[], char *ebuf)
 			switch (token) {
 			case TOK_SPI:
 				/*
-				 * If some cretin types in "spi 0" then he/she
+				 * If some cretin types in "spi 0" then they
 				 * can type in another SPI.
 				 */
 				if (assoc->sadb_sa_spi != 0) {

--- a/usr/src/cmd/cron/at.c
+++ b/usr/src/cmd/cron/at.c
@@ -24,6 +24,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -602,7 +603,7 @@ copy(char *jobfile, FILE *inputfile, int when)
 	/*
 	 * Fix for 1053807:
 	 * Determine what shell we should use to run the job. If the user
-	 * didn't explicitly request that his/her current shell be over-
+	 * didn't explicitly request that their current shell be over-
 	 * ridden (shflag or cshflag), then we use the current shell.
 	 */
 	if (cshflag)

--- a/usr/src/cmd/cron/atq.c
+++ b/usr/src/cmd/cron/atq.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -229,7 +230,7 @@ countfiles(uid_t *uidlist, int nuids)
 	 * For each file in the queue, see if the user(s) own the file. We
 	 * have to use "entryfound" (rather than simply incrementing "numfiles")
 	 * so that if a person's name appears twice on the command line we
-	 * don't double the number of files owned by him/her.
+	 * don't double the number of files owned by that user.
 	 */
 	for (i = 0; i < numentries; i++) {
 		if ((stat(queue[i]->d_name, &stbuf)) < 0) {
@@ -276,7 +277,7 @@ printqueue(uid_t *uidlist, int nuids)
 	 * belonging to that person(s), otherwise print the entire queue.
 	 * Once again, we have to use "entryfound" (rather than simply
 	 * comparing each command line argument) so that if a person's name
-	 * appears twice we don't print each file owned by him/her twice.
+	 * appears twice we don't print each of their files twice.
 	 *
 	 *
 	 * "printrank", "printdate", and "printjobname" all take existing
@@ -316,7 +317,7 @@ printqueue(uid_t *uidlist, int nuids)
 }
 
 /*
- * Get the uid of a person using his/her login name. Return -1 if no
+ * Get the uid of a person using their login name. Return -1 if no
  * such account name exists.
  */
 uid_t
@@ -333,7 +334,7 @@ getid(char *name)
 }
 
 /*
- * Get the full login name of a person using his/her user id.
+ * Get the full login name of a person using their user id.
  */
 char *
 getname(uid_t uid)

--- a/usr/src/cmd/cron/atrm.c
+++ b/usr/src/cmd/cron/atrm.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -185,7 +186,7 @@ main(int argc, char **argv)
 				continue;
 
 			/*
-			 * if argv is a username, compare his/her uid to
+			 * if argv is a username, compare their uid to
 			 * the uid of the owner of the file......
 			 */
 			if (pwd = getpwnam(*argv)) {
@@ -240,7 +241,7 @@ usage(void)
  * print the job number that we are removing and the result of the access
  * check (either "permission denied" or "removed"). If we are running
  * interactively (iflag), prompt the user before we unlink the file. If
- * the super-user is removing jobs, inform him/her who owns each file before
+ * the super-user is removing jobs, inform them who owns each file before
  * it is removed.  Return TRUE if file removed, else FALSE.
  */
 int
@@ -370,7 +371,7 @@ getjoblist(struct dirent ***namelistp, struct stat ***statlistp,
 }
 
 /*
- * Get the full login name of a person using his/her user id.
+ * Get the full login name of a person using their user id.
  */
 char *
 getname(uid_t uid)

--- a/usr/src/cmd/cron/cron.c
+++ b/usr/src/cmd/cron/cron.c
@@ -25,6 +25,7 @@
  * Copyright 2013 Joshua M. Clulow <josh@sysmgr.org>
  *
  * Copyright (c) 2014 Gary Mills
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1452,7 +1453,7 @@ next_field(int lower, int upper)
 	 *   if (numbers in this field are out of range (lower..upper),
 	 *	or there is a syntax error) then
 	 *	NULL is returned, and a mail message is sent to the
-	 *	user telling him which line the error was in.
+	 *	user telling them which line the error was in.
 	 */
 
 	char *s;
@@ -2391,7 +2392,7 @@ ex(struct event *e)
 	}
 
 	/*
-	 * set correct user identification and check his account
+	 * set correct user identification and check their account
 	 */
 	r = set_user_cred(e->u, pproj);
 	if (r == VUC_EXPIRED) {

--- a/usr/src/cmd/csh/sh.c
+++ b/usr/src/cmd/csh/sh.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1080,8 +1081,8 @@ dosource(tchar **t)
  * If we are a login shell, then we don't want to tell
  * about any mail file unless its been modified
  * after the time we started.
- * This prevents us from telling the user things he already
- * knows, since the login program insists on saying
+ * This prevents us from telling the user things they already
+ * know, since the login program insists on saying
  * "You have mail."
  */
 void

--- a/usr/src/cmd/csh/sh.dir.c
+++ b/usr/src/cmd/csh/sh.dir.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -49,7 +50,7 @@ dinit(tchar *hp)
 	/*
 	 * If this is a login shell, we should have a home directory.  But,
 	 * if we got here via 'su - <user>' where the user has no directory
-	 * in his passwd file, then su has passed HOME=<nothing>, so hp is
+	 * in their passwd file, then su has passed HOME=<nothing>, so hp is
 	 * non-null, but has zero length.  Thus, we do not know the current
 	 * working directory based on the home directory.
 	 */

--- a/usr/src/cmd/eject/eject.c
+++ b/usr/src/cmd/eject/eject.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -313,7 +314,7 @@ ejectit(char *name)
 	/*
 	 * If volume management is either not running or not being managed by
 	 * vold, and the device is mounted, we try to umount the device.  If we
-	 * fail, we give up, unless he used the -f flag.
+	 * fail, we give up, unless it used the -f flag.
 	 */
 
 	if (_dev_mounted(name)) {

--- a/usr/src/cmd/expr/compile.c
+++ b/usr/src/cmd/expr/compile.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1995-2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -237,8 +238,8 @@ out:
 	/*
 	 * Return code from libgen regcomp with mods.  Note weird return
 	 * value - if space is malloc'd return pointer to start of space,
-	 * if user provided his own space, return pointer to 1+last byte
-	 * of his space.
+	 * if user provided their own space, return pointer to 1+last byte
+	 * of that space.
 	 */
 	if (regerrno != 0) {
 		if (alloc)

--- a/usr/src/cmd/filesync/action.c
+++ b/usr/src/cmd/filesync/action.c
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright (c) 1995 Sun Microsystems, Inc.  All Rights Reserved
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * module:
  *	action.c
@@ -625,7 +626,7 @@ do_copy(struct file *fp, side_t srcdst)
 		 * The first thing to do is ascertain whether or not
 		 * the alleged new copy might in fact be a new link.
 		 * We trust find_link to weigh all the various factors,
-		 * so if he says make a link, we'll do it.
+		 * so if it says make a link, we'll do it.
 		 */
 		lp = find_link(fp, srcdst);
 		if (lp) {
@@ -652,8 +653,8 @@ do_copy(struct file *fp, side_t srcdst)
 				/*
 				 * if we couldn't do the unlink, we must
 				 * mark the linkee in conflict as well
-				 * so his reference count remains the same
-				 * in the baseline and he continues to show
+				 * so its reference count remains the same
+				 * in the baseline and it continues to show
 				 * up on the change list.
 				 */
 				if (rc != 0) {
@@ -692,8 +693,8 @@ do_copy(struct file *fp, side_t srcdst)
 				/*
 				 * if we failed to make a link, we want to
 				 * mark the linkee in conflict too, so that
-				 * his reference count remains the same in
-				 * the baseline, and he shows up on the change
+				 * its reference count remains the same in
+				 * the baseline, and it shows up on the change
 				 * list again next time.
 				 */
 				lp->f_flags |= F_CONFLICT;

--- a/usr/src/cmd/filesync/filesync.h
+++ b/usr/src/cmd/filesync/filesync.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright (c) 1996 Sun Microsystems, Inc.  All Rights Reserved
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * module:
  *	filesync.h
@@ -142,7 +143,7 @@ extern uid_t my_uid;	/* User ID for files I create			*/
 extern gid_t my_gid;	/* Group ID for files I create			*/
 
 /* error and warning routines						*/
-void confirm(char *);		/* ask user if he's sure		*/
+void confirm(char *);		/* ask user if they're sure		*/
 void nomem(char *);		/* die from malloc failure		*/
 
 /* routines for dealing with strings and file names			*/

--- a/usr/src/cmd/format/ctlr_scsi.c
+++ b/usr/src/cmd/format/ctlr_scsi.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -425,7 +426,7 @@ scsi_format(start, end, list)
 
 	/*
 	 * Construct the uscsi format ioctl.  The form depends
-	 * upon the defect list the user extracted.  If s/he
+	 * upon the defect list the user extracted.  If they
 	 * extracted the "original" list, we format with only
 	 * the P (manufacturer's defect) list.  Otherwise, we
 	 * format with both the P and the G (grown) list.

--- a/usr/src/cmd/format/hardware_structs.h
+++ b/usr/src/cmd/format/hardware_structs.h
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	_HARDWARE_STRUCTS_H
@@ -175,7 +176,7 @@ struct ctlr_ops {
 
 /*
  * This structure describes a specific partition layout.  It is malloc'd
- * when the data file is read and whenever the user creates his own
+ * when the data file is read and whenever the user creates their own
  * partition layout.  The link is used to make a list of possible
  * partition layouts for each drive type.
  */

--- a/usr/src/cmd/format/main.c
+++ b/usr/src/cmd/format/main.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -444,7 +445,7 @@ init_globals(disk)
 		pattern_buf = (void *) zalloc(BUF_SECTS * cur_blksz);
 
 		/*
-		 * Tell the user which disk (s)he selected.
+		 * Tell the user which disk they selected.
 		 */
 		if (chk_volname(cur_disk)) {
 			fmt_print("selecting %s: ", cur_disk->disk_name);
@@ -490,7 +491,7 @@ init_globals(disk)
 			}
 			fmt_print("]");
 		/*
-		 * Drive wasn't formatted.  Tell the user in case he
+		 * Drive wasn't formatted.  Tell the user in case they
 		 * disagrees.
 		 */
 		} else if (EMBEDDED_SCSI) {

--- a/usr/src/cmd/format/menu_command.c
+++ b/usr/src/cmd/format/menu_command.c
@@ -24,6 +24,7 @@
  * Copyright 2014 Toomas Soome <tsoome@me.com>
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -241,7 +242,7 @@ c_disk()
 	}
 
 	/*
-	 * Determine total number of disks, and ask the user which disk he
+	 * Determine total number of disks, and ask the user which disk they
 	 * would like to make current.
 	 */
 
@@ -415,7 +416,7 @@ c_type()
 	index = input(FIO_INT, "Specify disk type (enter its number)", ':',
 	    &ioparam, defltptr, DATA_INPUT);
 	/*
-	 * Find the type s/he chose.
+	 * Find the type they chose.
 	 */
 	if (index == auto_conf_choice) {
 		float			scaled;
@@ -1095,7 +1096,7 @@ currently being used for swapping.\n");
 	 * Print the time so that the user will know when format started.
 	 * Lock out interrupts.  This could be a problem, since it could
 	 * cause the user to sit for quite awhile with no control, but we
-	 * don't have any other good way of keeping his gun from going off.
+	 * don't have any other good way of keeping their gun from going off.
 	 */
 	clock = time((time_t *)0);
 	fmt_print("Beginning format. The current time is %s\n",
@@ -1833,7 +1834,7 @@ c_defect()
 
 	/*
 	 * If the user has modified the working list but not committed
-	 * it, warn him that he is probably making a mistake.
+	 * it, warn them that they are probably making a mistake.
 	 */
 	if (work_list.flags & LIST_DIRTY) {
 		if (!EMBEDDED_SCSI) {

--- a/usr/src/cmd/format/menu_defect.c
+++ b/usr/src/cmd/format/menu_defect.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -37,7 +38,7 @@
 /*
  * This is the working defect list.  All the commands here operate on
  * the working list, except for 'commit'.  This way the user can
- * change his mind at any time without having mangled the current defect
+ * change their mind at any time without having mangled the current defect
  * list.
  */
 struct	defect_list work_list;
@@ -199,7 +200,7 @@ d_extract()
 		return (-1);
 
 	/*
-	 * If this takes a long time, let's ask the user if he
+	 * If this takes a long time, let's ask the user if they
 	 * doesn't mind waiting.  Note, for SCSI disks
 	 * this operation is instantaneous so we won't ask for
 	 * for confirmation.
@@ -270,7 +271,7 @@ d_add()
 	assert(!EMBEDDED_SCSI);
 
 	/*
-	 * Ask the user which mode of input he'd like to use.
+	 * Ask the user which mode of input they'd like to use.
 	 */
 	fmt_print("        0. bytes-from-index\n");
 	fmt_print("        1. logical block\n");

--- a/usr/src/cmd/format/partition.c
+++ b/usr/src/cmd/format/partition.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -197,7 +198,7 @@ change_partition(int num)
 	    return;
 	}
 	/*
-	 * Print out the given partition so the user knows what he/she's
+	 * Print out the given partition so the user knows what they're
 	 * getting into.
 	 */
 	print_partition(cur_parts, num, 1);

--- a/usr/src/cmd/fs.d/pcfs/fsck/clusters.c
+++ b/usr/src/cmd/fs.d/pcfs/fsck/clusters.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1999,2000 by Sun Microsystems, Inc.
  * All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -307,8 +308,8 @@ seekCluster(int fd, int32_t clusterNum)
 /*
  *  getcluster
  *	Get cluster bytes off the disk.  We always read those bytes into
- *	the same static buffer.  If the caller wants his own copy of the
- *	data he'll have to make his own copy.  We'll return all the data
+ *	the same static buffer.  If the caller wants its own copy of the
+ *	data it'll have to make its own copy.  We'll return all the data
  *	read, even if it's short of a full cluster.  This is for future use
  *	when we might want to relocate any salvagable data from bad clusters.
  */

--- a/usr/src/cmd/fs.d/ufs/edquota/edquota.c
+++ b/usr/src/cmd/fs.d/ufs/edquota/edquota.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -282,7 +283,7 @@ editit(void)
 		/*
 		 * Certain editors can exit with a non-zero status even
 		 * though everything is peachy. Best to ask the user what
-		 * s/he really wants to do. (N.B.: if we're non-interactive
+		 * they really wants to do. (N.B.: if we're non-interactive
 		 * we'll "break" the while loop before we get here.)
 		 */
 		if (WIFEXITED(status) && (WEXITSTATUS(status) != 0)) {

--- a/usr/src/cmd/fs.d/ufs/fsck/utilities.c
+++ b/usr/src/cmd/fs.d/ufs/fsck/utilities.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -2314,7 +2315,7 @@ dirty(struct bufarea *bp)
 	if (fswritefd < 0) {
 		/*
 		 * No one should call dirty() in read only mode.
-		 * But if one does, it's not fatal issue. Just warn him.
+		 * But if one does, it's not fatal issue. Just warn them.
 		 */
 		pwarn("WON'T SET DIRTY FLAG IN READ_ONLY MODE\n");
 	} else {

--- a/usr/src/cmd/ldap/common/common.c
+++ b/usr/src/cmd/ldap/common/common.c
@@ -8,21 +8,22 @@
  * License Version 1.1 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of
  * the License at http://www.mozilla.org/NPL/
- *  
+ *
  * Software distributed under the License is distributed on an "AS
  * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
  * implied. See the License for the specific language governing
  * rights and limitations under the License.
- *  
+ *
  * The Original Code is Mozilla Communicator client code, released
  * March 31, 1998.
- * 
+ *
  * The Initial Developer of the Original Code is Netscape
  * Communications Corporation. Portions created by Netscape are
  * Copyright (C) 1998-1999 Netscape Communications Corporation. All
  * Rights Reserved.
- * 
- * Contributor(s): 
+ *
+ * Contributor(s):
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -75,7 +76,7 @@ static int wait4result( LDAP *ld, int msgid, struct berval **servercredp,
 static int parse_result( LDAP *ld, LDAPMessage *res,
 	struct berval **servercredp, char *msg, int freeit );
 
-#ifdef LDAPTOOL_DEBUG_MEMORY   
+#ifdef LDAPTOOL_DEBUG_MEMORY
 static void *ldaptool_debug_malloc( size_t size );
 static void *ldaptool_debug_calloc( size_t nelem, size_t elsize );
 static void *ldaptool_debug_realloc( void *ptr, size_t size );
@@ -263,7 +264,7 @@ static char             *ssl_donglefile = NULL;
 #if 0
 static char             *pkcs_pin = NULL;
 #endif
-static struct ldapssl_pkcs_fns local_pkcs_fns = 
+static struct ldapssl_pkcs_fns local_pkcs_fns =
     {0,NULL,NULL,NULL,NULL,NULL,NULL,NULL, NULL };
 
 #ifdef FORTEZZA
@@ -582,15 +583,15 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 	    /* This option removed to prevent interference
 	       with the getEffectiveRights option, also -X
 	       case 'X':	* path to FORTEZZA CKL file *
-	       
+
 	       fortezza_krlfile = strdup( optarg );
-	       
-	       
+
+
 	       break;
 	    */
 	case 'I':	/* FORTEZZA PIN (password file) */
 	    ssl_donglefile = strdup( optarg );
-	    
+
 	    break;
 #endif /* LDAP_TOOL_PKCS11 */
 
@@ -634,7 +635,7 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 		perror( "malloc" );
 		exit( LDAP_NO_MEMORY );
 	    }
-		
+
 	    break;
 	case 'k':   /* conversion directory */
 	    ldaptool_convdir = strdup( optarg );
@@ -672,9 +673,9 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 	    }
 	    ldctrl = calloc(1,sizeof(LDAPControl));
 	    if (ctrl_value) {
-		rc = ldaptool_berval_from_ldif_value( ctrl_value, 
+		rc = ldaptool_berval_from_ldif_value( ctrl_value,
 			vlen, &(ldctrl->ldctl_value),
-			1 /* recognize file URLs */, 
+			1 /* recognize file URLs */,
 			0 /* always try file */,
 			1 /* report errors */ );
 		if ((rc = ldaptool_fileurlerr2ldaperr( rc )) != LDAP_SUCCESS) {
@@ -704,7 +705,7 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
     /* If '-Z' is specified, check if '-P' is specified too. */
     if ( isN || isW ) {
 	if ( !isZ ) {
-		fprintf( stderr, gettext("%s: with -N, -W options, please specify -Z\n\n"), ldaptool_progname ); 
+		fprintf( stderr, gettext("%s: with -N, -W options, please specify -Z\n\n"), ldaptool_progname );
 		return (-1);
 	}
     }
@@ -815,14 +816,14 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 
 #ifdef HAVE_SASL_OPTIONS
     if (ldapauth == LDAP_AUTH_SASL) {
-	/* BindDN not required for SASL */ 
+	/* BindDN not required for SASL */
 	ldaptool_require_binddn = 0;
     }
 #endif	/* HAVE_SASL_OPTIONS */
 
 #ifdef NET_SSL
     if (secure == 1) {
-	/* BindDN not required for SSL */ 
+	/* BindDN not required for SSL */
 	ldaptool_require_binddn = 0;
     }
 #endif	/* NET_SSL */
@@ -853,7 +854,7 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 #ifdef LDAP_TOOL_PKCS11
     if ((NULL != pkcs_token) && (NULL != ssl_certname)) {
 	char *result;
-	
+
 	if ( (result = buildTokenCertName( pkcs_token, ssl_certname)) != NULL){
 	    free( ssl_certname );
 	    ssl_certname = result;
@@ -889,15 +890,15 @@ ldaptool_process_args( int argc, char **argv, char *extra_opts,
 static void
 print_library_info( const LDAPAPIInfo *aip, FILE *fp )
 {
-    int                 i;                                                      
-    LDAPAPIFeatureInfo  fi;         
+    int                 i;
+    LDAPAPIFeatureInfo  fi;
 
     fprintf( fp, gettext("LDAP Library Information -\n"
 	    "    Highest supported protocol version: %d\n"
 	    "    LDAP API revision:                  %d\n"
 	    "    API vendor name:                    %s\n"
 	    "    Vendor-specific version:            %.2f\n"),
-	    aip->ldapai_protocol_version, aip->ldapai_api_version, 
+	    aip->ldapai_protocol_version, aip->ldapai_api_version,
 	    aip->ldapai_vendor_name,
 	    (float)aip->ldapai_vendor_version / 100.0 );
 
@@ -929,9 +930,9 @@ print_library_info( const LDAPAPIInfo *aip, FILE *fp )
 #ifdef LDAP_TOOL_ARGPIN
 static int PinArgRegistration( void )
 {
-    
+
     /* pkcs_init was successful  register the pin args */
-    
+
     SVRCOREArgPinObj *ArgPinObj;
     char *tokenName;
 #ifndef _WIN32
@@ -982,7 +983,7 @@ static int PinArgRegistration( void )
 
 	}
 	SVRCORE_RegisterPinObj((SVRCOREPinObj *)ArgPinObj);
-	
+
     }
     else
     {
@@ -1015,7 +1016,7 @@ static int PinArgRegistration( void )
     }
 #endif
     return LDAP_SUCCESS;
-    
+
 }
 #endif /* LDAP_TOOL_ARGPIN */
 
@@ -1034,7 +1035,7 @@ ldaptool_ldap_init( int second_host )
     if ( ldaptool_not ) {
 	return( NULL );
     }
-    
+
     if ( second_host ) {
 	host = ldaptool_host2;
 	port = ldaptool_port2;
@@ -1059,7 +1060,7 @@ ldaptool_ldap_init( int second_host )
 #ifdef LDAP_TOOL_PKCS11
     ldaptool_setcallbacks( &local_pkcs_fns );
 
-    if ( !second_host 	&& secure  
+    if ( !second_host 	&& secure
 	 &&(rc = ldapssl_pkcs_init( &local_pkcs_fns))  < 0) {
 	    /* secure connection requested -- fail if no SSL */
 #ifndef SOLARIS_LDAP_CMD
@@ -1079,7 +1080,7 @@ ldaptool_ldap_init( int second_host )
 #endif /* LDAP_TOOL_ARGPIN */
 
 #else /* LDAP_TOOL_PKCS11 */
-    if ( !second_host 	&& secure  
+    if ( !second_host 	&& secure
 	 &&(rc = ldapssl_client_init( ssl_certdbpath, NULL )) < 0) {
 	    /* secure connection requested -- fail if no SSL */
 #ifndef SOLARIS_LDAP_CMD
@@ -1102,7 +1103,7 @@ ldaptool_ldap_init( int second_host )
 	if ( !user_port ) {
 	    port = LDAPS_PORT;
 	}
-	
+
 	if (( ld = ldapssl_init( host, port,
 		secure )) != NULL && ssl_certname != NULL )
 	    if (ldapssl_enable_clientauth( ld, ssl_keydbpath, ssl_passwd,
@@ -1237,7 +1238,7 @@ ldaptool_bind( LDAP *ld )
               return;
            }
         }
-       
+
         defaults = ldaptool_set_sasl_defaults( ld, sasl_mech, sasl_authid, sasl_username, passwd, sasl_realm );
         if (defaults == NULL) {
 	   perror ("malloc");
@@ -1636,14 +1637,14 @@ parse_result( LDAP *ld, LDAPMessage *res, struct berval **servercredp,
 	    if ( 0 == strcmp( ctrls[i]->ldctl_oid,
 			LDAP_CONTROL_PWEXPIRING )) {
 
-		    /* Warn the user his passwd is to expire */
-		    errno = 0;	
+		    /* Warn the user that their passwd is to expire */
+		    errno = 0;
 		    pw_secs = atoi(ctrls[i]->ldctl_value.bv_val);
 		    if ( pw_secs > 0  && errno != ERANGE ) {
 			if ( pw_secs > 86400 ) {
 				pw_days = ( pw_secs / 86400 );
 				pw_secs = ( pw_secs % 86400 );
-			} 
+			}
 			if ( pw_secs > 3600 ) {
 				pw_hrs = ( pw_secs / 3600 );
 				pw_secs = ( pw_secs % 3600 );
@@ -1664,7 +1665,7 @@ parse_result( LDAP *ld, LDAPMessage *res, struct berval **servercredp,
 				printf (gettext("%d mins, "), pw_mins);
 			}
 			printf(gettext("%d seconds.\n"), pw_secs);
-			
+
 		   }
 		}
 	}
@@ -1727,7 +1728,7 @@ ldaptool_create_proxyauth_control( LDAP *ld )
 {
     LDAPControl	*ctl = NULL;
     int rc;
-    
+
 
     if ( !proxyauth_id)
 	return( NULL );
@@ -1737,7 +1738,7 @@ ldaptool_create_proxyauth_control( LDAP *ld )
     } else {
 	rc = ldap_create_proxyauth_control( ld, proxyauth_id, 1, &ctl);
     }
-    if ( rc != LDAP_SUCCESS) 
+    if ( rc != LDAP_SUCCESS)
     {
 	if (ctl)
 	    ldap_control_free( ctl);
@@ -1753,11 +1754,11 @@ ldaptool_create_geteffectiveRights_control ( LDAP *ld, const char *authzid,
 {
     LDAPControl	*ctl = NULL;
     int rc;
-    
+
 	rc = ldap_create_geteffectiveRights_control( ld, authzid, attrlist, 1,
 							&ctl);
- 
-    if ( rc != LDAP_SUCCESS) 
+
+    if ( rc != LDAP_SUCCESS)
     {
 		if (ctl)
 	    	ldap_control_free( ctl);
@@ -1771,7 +1772,7 @@ ldaptool_create_geteffectiveRights_control ( LDAP *ld, const char *authzid,
 void
 ldaptool_add_control_to_array( LDAPControl *ctrl, LDAPControl **array)
 {
-    
+
     int i;
     for (i=0; i< CONTROL_REQUESTS; i++)
     {
@@ -1822,7 +1823,7 @@ calculate_ctrl_value( const char *value,
     if ( b64 ) {
 	if (( *vlen = ldif_base64_decode( (char *)value,
 		(unsigned char *)value )) < 0 ) {
-	    fprintf( stderr, 
+	    fprintf( stderr,
 		gettext("Unable to decode base64 control value \"%s\"\n"), value);
 	    return( -1 );
 	}
@@ -1834,7 +1835,7 @@ calculate_ctrl_value( const char *value,
 
 /*
  * Parse the optarg from -J option of ldapsearch
- * and within LDIFfile for ldapmodify. Take ctrl_arg 
+ * and within LDIFfile for ldapmodify. Take ctrl_arg
  * (the whole string) and divide it into oid, criticality
  * and value. This function breaks down original ctrl_arg
  * with '\0' in places. Also, calculate length of valuestring.
@@ -1854,7 +1855,7 @@ ldaptool_parse_ctrl_arg(char *ctrl_arg, char sep,
 
     strict = (sep == ' ' ? 1 : 0);
     if(!(s=strchr(ctrl_arg, sep))) {
-	/* Possible values of ctrl_arg are 
+	/* Possible values of ctrl_arg are
 	 * oid[:value|::b64value|:<fileurl] within LDIF, i.e. sep=' '
 	 * oid from command line option, i.e. sep=':'
 	 */
@@ -1899,7 +1900,7 @@ ldaptool_parse_ctrl_arg(char *ctrl_arg, char sep,
 	    }
 	}
 	else {
-	    if (*(s+1) == '\0') { 
+	    if (*(s+1) == '\0') {
 	        fprintf( stderr, gettext("missing value\n") );
 	        return ( -1 );
 	    }
@@ -1996,7 +1997,7 @@ ldaptool_berval_is_ascii( const struct berval *bvp )
 }
 
 
-#ifdef LDAP_DEBUG_MEMORY   
+#ifdef LDAP_DEBUG_MEMORY
 #define LDAPTOOL_ALLOC_FREED	0xF001
 #define LDAPTOOL_ALLOC_INUSE	0xF002
 
@@ -2139,7 +2140,7 @@ certpath2keypath( char *certdbpath )
 	    strcasecmp( "cert.db", keydbpath + len - 7 ) == 0 ) {
 	striplen = 7;
 	appendstr = "key.db";
-	
+
     } else if ( len > 8 &&
 	    strcasecmp( "cert5.db", keydbpath + len - 8 ) == 0 ) {
 	striplen = 8;
@@ -2163,15 +2164,15 @@ certpath2keypath( char *certdbpath )
 }
 
 #ifdef LDAP_TOOL_PKCS11
-static 
-char * 
+static
+char *
 buildTokenCertName( const char *tokenName, const char *certName)
 {
-    
+
     int tokenlen = strlen(tokenName);
     int len = tokenlen + strlen(certName) +2;
     char *result;
-    
+
     if (( result = malloc( len )) != NULL) {
 	strcpy(result, tokenName);
 	*(result+tokenlen) = ':';
@@ -2190,7 +2191,7 @@ static
 int
 ldaptool_getcertpath( void *context, char **certlocp )
 {
-    
+
     *certlocp = ssl_certdbpath;
     if ( ldaptool_verbose ) {
 	if (ssl_certdbpath)
@@ -2201,15 +2202,15 @@ ldaptool_getcertpath( void *context, char **certlocp )
 	{
 	    printf(gettext("ldaptool_getcertpath -- (null)\n"));
 	}
-	
+
     }
     return LDAP_SUCCESS;
 }
 
 int
 ldaptool_getcertname( void *context, char **certnamep )
-{ 
-    
+{
+
    *certnamep = ssl_certname;
     if ( ldaptool_verbose ) {
 	if (ssl_certname)
@@ -2238,14 +2239,14 @@ ldaptool_getkeypath(void *context, char **keylocp )
 	    printf(gettext("ldaptool_getkeypath -- (null)\n"));
 	}
     }
-    
+
     return LDAP_SUCCESS;
 }
 
 int
 ldaptool_gettokenname( void *context, char **tokennamep )
 {
-    
+
     *tokennamep = pkcs_token;
     if ( ldaptool_verbose ) {
 	if (pkcs_token)
@@ -2263,19 +2264,19 @@ ldaptool_gettokenname( void *context, char **tokennamep )
 int
 ldaptool_gettokenpin( void *context, const char *tokennamep, char **tokenpinp)
 {
-  
+
 #if 0
   char *localtoken;
 #endif
 
-/* XXXceb this stuff is removed for the time being.  
+/* XXXceb this stuff is removed for the time being.
  * This function should return the pin from ssl_password
  */
 
 
   *tokenpinp = ssl_passwd;
   return LDAP_SUCCESS;
-  
+
 #if 0
 
   ldaptool_gettokenname( NULL, &localtoken);
@@ -2283,7 +2284,7 @@ ldaptool_gettokenpin( void *context, const char *tokennamep, char **tokenpinp)
   if (strcmp( localtoken, tokennamep))
 
       *tokenpinp = pkcs_pin;
-   else 
+   else
       *tokenpinp = NULL;
 
     if ( ldaptool_verbose ) {
@@ -2314,7 +2315,7 @@ ldaptool_getmodpath( void *context, char **modulep )
 	    printf(gettext("ldaptool_getmodpath -- (null)\n"));
 	}
     }
-    
+
     return LDAP_SUCCESS;
 }
 
@@ -2331,9 +2332,9 @@ ldaptool_getdonglefilename( void *context, char **filename )
 	{
 	    printf(gettext("ldaptool_getdonglefilename -- (null)\n"));
 	}
-	
+
     }
-    
+
     return LDAP_SUCCESS;
 }
 
@@ -2469,11 +2470,11 @@ ldaptool_boolean_str2value ( const char *ptr, int strict )
 	     !(strcmp(ptr, "0")) ) {
 	    	return (0);
 	}
-	else { 
+	else {
 	    return (-1);
-	}	
+	}
     }
-} 
+}
 
 FILE *
 ldaptool_open_file(const char *filename, const char *mode)
@@ -2559,7 +2560,7 @@ void L_Remove(Element *Node, Head *HeadNode)
 #endif
 
 #ifdef HAVE_SASL_OPTIONS
-/* 
+/*
  * Function checks for valid args, returns an error if not found
  * and sets SASL params from command line
  */
@@ -2576,7 +2577,7 @@ saslSetParam(char *saslarg)
 	}
 	*attr = '\0';
 	attr++;
-	    
+
 	if (!strcasecmp(saslarg, "secProp")) {
 	     if ( sasl_secprops != NULL ) {
                 fprintf( stderr, gettext("secProp previously specified\n"));
@@ -2625,7 +2626,7 @@ saslSetParam(char *saslarg)
 	} else {
 	     fprintf (stderr, gettext("Invalid attribute name %s\n"), saslarg);
 	     return (-1);
-	} 
+	}
 	return 0;
 }
 #endif	/* HAVE_SASL_OPTIONS */

--- a/usr/src/cmd/ldap/ns_ldap/ldapclient.c
+++ b/usr/src/cmd/ldap/ns_ldap/ldapclient.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1523,7 +1524,7 @@ client_init(clientopts_t *arglist)
 		cfg.SA_CRED = "proxy";
 		/*
 		 * We don't want to force users to always specify authentication
-		 * method when we can infer it. If users want SSL, he/she would
+		 * method when we can infer it. If users want SSL, they would
 		 * have to specify appropriate -a though.
 		 */
 		auth.type = NS_LDAP_AUTH_SIMPLE;

--- a/usr/src/cmd/lp/cmd/lpadmin/do_align.c
+++ b/usr/src/cmd/lp/cmd/lpadmin/do_align.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -183,7 +184,7 @@ int			do_align (printer, form, pwheel)
 	 * feature is likely to be used much, so why hassle the
 	 * administrator?
 #if	defined(WARN_OF_TOO_MANY_LINES)
-	 * However, do warn him or her.
+	 * However, do warn them.
 #endif
 	 */
 

--- a/usr/src/cmd/lp/cmd/lpadmin/do_printer.c
+++ b/usr/src/cmd/lp/cmd/lpadmin/do_printer.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -185,7 +186,7 @@ void			do_printer ()
 	/*
 	 * Mount or unmount form, print-wheel.
 	 */
-	if (M) 
+	if (M)
 		do_mount(p, (f? f : (char *)0), (S? *S : (char *)0));
 	else if (t) do_max_trays(p);
 
@@ -312,7 +313,7 @@ Done:
 	if (r) {
 		if (STREQU(r, NAME_ALL) || STREQU(r, NAME_ANY))
 			fromallclasses(p);
-		else 
+		else
 			fromclass(p, r);
 	}
 
@@ -382,7 +383,7 @@ static void		configure_printer (list)
 		/*
 		 * If we are making this a local printer, make
 		 * sure that some local-only attributes are set.
-		 * (If the user has specified these as well, his/her
+		 * (If the user has specified these as well, their
 		 * values will overwrite what we set here.)
 		 */
 		} else if (oldp->remote) {
@@ -685,7 +686,7 @@ char			*nameit (cmd)
 {
 	register char		*nm = getname(),
 				*copy = malloc(
-					(unsigned) (strlen(cmd) + 1 + 
+					(unsigned) (strlen(cmd) + 1 +
 					strlen(nm) + 1)
 	);
 

--- a/usr/src/cmd/lp/cmd/lpsched/disp1.c
+++ b/usr/src/cmd/lp/cmd/lpsched/disp1.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -547,7 +548,7 @@ s_end_change_request(char *m, MESG *md)
 				rp->request->outcome |= RS_HELD;
 				/*
 				 * To be here means either the user owns
-				 * the request or he or she is the
+				 * the request or they are the
 				 * administrator. Since we don't want to
 				 * set the RS_ADMINHELD flag if the user
 				 * is the administrator, the following

--- a/usr/src/cmd/lp/cmd/lpsched/exec.c
+++ b/usr/src/cmd/lp/cmd/lpsched/exec.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -328,7 +329,7 @@ exec(int type, ...)
 		request = printer->request;
 		ep = printer->exec;
 		break;
-		
+
 	case EX_FAULT_MESSAGE:
 		printer = va_arg(args, PSTATUS *);
 		request = va_arg(args, RSTATUS *);
@@ -336,7 +337,7 @@ exec(int type, ...)
 			return(0);
 		}
 		ep = printer->fault_exec;
-		printerName = (printer->printer && printer->printer->name 
+		printerName = (printer->printer && printer->printer->name
 				  ? printer->printer->name : "??");
 			snprintf(nameBuf, sizeof (nameBuf),
 				"%s (on %s)\n", printerName, Local_System);
@@ -474,7 +475,7 @@ exec(int type, ...)
 	 * Open the standard input, standard output, and standard error.
 	 */
 	switch (type) {
-		
+
 	case EX_SLOWF:
 	case EX_INTERF:
 		/*
@@ -584,7 +585,7 @@ exec(int type, ...)
 					 printer->printer->device);
 		if (ret != 0)
 			Done (ret, errno);
-			
+
 		if (!(request->request->outcome & RS_FILTERED))
 			file_list = request->request->file_list;
 
@@ -718,7 +719,7 @@ exec(int type, ...)
 		 */
 		cp = strchr(request->secure->user, '@');
 
-		allTraysWithForm(printer, request->form); 
+		allTraysWithForm(printer, request->form);
 
 		/*
 		 * Fix for 4137389
@@ -881,7 +882,7 @@ exec(int type, ...)
 		 */
 
 		argbuf[0] = '\0';
-				
+
 		if (printer->printer->options) {
 			char **tmp = printer->printer->options;
 			while(*tmp != NULL) {
@@ -959,8 +960,8 @@ exec(int type, ...)
 
 		/*
 		 * Do the ``raw'' bit last, to ensure it gets
-		 * done. If the user doesn't want this, then he or
-		 * she can do the correct thing using -o stty=
+		 * done. If the user doesn't want this, then they
+		 * can do the correct thing using -o stty=
 		 * and leaving out the -r option.
 		 */
 		if (request->request->actions & ACT_RAW) {
@@ -1179,7 +1180,7 @@ exec(int type, ...)
 	} else if (initgroups(pwp->pw_name, procgid) < 0) {
 		note("initgroups() call failed %d\n", errno);
 	}
-	
+
 	setgid (procgid);
 	setuid (procuid);
 
@@ -1245,7 +1246,7 @@ Fork1(EXEC *ep)
 		close(fds[1]);
 		ep->md = 0;
 		return (-1);
-	
+
 	case 0:
 		ChildMd = mconnect(NULL, fds[1], fds[1]);
 		return (0);
@@ -1268,10 +1269,10 @@ Fork2(void)
 	case -1:
 		Done (EXEC_EXIT_NFORK, errno);
 		/*NOTREACHED*/
-					
+
 	case 0:
 		return;
-					
+
 	default:
 		/*
 		 * Delay calling "ignore_fault_signals()" as long
@@ -1319,7 +1320,7 @@ cool_heels(void)
 	WaitedChildPid = 0;
 	while ((WaitedChildPid = wait(&status)) != ChildPid)
 		;
-			
+
 	if (
 		EXITED(status) > EXEC_EXIT_USER
 	     && EXITED(status) != EXEC_EXIT_FAULT

--- a/usr/src/cmd/lp/cmd/lpsched/pickfilter.c
+++ b/usr/src/cmd/lp/cmd/lpsched/pickfilter.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1996 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -44,7 +45,7 @@
  * BUT we'll leave LP_SEP inside single quotes alone!
  *
  * This is to allow the following case (and the like) to work correctly:
- *	prtitle='standard input' 
+ *	prtitle='standard input'
  */
 
 void
@@ -329,7 +330,7 @@ pickfilter(RSTATUS *prs, CANDIDATE *pc, FSTATUS *pfs)
 
 	/*
 	 * Don't try using a filter if the user doesn't want
-	 * a filter to be used! He or she would rather see an
+	 * a filter to be used! They would rather see an
 	 * error message than (heaven forbid!) a filter being
 	 * used.
 	 */

--- a/usr/src/cmd/lp/cmd/lpsched/ports.c
+++ b/usr/src/cmd/lp/cmd/lpsched/ports.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "termio.h"
@@ -118,7 +119,7 @@ open_dialup(char *ptype, PRINTER *pp)
 	 * override the default in the interface progam.
 	 * Putting the override in ".stty" allows the user
 	 * to override us (although it would be probably be
-	 * silly for him or her to do so.)
+	 * silly for them to do so.)
 	 */
 	if (ioctl(1, TCGETS, &tios) < 0) {
 		ioctl(1, TCGETA, &tio);

--- a/usr/src/cmd/lp/cmd/lpsched/validate.c
+++ b/usr/src/cmd/lp/cmd/lpsched/validate.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -168,10 +169,10 @@ _validate(RSTATUS *prs, PSTATUS *pps, PSTATUS *stop_pps, char **prefixp,
 	 * the Spooler's job is SPOOLING, not PRINTING. That's right,
 	 * except that the Spooler will be making a choice of printers
 	 * so it has to evaluate carefully: E.g. user wants ANY printer,
-	 * so we should pick one that can handle what he/she wants.
-	 * 
+	 * so we should pick one that can handle what they want.
+	 *
 	 * Parse out the important stuff here so we have it when we
-	 * need it. 
+	 * need it.
 	 */
 	{
 		register char		**list,
@@ -873,7 +874,7 @@ _chkopts(RSTATUS *prs, CANDIDATE *pc, FSTATUS *pfs)
 	 * character set. (Note: The check for the print wheel case
 	 * is done elsewhere.)
 	 */
-		
+
 	if (pc->pps->printer->daisy ||
 	    search_cslist(prs->request->charset, pc->pps->printer->char_sets))
 		charset = 0;

--- a/usr/src/cmd/lp/filter/postscript/dpost/dpost.c
+++ b/usr/src/cmd/lp/filter/postscript/dpost/dpost.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -210,7 +211,7 @@
  * of page independence. If you don't approve append *drawfile to *prologue and
  * make sure *drawfile can't be read when DPOST runs.
  *
- * Many default values, like the magnification and orientation, are defined in 
+ * Many default values, like the magnification and orientation, are defined in
  * the prologue, which is where they belong. If they're changed (by options), an
  * appropriate definition is made after the prologue is added to the output file.
  * The -P option passes arbitrary PostScript through to the output file. Among
@@ -220,7 +221,7 @@
  *
  * output language from troff:
  * all numbers are character strings
- * 
+ *
  * sn	size in points
  * fn	font as number from 1-n
  * cx	ascii character x
@@ -254,7 +255,7 @@
  * 	x f n s	font position n contains font s
  * 	x H n	set character height to n
  * 	x S n	set slant to N
- * 
+ *
  * 	Subcommands like "i" are often spelled out like "init".
  *
  */
@@ -1352,7 +1353,7 @@ fontinit(void)
  * font position, just to be sure device emulation works reasonably well - there's
  * no guarantee *devname's special fonts match what's needed when *realdev's tables
  * are used.
- * 
+ *
  */
 
 
@@ -1708,7 +1709,7 @@ resetpos(void)
  * done something that may have wiped it out, and we want to force dpost to set
  * the printer's position before printing text or whatever. For example stroke or
  * fill implicitly do a newpath, and that wipes out the current point, unless the
- * calls were bracketed by a gsave/grestore pair. 
+ * calls were bracketed by a gsave/grestore pair.
  *
  */
 
@@ -1779,7 +1780,7 @@ t_page(int pg)
  * restore so it can be easily redefined to have side-effects in the printer's VM.
  * Although it seems reasonable I haven't implemented it, because it makes other
  * things, like selectively setting manual feed or choosing an alternate paper
- * tray, clumsy - at least on a per page basis. 
+ * tray, clumsy - at least on a per page basis.
  *
  */
 

--- a/usr/src/cmd/lp/lib/access/bang.c
+++ b/usr/src/cmd/lp/lib/access/bang.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1999 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -123,7 +124,7 @@ bangequ (char *user1p, char *user2p)
 		(void) snprintf(sysname2, sizeof (sysname2), "%s", Nodenamep);
 		(void) snprintf(username2, sizeof (username2), "%s", user1p);
 	}
-	
+
 	sysname2_all = STREQU (NAME_ALL, sysname2);
 	username2_all = STREQU (NAME_ALL, username2);
 
@@ -193,16 +194,16 @@ bang_dellist(char ***plist, char *item)
 	 * ALL matching items in the list are deleted.
 	 *
 	 * Now suppose the list contains just the word ``all'', and
-	 * the item to be deleted is the name ``fred''. What will
+	 * the item to be deleted is the name ``foo''. What will
 	 * happen? The word ``all'' will be deleted, leaving the list
 	 * empty (null)! This may sound odd at first, but keep in mind
 	 * that this routine is paired with the regular "addlist()"
-	 * routine; the item (``fred'') is ADDED to an opposite list
+	 * routine; the item (``foo'') is ADDED to an opposite list
 	 * (we are either deleting from a deny list and adding to an allow
 	 * list or vice versa). So, to continue the example, if previously
-	 * ``all'' were allowed, removing ``fred'' from the allow list
-	 * does indeed empty that list, but then putting him in the deny
-	 * list means only ``fred'' is denied, which is the effect we
+	 * ``all'' were allowed, removing ``foo'' from the allow list
+	 * does indeed empty that list, but then putting it in the deny
+	 * list means only ``foo'' is denied, which is the effect we
 	 * want.
 	 */
 

--- a/usr/src/cmd/lp/lib/lp/alerts.c
+++ b/usr/src/cmd/lp/lib/lp/alerts.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1997 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -73,7 +74,7 @@ static struct {
 /*
  * These are used to bracket the administrator's command, so that
  * we can find it easily. We're out of luck if the administrator
- * includes an identical phrase in his or her command.
+ * includes an identical phrase in their command.
  */
 #define ALRT_CMDSTART "## YOUR COMMAND STARTS HERE -- DON'T TOUCH ABOVE!!"
 #define ALRT_CMDEND   "## YOUR COMMAND ENDS HERE -- DON'T TOUCH BELOW!!"

--- a/usr/src/cmd/mailx/hdr/def.h
+++ b/usr/src/cmd/mailx/hdr/def.h
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 1985, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T */
@@ -211,7 +212,7 @@ struct cmd {
 
 typedef struct headline {
 	custr_t	*hl_from;	/* The name of the sender */
-	custr_t	*hl_tty;	/* His tty string (if any) */
+	custr_t	*hl_tty;	/* Its tty string (if any) */
 	custr_t	*hl_date;	/* The entire date string */
 } headline_t;
 

--- a/usr/src/cmd/mailx/lex.c
+++ b/usr/src/cmd/mailx/lex.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T */
@@ -443,7 +444,7 @@ more:;
 /*
  * Execute a single command.  If the command executed
  * is "quit," then return non-zero so that the caller
- * will know to return back to main, if he cares.
+ * will know to return back to main, if it cares.
  * Contxt is non-zero if called while composing mail.
  */
 
@@ -529,7 +530,7 @@ execute(char linebuf[], int contxt)
 
 	/*
 	 * Process the arguments to the command, depending
-	 * on the type he expects.  Default to an error.
+	 * on the type it expects.  Default to an error.
 	 * If we are sourcing an interactive command, it's
 	 * an error.
 	 */

--- a/usr/src/cmd/mailx/main.c
+++ b/usr/src/cmd/mailx/main.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -56,7 +57,7 @@ static jmp_buf	hdrjmp;
 const char *const version = "mailx version 5.0";
 
 /*
- * Find out who the user is, copy his mail file (if exists) into
+ * Find out who the user is, copy their mail file (if exists) into
  * /tmp/Rxxxxx and set up the message pointers.  Then, print out the
  * message headers and read user commands.
  *
@@ -68,7 +69,7 @@ const char *const version = "mailx version 5.0";
  * and a bunch of other options.
  */
 
-int 
+int
 main(int argc, char **argv)
 {
 	register char *ef;
@@ -244,8 +245,8 @@ main(int argc, char **argv)
 			/*
 			 * User is specifying file to "edit" with mailx,
 			 * as opposed to reading system mailbox.
-			 * If no argument is given after -f, we read his/her
-			 * $MBOX file or mbox in his/her home directory.
+			 * If no argument is given after -f, we read their
+			 * $MBOX file or mbox in their home directory.
 			 */
 			ef = (argc == optind || *argv[optind] == '-')
 				? "" : argv[optind++];
@@ -444,7 +445,7 @@ gettext("Usage: %s -eiIUdFntBNHvV~ -T FILE -u USER -h hops -r address\n"),
 /*
  * Interrupt printing of the headers.
  */
-static void 
+static void
 #ifdef	__cplusplus
 hdrstop(int)
 #else

--- a/usr/src/cmd/mailx/names.c
+++ b/usr/src/cmd/mailx/names.c
@@ -23,6 +23,7 @@
 /*
  * Copyright 2001 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -654,9 +655,9 @@ unpack(struct name *np)
 }
 
 /*
- * See if the user named himself as a destination
- * for outgoing mail.  If so, set the global flag
- * selfsent so that we avoid removing his mailbox.
+ * See if the user named themself as a destination
+ * for outgoing mail. If so, set the global flag
+ * selfsent so that we avoid removing their mailbox.
  */
 
 void

--- a/usr/src/cmd/mailx/quit.c
+++ b/usr/src/cmd/mailx/quit.c
@@ -21,7 +21,9 @@
  */
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
 /*	  All Rights Reserved  	*/
-
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 /*
  * University Copyright- Copyright (c) 1982, 1986, 1988
@@ -57,7 +59,7 @@ static void		writeback(int noremove);
  * Remove the system mailbox, if none saved there.
  */
 
-void 
+void
 quit(
     int noremove	/* don't remove system mailbox, trunc it instead */
 )
@@ -163,7 +165,7 @@ quit(
 	/*
 	 * Create another temporary file and copy user's mbox file
 	 * therein.  If there is no mbox, copy nothing.
-	 * If s/he has specified "append" don't copy the mailbox,
+	 * If they have specified "append" don't copy the mailbox,
 	 * just copy saveable entries at the end.
 	 */
 
@@ -267,7 +269,7 @@ quit(
  * mailbox, and print a nice message indicating how many were
  * saved.  Incorporate any new mail that we found.
  */
-static void 
+static void
 writeback(int noremove)
 {
 	register struct message *mp;
@@ -379,7 +381,7 @@ die:
 		fclose(rbuf);
 		PRIV(removefile(tempResid));
 	}
-	if (obuf)	
+	if (obuf)
 		fclose(obuf);
 	if (issysmbox)
 		unlockmail();
@@ -388,13 +390,13 @@ die:
 	sigset(SIGQUIT, fquit);
 }
 
-void 
+void
 lockmail(void)
 {
     PRIV(maillock(lockname,10));
 }
 
-void 
+void
 unlockmail(void)
 {
     PRIV(mailunlock());

--- a/usr/src/cmd/mailx/send.c
+++ b/usr/src/cmd/mailx/send.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1985, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -234,7 +235,7 @@ writeit:
 /*
  * Test if the passed line is a header line, RFC 822 style.
  */
-int 
+int
 headerp(register char *line)
 {
 	register char *cp = line;
@@ -275,7 +276,7 @@ statusput(
  * which does all the dirty work.
  */
 
-int 
+int
 mail(char **people)
 {
 	register char *cp2, *cp3;
@@ -309,7 +310,7 @@ mail(char **people)
 	return(0);
 }
 
-int 
+int
 sendm(char *str)
 {
 	if (value("flipm") != NOSTR)
@@ -317,7 +318,7 @@ sendm(char *str)
 	else return(sendmail(str));
 }
 
-int 
+int
 Sendm(char *str)
 {
 	if (value("flipm") != NOSTR)
@@ -329,7 +330,7 @@ Sendm(char *str)
  * Interface to the mail1 routine for the -t flag
  * (read headers from text).
  */
-int 
+int
 tmail(void)
 {
 	struct header head;
@@ -346,7 +347,7 @@ tmail(void)
  * Send mail to a bunch of user names.  The interface is through
  * the mail routine below.
  */
-static int 
+static int
 sendmail(char *str)
 {
 	struct header head;
@@ -367,7 +368,7 @@ sendmail(char *str)
  * the mail routine below.
  * save a copy of the letter
  */
-static int 
+static int
 Sendmail(char *str)
 {
 	struct header head;
@@ -398,7 +399,7 @@ closefd_walk(void *special_fd, int fd)
  * Mail a message on standard input to the people indicated
  * in the passed header.  (Internal interface).
  */
-void 
+void
 mail1(struct header *hp, int use_to, char *orig_to)
 {
 	pid_t p, pid;
@@ -508,7 +509,7 @@ mail1(struct header *hp, int use_to, char *orig_to)
 	 * Wait, to absorb a potential zombie, then
 	 * fork, set up the temporary mail file as standard
 	 * input for "mail" and exec with the user list we generated
-	 * far above. Return the process id to caller in case he
+	 * far above. Return the process id to caller in case it
 	 * wants to await the completion of mail.
 	 */
 

--- a/usr/src/cmd/make/bin/doname.cc
+++ b/usr/src/cmd/make/bin/doname.cc
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2016 RackTop Systems.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -463,7 +464,7 @@ recheck_target:
 
 /*
  * after making the call to dynamic_dependecies unconditional we can handle
- * target names that are same as file name. In this case $$@ in the 
+ * target names that are same as file name. In this case $$@ in the
  * dependencies did not mean anything. WIth this change it expands it
  * as expected.
  */
@@ -619,7 +620,7 @@ recheck_target:
  * Regression! See BugId 1255360
  * If more than one percent rules are defined for the same target then
  * the behaviour of 'make' with my previous fix may be different from one
- * of the 'old make'. 
+ * of the 'old make'.
  * The global variable second_pass (maybe it should be an argument to doname())
  * is intended to avoid this regression. It is set in doname_check().
  * First, 'make' will work as it worked before. Only when it is
@@ -722,7 +723,7 @@ r_command:
 	if ((command != NULL) &&
 	    (command->body.line.command_template != NULL)) {
 		if (result != build_failed) {
-			result = run_command(command, 
+			result = run_command(command,
 					     (Boolean) ((parallel || save_parallel) && !silent));
 		}
 		switch (result) {
@@ -902,7 +903,7 @@ r_command:
  *
  *	Return value:
  *				True returned if some dependencies left running
- *				
+ *
  *	Parameters:
  *		result		Pointer to cell we update if build failed
  *		line		We get the dependencies from here
@@ -1081,7 +1082,7 @@ check_dependencies(Doname *result, Property line, Boolean do_get, Name target, N
 					true_target->stat.time = dependency->name->stat.time;
 					true_target->stat.time.tv_sec--;
 				} else {
-					/* Dina: 
+					/* Dina:
 					 * The next statement is commented
 					 * out as a fix for bug #1051032.
 					 * if dependency hasn't changed
@@ -1627,7 +1628,7 @@ run_command(register Property line, Boolean)
 	    keep_state &&
 	    !remember_only) {
 		(void) exists(make_state);
-		if((strlen(temp_file_directory) == 1) && 
+		if((strlen(temp_file_directory) == 1) &&
 			(temp_file_directory[0] == '/')) {
 		   tmp_file_path[0] = '\0';
 		} else {
@@ -1744,7 +1745,7 @@ run_command(register Property line, Boolean)
  *	Return value:
  *				The result of the command build
  *
- *	Parameters:	
+ *	Parameters:
  *		line		The command to execute
  *
  *	Static variables used:
@@ -1865,15 +1866,15 @@ execute_serial(Property line)
 	if(spro) {
 		char *val = spro->body.env_mem.value;
 		if(val != NULL) {
-			/* 
+			/*
 			 * Do not return memory allocated for SUNPRO_DEPENDENCIES
-			 * It will be returned in setvar_daemon() in macro.cc 
+			 * It will be returned in setvar_daemon() in macro.cc
 			 */
 			//	retmem_mb(val);
 			spro->body.env_mem.value = NULL;
 		}
 	}
-	
+
         return result;
 }
 
@@ -1953,14 +1954,14 @@ check_state(Name temp_file_name)
 	}
 
 	/*
-	 * Then read the temp file that now might 
-	 * contain dependency reports from utilities 
+	 * Then read the temp file that now might
+	 * contain dependency reports from utilities
 	 */
 	read_dependency_file(temp_file_name);
 
 	/*
 	 * And reread .make.state if it
-	 * changed (the command ran recursive makes) 
+	 * changed (the command ran recursive makes)
 	 */
 	check_read_state_file();
 	if (temp_file_name != NULL) {
@@ -2263,7 +2264,7 @@ build_command_strings(Name target, register Property line)
 	Chain hat_list = NULL;
 	Chain *hat_list_tail = &hat_list;
 
-	for (Dependency dependency = line->body.line.dependencies; 
+	for (Dependency dependency = line->body.line.dependencies;
 		dependency != NULL;
 		dependency = dependency->next) {
 		/* skip automatic dependencies */
@@ -2271,10 +2272,10 @@ build_command_strings(Name target, register Property line)
 			if ((dependency->name != force) &&
 				(dependency->stale == false)) {
 				*hat_list_tail = ALLOC(Chain);
-			
+
 				if (dependency->name->is_member &&
 					(get_prop(dependency->name->prop, member_prop) != NULL)) {
-					(*hat_list_tail)->name = 
+					(*hat_list_tail)->name =
 							get_prop(dependency->name->prop,
 								member_prop)->body.member.member;
 				} else {
@@ -2592,14 +2593,14 @@ update_target(Property line, Doname result)
 	/*
 	 * [tolik] Additional fix for bug 1063790. It was fixed
 	 * for serial make long ago, but DMake dumps core when
-	 * target is a symlink and sccs file is newer then target. 
+	 * target is a symlink and sccs file is newer then target.
 	 * In this case, finish_children() calls update_target()
 	 * with line==NULL.
 	 */
 	if(line == NULL) {
 		/* XXX. Should we do anything here? */
 		return;
-	}	
+	}
 
 	target = line->body.line.target;
 
@@ -2778,7 +2779,7 @@ sccs_get(register Name target, register Property *command)
 		      (target->prop->body.sccs.file) &&
 		      (target->prop->body.sccs.file->string_mb)) {
 		      if((strlen(target->prop->body.sccs.file->string_mb) ==
-			strlen(target->string_mb) + 2) && 
+			strlen(target->string_mb) + 2) &&
 		        (target->prop->body.sccs.file->string_mb[0] == 's') &&
 		        (target->prop->body.sccs.file->string_mb[1] == '.')) {
 
@@ -3164,7 +3165,7 @@ target_can_be_built(register Name target) {
 	if (result == build_dont_know) {
 		result = find_percent_rule(target, NULL, false);
 	}
-	
+
 	/* try to find double suffix rule */
 	if (result == build_dont_know) {
 		if (target->is_member) {
@@ -3178,17 +3179,17 @@ target_can_be_built(register Name target) {
 			result = find_double_suffix_rule(target, NULL, false);
 		}
 	}
-	
+
 	/* try to find suffix rule */
 	if ((result == build_dont_know) && second_pass) {
 		result = find_suffix_rule(target, target, empty_name, NULL, false);
 	}
-	
+
 	/* check for sccs */
 	if (result == build_dont_know) {
 		result = sccs_get(target, NULL);
 	}
-	
+
 	/* try to find dyn target */
 	if (result == build_dont_know) {
 		Name dtarg = find_dyntarget(target);
@@ -3196,7 +3197,7 @@ target_can_be_built(register Name target) {
 			result = target_can_be_built(dtarg);
 		}
 	}
-	
+
 	/* check whether target was mentioned in makefile */
 	if (result == build_dont_know) {
 		if (target->colons != no_colon) {

--- a/usr/src/cmd/mdb/common/kmdb/kctl/kctl_wr.c
+++ b/usr/src/cmd/mdb/common/kmdb/kctl/kctl_wr.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -72,7 +73,7 @@ kctl_wr_process_cb(kmdb_wr_t *wn, void *arg)
 		if (unloading) {
 			/*
 			 * If the user didn't wait for all dmods to load before
-			 * she triggered the debugger unload, we may have some
+			 * they triggered the debugger unload, we may have some
 			 * dmod load requests on the queue in front of the
 			 * blizzard of dmod unload requests that the debugger
 			 * will generate as part of its unload.  The debugger

--- a/usr/src/cmd/mdb/common/modules/genunix/modhash.c
+++ b/usr/src/cmd/mdb/common/modules/genunix/modhash.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -403,7 +404,7 @@ modhash(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 			    "permitted\n");
 			return (DCMD_USAGE);
 		}
-		/* we force short mode here, no matter what he says */
+		/* we force short mode here, no matter what it says */
 		new_argv[0].a_type = MDB_TYPE_STRING;
 		new_argv[0].a_un.a_str = opt_t ? "-st" : "-s";
 		if (mdb_walk_dcmd("modhash", "modhash", 1, new_argv) == -1) {

--- a/usr/src/cmd/mpathadm/mpathadm.c
+++ b/usr/src/cmd/mpathadm/mpathadm.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1126,7 +1127,7 @@ compareLUName(MP_CHAR *cmpString, MP_CHAR *deviceProperty)
  *	Displays info about an LU
  *
  * luOid	- LU to list
- * luProps	- properties of he LU to list
+ * luProps	- properties of the LU to list
  *
  * ****************************************************************************
  */
@@ -1265,7 +1266,7 @@ showLogicalUnit(int operandLen, char *operand[])
  *	Displays info about an LU
  *
  * luOid	- LU to show
- * luProps	- properties of he LU to show
+ * luProps	- properties of the LU to show
  * pluginProps	- propertis of the plugin this LU belongs to
  *
  * ****************************************************************************

--- a/usr/src/cmd/nscd/cache.c
+++ b/usr/src/cmd/nscd/cache.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1276,7 +1277,7 @@ check_config(nsc_lookup_args_t *largs, nscd_cfg_cache_t *cfgp,
 	}
 
 	/*
-	 * if caller requests lookup using his
+	 * if caller requests lookup using its
 	 * own nsswitch config, bypass cache
 	 */
 	if (nsw_config_in_phdr(largs->buffer))

--- a/usr/src/cmd/nscd/server.c
+++ b/usr/src/cmd/nscd/server.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1994, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -144,7 +145,7 @@ main(int argc, char ** argv)
 	}
 
 	/*
-	 *  Special case non-root user here - he can just print stats
+	 *  Special case non-root user here - they can only print stats
 	 */
 	if (geteuid()) {
 		if (argc != 2 ||

--- a/usr/src/cmd/pg/pg.c
+++ b/usr/src/cmd/pg/pg.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -516,7 +517,7 @@ char *filename;
 		/*
 		 * Wait for output to drain before going on.
 		 * This is done so that the user will not hit
-		 * break and quit before he has seen the prompt.
+		 * break and quit before they have seen the prompt.
 		 */
 		(void) ioctl(1, TCSBRK, 1);
 		if (setjmp(restore) > 0)

--- a/usr/src/cmd/rcm_daemon/common/ttymux_rcm.c
+++ b/usr/src/cmd/rcm_daemon/common/ttymux_rcm.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
@@ -917,7 +918,7 @@ rsrc_unavailable(rsrc_t *rsrc)
  * greater than zero then a resource which uses rsrc will only be
  * returned if it is associated with >= redundancy dependents.
  *
- * Thus, provided that the caller keeps the list locked he can iterate
+ * Thus, provided that the caller keeps the list locked it can iterate
  * through all the resources in the cache that depend upon rsrc.
  */
 static rsrc_t *

--- a/usr/src/cmd/rpcsvc/rpc.bootparamd/bootparam_subr.c
+++ b/usr/src/cmd/rpcsvc/rpc.bootparamd/bootparam_subr.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1999-2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -177,8 +178,8 @@ bootparamproc_getfile_1(bp_getfile_arg *argp, CLIENT *cl)
 	 *
 	 *	file_key=server_hostname:path_on_server
 	 *
-	 * In the getfile RPC call, the client gives us his hostname
-	 * and a file_key.  We lookup his client entry, then locate a
+	 * In the getfile RPC call, the client gives us its hostname
+	 * and a file_key.  We lookup its client entry, then locate a
 	 * file entry matching that file_key.  We then parse out the
 	 * server_hostname and path_on_server from the file entry, map
 	 * the server_hostname to an IP address, and return both the

--- a/usr/src/cmd/sendmail/aux/vacation.c
+++ b/usr/src/cmd/sendmail/aux/vacation.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  *	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T
  *	  All Rights Reserved
@@ -47,7 +48,7 @@ static char	SccsId[] = "%W%	%E% SMI";
  *	For best operation, this program should run setuid to
  *	root or uucp or someone else that sendmail will believe
  *	a -f flag from.  Otherwise, the user must be careful
- *	to include a header on his .vacation.msg file.
+ *	to include a header on their .vacation.msg file.
  *
  *	Positional Parameters:
  *		the user to collect the vacation message from.

--- a/usr/src/cmd/sendmail/src/conf.c
+++ b/usr/src/cmd/sendmail/src/conf.c
@@ -14,6 +14,7 @@
 /*
  * Copyright 1999-2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sendmail.h>
@@ -1152,7 +1153,7 @@ username()
 **  TTYPATH -- Get the path of the user's tty
 **
 **	Returns the pathname of the user's tty.  Returns NULL if
-**	the user is not logged in or if s/he has write permission
+**	the user is not logged in or if they have write permission
 **	denied.
 **
 **	Parameters:

--- a/usr/src/cmd/sendmail/src/envelope.c
+++ b/usr/src/cmd/sendmail/src/envelope.c
@@ -10,7 +10,9 @@
  * the sendmail distribution.
  *
  */
-
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 #include <sendmail.h>
 
 SM_RCSID("@(#)$Id: envelope.c,v 8.310 2009/12/18 17:08:01 ca Exp $")
@@ -930,7 +932,7 @@ closexscript(e)
 **  SETSENDER -- set the person who this message is from
 **
 **	Under certain circumstances allow the user to say who
-**	s/he is (using -f or -r).  These are:
+**	they are (using -f or -r).  These are:
 **	1.  The user's uid is zero (root).
 **	2.  The user's login name is in an approved list (typically
 **	    from a network server).

--- a/usr/src/cmd/sendmail/src/savemail.c
+++ b/usr/src/cmd/sendmail/src/savemail.c
@@ -10,7 +10,9 @@
  * the sendmail distribution.
  *
  */
-
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 #include <sendmail.h>
 
 SM_RCSID("@(#)$Id: savemail.c,v 8.314 2009/12/18 17:08:01 ca Exp $")
@@ -23,7 +25,7 @@ static bool	pruneroute __P((char *));
 **
 **	If mailing back errors, mail it back to the originator
 **	together with an error message; otherwise, just put it in
-**	dead.letter in the user's home directory (if he exists on
+**	dead.letter in the user's home directory (if they exist on
 **	this machine).
 **
 **	Parameters:
@@ -37,7 +39,7 @@ static bool	pruneroute __P((char *));
 **
 **	Side Effects:
 **		Saves the letter, by writing or mailing it back to the
-**		sender, or by putting it in dead.letter in her home
+**		sender, or by putting it in dead.letter in their home
 **		directory.
 */
 

--- a/usr/src/cmd/soelim/soelim.c
+++ b/usr/src/cmd/soelim/soelim.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -24,7 +25,7 @@
  * This program eliminates .so's from a n/troff input stream.
  * It can be used to prepare safe input for submission to the
  * phototypesetter since the software supporting the operator
- * doesn't let him do chdir.
+ * doesn't let them do chdir.
  *
  * This is a kludge and the operator should be given the
  * ability to do chdir.

--- a/usr/src/cmd/stat/fsstat/fsstat.c
+++ b/usr/src/cmd/stat/fsstat/fsstat.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -1031,7 +1032,7 @@ main(int argc, char *argv[])
 			 * If we're only displaying FStypes (-F) then don't
 			 * complain about any file systems that might not
 			 * be loaded.  Otherwise, let the user know that
-			 * he chose poorly.
+			 * they chose poorly.
 			 */
 			if (fstypes_only == B_FALSE) {
 				(void) fprintf(stderr, gettext(

--- a/usr/src/cmd/sulogin/sulogin.c
+++ b/usr/src/cmd/sulogin/sulogin.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -777,7 +778,7 @@ childcleanup(int sig)
 
 	/* Only need to kill the child that became the shell. */
 	for (i = 0; i < nchild; i++) {
-		/* Don't kill gramps before his time */
+		/* Don't kill grandparent before it's necessary */
 		if (pidlist[i] != getppid())
 			(void) sigsend(P_PID, pidlist[i], SIGHUP);
 	}

--- a/usr/src/cmd/svc/configd/configd.c
+++ b/usr/src/cmd/svc/configd/configd.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <assert.h>
@@ -353,11 +354,11 @@ create_connection(ucred_t *uc, repository_door_request_t *rp,
 		    sizeof (info))
 			return (REPOSITORY_DOOR_FAIL_PERMISSION_DENIED);
 
-		privileged = 1;			/* he gets full privileges */
+		privileged = 1;			/* it gets full privileges */
 	} else if (privileged_user != 0) {
 		/*
 		 * in privileged user mode, only one particular user is
-		 * allowed to connect to us, and he can do anything.
+		 * allowed to connect to us, and they can do anything.
 		 */
 		if (ucred_geteuid(uc) != privileged_user)
 			return (REPOSITORY_DOOR_FAIL_PERMISSION_DENIED);

--- a/usr/src/cmd/svc/configd/file_object.c
+++ b/usr/src/cmd/svc/configd/file_object.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -247,7 +248,7 @@ pg_lnk_tbl_delete(delete_info_t *dip, const delete_ent_t *ent)
 
 	/*
 	 * For non-persistent backends, we could only have one parent, and
-	 * he's already been deleted.
+	 * it's already been deleted.
 	 *
 	 * For normal backends, we need to check to see if we're in
 	 * a snapshot or are the active generation for the property

--- a/usr/src/cmd/svc/configd/rc_node.c
+++ b/usr/src/cmd/svc/configd/rc_node.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -585,11 +586,11 @@ static audit_special_prop_item_t special_props_list[] = {
  * Clients use their position in the list to track which notifications they
  * have not yet reported.  As they process notifications, they move forward
  * in the list past them.  There is always a client at the beginning of the
- * list -- as he moves past notifications, he removes them from the list and
+ * list -- as it moves past notifications, it removes them from the list and
  * cleans them up.
  *
  * The rc_pg_notify_lock protects all notification state.  The rc_pg_notify_cv
- * is used for global signalling, and each client has a cv which he waits for
+ * is used for global signalling, and each client has a cv which it waits for
  * events of interest on.
  *
  * rc_notify_in_use is used to protect rc_notify_list from deletions when

--- a/usr/src/cmd/svc/svcs/svcs.c
+++ b/usr/src/cmd/svc/svcs/svcs.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, Joyent, Inc. All rights reserved.
- * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2493,7 +2493,7 @@ print_detailed(void *unused, scf_walkinfo_t *wip)
 	/*
 	 * Property values may be longer than max_scf_fmri_length, but these
 	 * shouldn't be, so we'll just reuse buf.  The user can use svcprop if
-	 * he suspects something fishy.
+	 * they suspect something fishy.
 	 */
 	if (scf_instance_get_pg(wip->inst, SCF_PG_RESTARTER, rpg) != 0) {
 		if (scf_error() != SCF_ERROR_NOT_FOUND)

--- a/usr/src/cmd/tar/tar.c
+++ b/usr/src/cmd/tar/tar.c
@@ -22,6 +22,7 @@
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Milan Jurik. All rights reserved.
  * Copyright 2015 Joyent, Inc.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1464,7 +1465,7 @@ dorep(char *argv[])
  *	endtape checks the entry in dblock.dbuf to see if its the
  *	special EOT entry.  Endtape is usually called after getdir().
  *
- *	endtape used to call backtape; it no longer does, he who
+ *	endtape used to call backtape; it no longer does, it who
  *	wants it backed up must call backtape himself
  *	RETURNS:	0 if not EOT, tape position unaffected
  *			1 if	 EOT, tape position unaffected

--- a/usr/src/cmd/utmpd/utmpd.c
+++ b/usr/src/cmd/utmpd/utmpd.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright 2014, 2015 Shruti V Sampat <shrutisampat@gmail.com>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -728,7 +729,7 @@ add_pid(pid_t pid)
 	 */
 	if (pid != 0 && (fd = proc_to_fd(pid)) == -1) {
 		/*
-		 * No so the process died before we got to watch for him
+		 * No, so the process died before we got to watch for it.
 		 */
 		return;
 	}

--- a/usr/src/cmd/vi/port/ex_cmdsub.c
+++ b/usr/src/cmd/vi/port/ex_cmdsub.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -477,14 +478,14 @@ pragged(bool kill)
 
 	if (!kill)
 		getDOT();
-	
+
 	/*
 	 * Copy "abcd" into genbuf.
 	 * Note that gp points to 'c'.
 	 */
 
 	strcpy(genbuf, linebuf);
-	
+
 	/*
 	 * Get last line of undo area ("3") into linebuf.
 	 */
@@ -492,7 +493,7 @@ pragged(bool kill)
 	getaline(*unddol);
 	if (kill)
 		*pkill[1] = 0;
-	
+
 
 	/*
 	 * Concatenate trailing end of current line
@@ -520,7 +521,7 @@ pragged(bool kill)
 	getaline(dol[1]);
 	if (kill)
 		strcLIN(pkill[0]);
-	
+
 	/*
 	 * Copy the first line of the undo save area
 	 * over what is pointed to by sp.
@@ -528,7 +529,7 @@ pragged(bool kill)
 	 */
 
 	strcpy(gp, linebuf);
-	
+
 	/*
 	 * Now copy genbuf back into linebuf.
 	 *	linebuf = "ab1"
@@ -662,8 +663,8 @@ badtag:
 
 	/*
 	 * Loop once for each file in tags "path".
-	 * 
-	 * System tags array limits to 4k (tags[ONMSZ]) long, 
+	 *
+	 * System tags array limits to 4k (tags[ONMSZ]) long,
 	 * therefore, tagfbuf should be able to hold all tags.
 	 */
 
@@ -780,7 +781,7 @@ badtags:
                         if (*savedfile) {
 				savetag((char *)savedfile);
                         }
-#endif 
+#endif
 			strcpy(cmdbuf, cp);
 			if (strcmp(filebuf, savedfile) || !edited) {
 				unsigned char cmdbuf2[sizeof filebuf + 10];
@@ -908,7 +909,7 @@ badtags2:
                         if (*savedfile) {
 				savetag((char *)savedfile);
                         }
-#endif 
+#endif
 			strcpy(cmdbuf, cp);
 			if (strcmp(filebuf, savedfile) || !edited) {
 				unsigned char cmdbuf2[sizeof filebuf + 10];
@@ -1209,7 +1210,7 @@ undo(bool c)
 	if (inglobal && inopen <= 0)
 		error(value(vi_TERSE) ? gettext("Can't undo in global") :
 			gettext("Can't undo in global commands"));
-	
+
 	/*
 	 * Unless flag indicates a forced undo, make sure
 	 * there really was a change before trying to undo it.
@@ -1217,7 +1218,7 @@ undo(bool c)
 
 	if (!c)
 		somechange();
-	
+
 	/*
 	 * Update change flags.
 	 */
@@ -1296,7 +1297,7 @@ undo(bool c)
 		 * then we must move the text between undap1 and undap2
 		 * and it must not be at the bottom of the file
 		 */
-		
+
 		if ((i = (kp = undap2) - (jp = undap1)) > 0) {
 			if (kp != dolp1) {
 
@@ -1330,18 +1331,18 @@ undo(bool c)
 			}
 			/*
 			 * Unddel, the line just before the spot where this
-			 * test was deleted, may have moved. Account for 
+			 * test was deleted, may have moved. Account for
 			 * this in restoration of saved deleted lines.
 			 */
 			if (unddel >= jp)
 				unddel -= i;
-			
+
 			/*
 			 * The last line (dol) may have changed,
 			 * account for this.
 			 */
 			 newdol -= i;
-			
+
 			/*
 			 * For the case where no lines are restored, dot
 			 * is the line before the first line deleted.
@@ -1356,25 +1357,25 @@ undo(bool c)
 			unddel = undap1 - 1;
 			squish();
 		}
-		
+
 		/*
 		 * Set jp to the line where deleted text is to be added.
 		 */
 		jp = unddel + 1;
-		
+
 		/*
 		 * Set kp to end of undo save area.
 		 *
 		 * If there is any deleted text to be added, do reverses.
 		 */
-		
+
 		if ((i = (kp = unddol) - dol) > 0) {
-			
+
 			/*
 			 * If deleted lines are not to be appended
 			 * to the bottom of the file...
 			 */
-			 
+
 			 if (jp != dolp1) {
 				/*
 				 * FILE:   LINE   START   REV1   REV2   REV3
@@ -1398,7 +1399,7 @@ undo(bool c)
 				 *         7)      mn      mn     kl     56
 				 * unddol: 8)      op      op     ij     78
 				 */
-				 
+
 				 reverse(jp, dolp1);
 				reverse(dolp1, ++kp);
 				reverse(jp, kp);
@@ -1414,11 +1415,11 @@ undo(bool c)
 			 * Dot is the first resurrected line.
 			 */
 			dot = jp;
-			
+
 			/*
 			 * Account for a shift in the last line (dol).
 			 */
-			 
+
 			 newdol += i;
 		}
 		/*
@@ -1434,17 +1435,17 @@ undo(bool c)
 			undadot = newadot;
 		} else
 			undkind = UNDCHANGE;
- 		/*
- 		 * Now relocate all marks for lines that were modified,
- 		 * since the marks point to lines whose address has 
- 		 * been modified from the save area to the current 
- 		 * area
- 		 */
- 			
- 		for (j=unddol; j> dol; j--) 
- 			for (k=0; k<=25; k++) 
- 				if (names[k] == *(j)) 
- 					names[k]= *((undap1+(j-dolp1)) );
+		/*
+		 * Now relocate all marks for lines that were modified,
+		 * since the marks point to lines whose address has
+		 * been modified from the save area to the current
+		 * area
+		 */
+
+		for (j=unddol; j> dol; j--)
+			for (k=0; k<=25; k++)
+				if (names[k] == *(j))
+					names[k]= *((undap1+(j-dolp1)) );
 	}
 	/*
 	 * Defensive programming - after a munged undadot.
@@ -1623,7 +1624,7 @@ addmac(unsigned char *src, unsigned char *dest, unsigned char *dname,
 		 * We don't let the user rob himself of ":", and making
 		 * multi char words is a bad idea so we don't allow it.
 		 * Note that if user sets mapinput and maps all of return,
-		 * linefeed, and escape, he can hurt himself. This is
+		 * linefeed, and escape, they can hurt themself. This is
 		 * so weird I don't bother to check for it.
 		 */
 		if (isalpha(src[0])  && isascii(src[0]) && src[1] || any(src[0],":"))
@@ -1651,7 +1652,7 @@ addmac(unsigned char *src, unsigned char *dest, unsigned char *dname,
 			zer = slot;	/* remember an empty slot */
 		}
 	}
-	
+
 	if (slot >= MAXNOMACS)
 		error(gettext("Too many macros"));
 
@@ -1805,7 +1806,7 @@ bool quick;
 	}
 	if (!tag_depth)
 		error(gettext("Tagstack empty."));
-	
+
 	/* change to old file */
 	if (strcmp(tagstack[tag_depth-1].tag_file, savedfile) ) {
 		if (!quick) {

--- a/usr/src/cmd/vi/port/ex_io.c
+++ b/usr/src/cmd/vi/port/ex_io.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -392,7 +393,7 @@ rop(int c)
 		if (c == 'e' && errno == ENOENT) {
 			edited++;
 			/*
-			 * If the user just did "ex foo" he is probably
+			 * If the user just did "ex foo" they're probably
 			 * creating a new file.  Don't be an error, since
 			 * this is ugly, and it messes up the + option.
 			 */
@@ -450,7 +451,7 @@ rop(int c)
 	/* If it is a read command, then we must set dot to addr1
 	 * (value of N in :Nr ).  In the default case, addr1 will
 	 * already be set to dot.
-	 * 
+	 *
 	 * Next, it is necessary to mark the beginning (undap1) and
 	 * ending (undap2) addresses affected (for undo).  Note that
 	 * rop2() and rop3() will adjust the value of undap2.
@@ -535,7 +536,7 @@ samei(struct stat64 *sp, unsigned char *cp)
 {
 	struct stat64 stb;
 
-	if (stat64((char *)cp, &stb) < 0) 
+	if (stat64((char *)cp, &stb) < 0)
 		return (0);
 	return (IDENTICAL((*sp), stb));
 }
@@ -589,7 +590,7 @@ gettext("No current filename"));
 	case 0:
 		if (!exclam && (!value(vi_WRITEANY) || value(vi_READONLY)))
 		switch (edfile()) {
-		
+
 		case NOTEDF:
 			if (nonexist)
 				break;

--- a/usr/src/cmd/vi/port/ex_unix.c
+++ b/usr/src/cmd/vi/port/ex_unix.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -138,8 +139,8 @@ gettext("No previous command to substitute for !"));
 				 *
 				 * The user has just entered ":!!" which
 				 * means that though there is only technically
-				 * one '!' we know he really meant ":!!!". So
-				 * substitute the last command for him.
+				 * one '!' we know they really meant ":!!!". So
+				 * substitute the last command for them.
 				 */
 				fp = puxb;
 				if (*fp == 0) {
@@ -166,7 +167,7 @@ gettext("No previous command to substitute for !"));
 					error(gettext("Command too long"));
 				}
 				*up++ = c;
-			} 
+			}
 			break;
 
 		case '#':
@@ -390,7 +391,7 @@ vi_filter(int mode)
 			error(gettext("No more processes"));
 		}
 		if (pid2 == 0) {
-			extern unsigned char tfname[];		
+			extern unsigned char tfname[];
 			setrupt();
 			io = pvec[1];
 			close(pvec[0]);

--- a/usr/src/cmd/vi/port/expreserve.c
+++ b/usr/src/cmd/vi/port/expreserve.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -392,7 +393,7 @@ mknext(unsigned char *dir, unsigned char *cp)
 }
 
 /*
- * Notify user uid that his file fname has been saved.
+ * Notify user uid that their file fname has been saved.
  */
 void
 notify(int uid, unsigned char *fname, int flag, int cryflag)
@@ -437,7 +438,7 @@ was killed or was unable to save your changes.\n", fname, (cryflag) ? "[ENCRYPTE
 	fprintf(mf,
 "This buffer can be retrieved using the \"recover\" command of the editor.\n");
 	fprintf(mf,
-"An easy way to do this is to give the command \"vi -r %s\".\n", 
+"An easy way to do this is to give the command \"vi -r %s\".\n",
 		(fname[0] == 0) ? "LOST" : (char *) fname);
 	fprintf(mf, "This works for \"edit\" and \"ex\" also.\n");
 	(void) pclose(mf);

--- a/usr/src/cmd/vscan/vscand/vs_eng.c
+++ b/usr/src/cmd/vscan/vscand/vs_eng.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -70,7 +71,7 @@
  * seconds will be closed by the housekeeper thread.
  *
  * When a scan engine is reconfigured to have less connections
- * (or is disabled) any of he superflous connections which are in
+ * (or is disabled) any of the superflous connections which are in
  * AVAILABLE state are closed (DISCONNECTED). Others are set to
  * CLOSE_PENDING to be closed (DISCONNECTED) when the engine is
  * released (when the current request completes).

--- a/usr/src/cmd/write/write.c
+++ b/usr/src/cmd/write/write.c
@@ -26,6 +26,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -232,7 +233,7 @@ main(int argc, char **argv)
 
 /*	If this is the second terminal, print out the first.  In all	*/
 /*	cases of multiple terminals, list out all the other terminals	*/
-/*	so the user can restart knowing what her/his choices are.	*/
+/*	so the user can restart knowing what their choices are.		*/
 
 			else if (terminal == NULL) {
 			    if (count == 1 && bad == 0) {
@@ -515,7 +516,7 @@ eof()
 
 /*
  * permit: check mode of terminal - if not writable by all disallow writing to
- * (even the user him/herself cannot therefore write to their own tty)
+ * (even the user cannot therefore write to their own tty)
  */
 
 static int
@@ -546,7 +547,7 @@ char *term;
 
 /*
  * permit1: check mode of terminal - if not writable by all disallow writing
- * to (even the user him/herself cannot therefore write to their own tty)
+ * to (even the user themself cannot therefore write to their own tty)
  */
 
 /* this is used with fstat (which is faster than stat) where possible */

--- a/usr/src/cmd/ypcmd/mknetid/mknetid.c
+++ b/usr/src/cmd/ypcmd/mknetid/mknetid.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -59,7 +60,7 @@ extern char *strcpy();
 
 /*
  * The group list
- * Store username and groups to which he/she belongs
+ * Store username and groups to which they belong
  */
 struct group_list {
 	char *user;

--- a/usr/src/cmd/ypcmd/ypcat.c
+++ b/usr/src/cmd/ypcmd/ypcat.c
@@ -21,6 +21,7 @@
  *
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -37,7 +38,7 @@
 /*
  * This is a user command which dumps each entry in a yp data base.  It gets
  * the stuff using the normal ypclnt package; the user doesn't get to choose
- * which server gives him the input.  Usage is:
+ * which server gives them the input.  Usage is:
  *	ypcat [-k] [-d domain] [-t] map
  *	ypcat -x
  * where the -k switch will dump keys followed by a single blank space

--- a/usr/src/cmd/ypcmd/yppush.c
+++ b/usr/src/cmd/ypcmd/yppush.c
@@ -28,7 +28,9 @@
  * 4.3 BSD under license from the Regents of the University of
  * California.
  */
-
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
 #define	_SVID_GETTOD
@@ -993,7 +995,7 @@ get_xfr_response(SVCXPRT *transp)
  * This sends a message to a single ypserv process.  The return value is
  * a state value.  If the RPC call fails because of a version
  * mismatch, we'll assume that we're talking to a version 1 ypserv process,
- * and will send him an old "YPPROC_GET" request, as was defined in the
+ * and will send it an old "YPPROC_GET" request, as was defined in the
  * earlier version of yp_prot.h
  */
 static unsigned short

--- a/usr/src/cmd/ypcmd/ypserv_proc.c
+++ b/usr/src/cmd/ypcmd/ypserv_proc.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -171,7 +172,7 @@ ypdomain(SVCXPRT *transp, bool always_respond)
 		 * This case is the one in which the domain is not
 		 * supported, and in which we are not to respond in the
 		 * unsupported case.  We are going to make an error happen
-		 * to allow the portmapper to end his wait without the
+		 * to allow the portmapper to end its wait without the
 		 * normal timeout period.  The assumption here is that
 		 * the only process in the world which is using the function
 		 * in its no-answer-if-nack form is the portmapper, which is

--- a/usr/src/cmd/ypcmd/ypxfr.c
+++ b/usr/src/cmd/ypcmd/ypxfr.c
@@ -21,6 +21,7 @@
  *
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -37,7 +38,7 @@
  * server, and gets it to the local site by using the normal NIS client
  * enumeration functions.  The map is copied to a temp name, then the real
  * map is removed and the temp map is moved to the real name.  ypxfr then
- * sends a "YPPROC_CLEAR" message to the local server to insure that he will
+ * sends a "YPPROC_CLEAR" message to the local server to insure that it will
  * not hold a removed map open, so serving an obsolete version.
  *
  * ypxfr [ -h <host> ] [ -d <domainname> ]
@@ -1828,7 +1829,7 @@ xfr_exit(status)
 
 /*
  * This sets up a UDP connection to the yppush process which contacted our
- * parent ypserv, and sends him a status on the requested transfer.
+ * parent ypserv, and sends it a status on the requested transfer.
  */
 void
 send_callback(status)

--- a/usr/src/cmd/zoneadmd/vplat.c
+++ b/usr/src/cmd/zoneadmd/vplat.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent Inc. All rights reserved.
- * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -465,7 +465,7 @@ make_one_dir(zlog_t *zlogp, const char *prefix, const char *subdir, mode_t mode,
 		/*
 		 * We don't check the file mode since presumably the zone
 		 * administrator may have had good reason to change the mode,
-		 * and we don't need to second guess him.
+		 * and we don't need to second guess them.
 		 */
 		if (!S_ISDIR(st.st_mode)) {
 			if (S_ISREG(st.st_mode)) {
@@ -1234,11 +1234,12 @@ mount_one(zlog_t *zlogp, struct zone_fstab *fsptr, const char *rootpath,
 	/*
 	 * In general the strategy here is to do just as much verification as
 	 * necessary to avoid crashing or otherwise doing something bad; if the
-	 * administrator initiated the operation via zoneadm(1m), he'll get
-	 * auto-verification which will let him know what's wrong.  If he
-	 * modifies the zone configuration of a running zone and doesn't attempt
-	 * to verify that it's OK we won't crash but won't bother trying to be
-	 * too helpful either.  zoneadm verify is only a couple keystrokes away.
+	 * administrator initiated the operation via zoneadm(1m), they'll get
+	 * auto-verification which will let them know what's wrong.  If they
+	 * modify the zone configuration of a running zone, and don't attempt
+	 * to verify that it's OK, then we won't crash but won't bother trying
+	 * to be too helpful either. zoneadm verify is only a couple keystrokes
+	 * away.
 	 */
 	if (!zonecfg_valid_fs_type(fsptr->zone_fs_type)) {
 		zerror(zlogp, B_FALSE, "cannot mount %s on %s: "

--- a/usr/src/cmd/zoneadmd/zoneadmd.c
+++ b/usr/src/cmd/zoneadmd/zoneadmd.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1373,7 +1374,7 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 				abort();
 			/*
 			 * We could have two clients racing to halt this
-			 * zone; the second client loses, but his request
+			 * zone; the second client loses, but its request
 			 * doesn't fail, since the zone is now in the desired
 			 * state.
 			 */
@@ -1469,7 +1470,7 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 		case Z_READY:
 			/*
 			 * We could have two clients racing to ready this
-			 * zone; the second client loses, but his request
+			 * zone; the second client loses, but its request
 			 * doesn't fail, since the zone is now in the desired
 			 * state.
 			 */
@@ -1551,7 +1552,7 @@ server(void *cookie, char *args, size_t alen, door_desc_t *dp,
 		case Z_BOOT:
 			/*
 			 * We could have two clients racing to boot this
-			 * zone; the second client loses, but his request
+			 * zone; the second client loses, but its request
 			 * doesn't fail, since the zone is now in the desired
 			 * state.
 			 */

--- a/usr/src/common/fs/ufsops.c
+++ b/usr/src/common/fs/ufsops.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -661,7 +662,7 @@ bufs_lseek(int fd, off_t addr, int whence)
 {
 	fileid_t *filep;
 
-	/* Make sure user knows what file he is talking to */
+	/* Make sure user knows what file they are talking to */
 	if (!(filep = find_fp(fd)))
 		return (-1);
 
@@ -738,7 +739,7 @@ bufs_close(int fd)
 {
 	fileid_t *filep;
 
-	/* Make sure user knows what file he is talking to */
+	/* Make sure user knows what file they are talking to */
 	if (!(filep = find_fp(fd)))
 		return (-1);
 

--- a/usr/src/common/nvpair/nvpair.c
+++ b/usr/src/common/nvpair/nvpair.c
@@ -2395,7 +2395,7 @@ nvlist_xpack(nvlist_t *nvl, char **bufp, size_t *buflen, int encoding,
 	 * 1. The nvlist has fixed allocator properties.
 	 *    All other nvlist routines (like nvlist_add_*, ...) use
 	 *    these properties.
-	 * 2. When using nvlist_pack() the user can specify his own
+	 * 2. When using nvlist_pack() the user can specify their own
 	 *    allocator properties (e.g. by using KM_NOSLEEP).
 	 *
 	 * We use the user specified properties (2). A clearer solution

--- a/usr/src/common/svc/repcache_protocol.h
+++ b/usr/src/common/svc/repcache_protocol.h
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	_REPCACHE_PROTOCOL_H
@@ -113,8 +114,8 @@
  *
  * An idiom the protocol uses to lower the number of round trips is
  * client-controlled identifiers.  The basic idea is this:  whenever a
- * client wants to set up and use a piece of server state, he picks an
- * integer *which he knows is not in use* to identify it.  The server then
+ * client wants to set up and use a piece of server state, it picks an
+ * integer *which it knows is not in use* to identify it.  The server then
  * maintains per-client, per-resource id->resource maps.  This has a number
  * of advantages:
  *

--- a/usr/src/head/arpa/telnet.h
+++ b/usr/src/head/arpa/telnet.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -245,10 +246,10 @@ extern char *slc_names[];
  * AUTHENTICATION suboptions
  */
 #define	AUTH_REJECT	0	/* Rejected */
-#define	AUTH_UNKNOWN	1	/* We don't know who he is, but he's okay */
-#define	AUTH_OTHER	2	/* We know him, but not his name */
-#define	AUTH_USER	3	/* We know his name */
-#define	AUTH_VALID	4	/* We know him, and he needs no password */
+#define	AUTH_UNKNOWN	1	/* We don't know who it is, but it's okay */
+#define	AUTH_OTHER	2	/* We know it, but not it's name */
+#define	AUTH_USER	3	/* We know it's name */
+#define	AUTH_VALID	4	/* We know it, and it needs no password */
 
 /*
  * Who is authenticating who ...

--- a/usr/src/head/netdir.h
+++ b/usr/src/head/netdir.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /*	Copyright (c) 1992 Sun Microsystems, Inc.	*/
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -141,8 +142,8 @@ char *_netdir_mergeaddr(struct netconfig *, char *uaddr, char *ruaddr);
 /*
  * The following netdir_options commands can be given to the fd. These is
  * a way of providing for any transport specific action which the caller
- * may want to initiate on his transport. It is up to the trasport provider
- * to support the netdir_options he wants to support.
+ * may want to initiate on its transport. It is up to the trasport provider
+ * to support the netdir_options it wants to support.
  */
 
 #define	ND_SET_BROADCAST	1	/* Do t_optmgmt to support broadcast */

--- a/usr/src/lib/cfgadm_plugins/shp/common/shp.c
+++ b/usr/src/lib/cfgadm_plugins/shp/common/shp.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -381,7 +382,7 @@ typedef struct error_sum_cb_arg {
 
 /*
  * Callback function for hp_traverse(), to add the error
- * message to he table.
+ * message to the table.
  */
 static int
 error_sumup_cb(hp_node_t node, void *arg)

--- a/usr/src/lib/gss_mechs/mech_dh/backend/mech/context.c
+++ b/usr/src/lib/gss_mechs/mech_dh/backend/mech/context.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -301,7 +302,7 @@ _NOTE(ARGUNUSED(ctx))
 	if ((*minor = __get_sig_size(qop_req, &sigsize)) != DH_SUCCESS)
 		return (GSS_S_BAD_QOP | stat);
 
-	/* Just return if we can't give the caller what he ask for. */
+	/* Just return if we can't give the caller what it asked for. */
 	if (stat)
 		return (stat);
 

--- a/usr/src/lib/gss_mechs/mech_dummy/mech/dmech.c
+++ b/usr/src/lib/gss_mechs/mech_dummy/mech/dmech.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * A module that implements a dummy security mechanism.
  * It's mainly used to test GSS-API application. Multiple tokens
@@ -333,7 +334,7 @@ dummy_gss_init_sec_context(ct, minor_status, claimant_cred_handle,
 				 * information to perform per-message
 				 * processing. So if initiator previously
 				 * returned GSS_S_COMPLETE, and acceptor
-				 * says he needs more, then we have
+				 * says it needs more, then we have
 				 * a problem.
 				 */
 				ctx->last_stat = GSS_S_FAILURE;

--- a/usr/src/lib/gss_mechs/mech_krb5/krb5/krb/sendauth.c
+++ b/usr/src/lib/gss_mechs/mech_krb5/krb5/krb/sendauth.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -14,7 +15,7 @@
  *   require a specific license from the United States Government.
  *   It is the responsibility of any person or organization contemplating
  *   export to obtain such a license before exporting.
- * 
+ *
  * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
  * distribute this software and its documentation for any purpose and
  * without fee is hereby granted, provided that the above copyright
@@ -28,7 +29,7 @@
  * M.I.T. makes no representations about the suitability of
  * this software for any purpose.  It is provided "as is" without express
  * or implied warranty.
- * 
+ *
  *
  * convenience sendauth/recvauth functions
  */
@@ -62,7 +63,7 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 	 * First, send over the length of the sendauth version string;
 	 * then, we send over the sendauth version.  Next, we send
 	 * over the length of the application version strings followed
-	 * by the string itself.  
+	 * by the string itself.
 	 */
 	outbuf.length = strlen(sendauth_version) + 1;
 	outbuf.data = (char *) sendauth_version;
@@ -110,7 +111,7 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 						  &creds.server)))
 			goto error_return;
 		if (client)
-			retval = krb5_copy_principal(context, client, 
+			retval = krb5_copy_principal(context, client,
 						     &creds.client);
 		else
 			retval = krb5_cc_get_principal(context, use_ccache,
@@ -147,14 +148,14 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 	    d.length = sizeof (rnd_data);
 	    d.data = rnd_data;
 	    len2 = sizeof (rnd_data);
-	    if (getpeername (*(int*)fd, (GETPEERNAME_ARG2_TYPE *) rnd_data, 
+	    if (getpeername (*(int*)fd, (GETPEERNAME_ARG2_TYPE *) rnd_data,
 			     &len2) == 0) {
 		d.length = len2;
 		/* Solaris Kerberos */
 		(void) krb5_c_random_seed (context, &d);
 	    }
 	    len2 = sizeof (rnd_data);
-	    if (getsockname (*(int*)fd, (GETSOCKNAME_ARG2_TYPE *) rnd_data, 
+	    if (getsockname (*(int*)fd, (GETSOCKNAME_ARG2_TYPE *) rnd_data,
 			     &len2) == 0) {
 		d.length = len2;
 		/* Solaris Kerberos */
@@ -199,7 +200,7 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 		krb5_xfree(inbuf.data);
 		goto error_return;
 	}
-	
+
 	/*
 	 * If we asked for mutual authentication, we should now get a
 	 * length field, followed by a AP_REP message
@@ -222,9 +223,9 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 	    krb5_xfree(inbuf.data);
 	    /*
 	     * If the user wants to look at the AP_REP message,
-	     * copy it for him
+	     * copy it for them.
 	     */
-	    if (rep_result) 
+	    if (rep_result)
 		*rep_result = repl;
 	    else
 		krb5_free_ap_rep_enc_part(context, repl);
@@ -238,7 +239,7 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context, krb5_pointe
 error_return:
     krb5_free_cred_contents(context, &creds);
     if (credspout != NULL)
-	krb5_free_creds(context, credspout); 
+	krb5_free_creds(context, credspout);
     /* Solaris Kerberos */
     if (!ccache && use_ccache)
 	(void) krb5_cc_close(context, use_ccache);

--- a/usr/src/lib/gss_mechs/mech_krb5/krb5/os/def_realm.c
+++ b/usr/src/lib/gss_mechs/mech_krb5/krb5/os/def_realm.c
@@ -8,7 +8,7 @@
  *   require a specific license from the United States Government.
  *   It is the responsibility of any person or organization contemplating
  *   export to obtain such a license before exporting.
- * 
+ *
  * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
  * distribute this software and its documentation for any purpose and
  * without fee is hereby granted, provided that the above copyright
@@ -22,7 +22,7 @@
  * M.I.T. makes no representations about the suitability of
  * this software for any purpose.  It is provided "as is" without express
  * or implied warranty.
- * 
+ *
  *
  * krb5_get_default_realm(), krb5_set_default_realm(),
  * krb5_free_default_realm() functions.
@@ -33,19 +33,20 @@
  * Use is subject to license terms.
  *
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "k5-int.h"
 #include "os-proto.h"
 #include <stdio.h>
 
-/* 
+/*
  * Solaris Kerberos:
  * For krb5int_foreach_localaddr()
  */
 #include "foreachaddr.h"
 
-#ifdef KRB5_DNS_LOOKUP	     
+#ifdef KRB5_DNS_LOOKUP
 #ifdef WSHELPER
 #include <wshelper.h>
 #else /* WSHELPER */
@@ -81,7 +82,7 @@ extern struct hostent *res_gethostbyaddr(const char *addr, int len, int type);
  * used as a callback for krb5int_foreach_localaddr().
  */
 static int krb5int_address_get_realm(void *data, struct sockaddr *addr) {
-	
+
 	krb5_context context = data;
 	struct hostent *he = NULL;
 
@@ -104,7 +105,7 @@ static int krb5int_address_get_realm(void *data, struct sockaddr *addr) {
 
 		/* If a realm was found return 1 to immediately halt
 		 * krb5int_foreach_localaddr()
-		 */ 
+		 */
 		if (context->default_realm != 0) {
 			return (1);
 		}
@@ -117,7 +118,7 @@ static int krb5int_address_get_realm(void *data, struct sockaddr *addr) {
  * Retrieves the default realm to be used if no user-specified realm is
  *  available.  [e.g. to interpret a user-typed principal name with the
  *  realm omitted for convenience]
- * 
+ *
  *  returns system errors, NOT_ENOUGH_SPACE, KV5M_CONTEXT
 */
 
@@ -137,7 +138,7 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
 
     (void) memset(localhost, 0, sizeof(localhost));
 
-    if (!context || (context->magic != KV5M_CONTEXT)) 
+    if (!context || (context->magic != KV5M_CONTEXT))
 	    return KV5M_CONTEXT;
 
     /*
@@ -187,7 +188,7 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
 		if ( localhost[0] ) {
 		    p = localhost;
 		    do {
-			retval = krb5_try_realm_txt_rr("_kerberos", p, 
+			retval = krb5_try_realm_txt_rr("_kerberos", p,
 						       &context->default_realm);
 			p = strchr(p,'.');
 			if (p)
@@ -195,10 +196,10 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
 		    } while (retval && p && p[0]);
 
 		    if (retval)
-			retval = krb5_try_realm_txt_rr("_kerberos", "", 
+			retval = krb5_try_realm_txt_rr("_kerberos", "",
 						       &context->default_realm);
 		} else {
-		    retval = krb5_try_realm_txt_rr("_kerberos", "", 
+		    retval = krb5_try_realm_txt_rr("_kerberos", "",
 						   &context->default_realm);
 		}
 		if (retval) {
@@ -231,7 +232,7 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
 		if (res_ninit(&res) == 0) {
 			for (i = 0; res.dnsrch[i]; i++) {
 				krb5int_domain_get_realm(context,
-				    res.dnsrch[i], &context->default_realm); 
+				    res.dnsrch[i], &context->default_realm);
 
 				if (context->default_realm != 0)
 					break;
@@ -253,7 +254,7 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
     }
 
     realm = context->default_realm;
-    
+
     /*LINTED*/
     if (!(*lrealm = cp = malloc((unsigned int) strlen(realm) + 1)))
         return ENOMEM;
@@ -264,7 +265,7 @@ krb5_get_default_realm(krb5_context context, char **lrealm)
 krb5_error_code KRB5_CALLCONV
 krb5_set_default_realm(krb5_context context, const char *lrealm)
 {
-    if (!context || (context->magic != KV5M_CONTEXT)) 
+    if (!context || (context->magic != KV5M_CONTEXT))
 	    return KV5M_CONTEXT;
 
     if (context->default_realm) {
@@ -272,7 +273,7 @@ krb5_set_default_realm(krb5_context context, const char *lrealm)
 	    context->default_realm = 0;
     }
 
-    /* Allow the user to clear the default realm setting by passing in 
+    /* Allow the user to clear the default realm setting by passing in
        NULL */
     if (!lrealm) return 0;
 

--- a/usr/src/lib/gss_mechs/mech_krb5/krb5/os/kuserok.c
+++ b/usr/src/lib/gss_mechs/mech_krb5/krb5/os/kuserok.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -14,7 +15,7 @@
  *   require a specific license from the United States Government.
  *   It is the responsibility of any person or organization contemplating
  *   export to obtain such a license before exporting.
- * 
+ *
  * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
  * distribute this software and its documentation for any purpose and
  * without fee is hereby granted, provided that the above copyright
@@ -28,7 +29,7 @@
  * M.I.T. makes no representations about the suitability of
  * this software for any purpose.  It is provided "as is" without express
  * or implied warranty.
- * 
+ *
  *
  * krb5_kuserok()
  */
@@ -288,8 +289,8 @@ krb5_kuserok(krb5_context context, krb5_principal principal, const char *luser)
 
     if (access(pbuf, F_OK)) {	 /* not accessible */
 	/*
-	 * if he's trying to log in as himself, and there is no .k5login file,
-	 * let him.  First, have krb5 check it's rules.  If no success,
+	 * if they're trying to log in as themself, and there is no .k5login file,
+	 * let them.  First, have krb5 check it's rules.  If no success,
 	 * search the gsscred table (the sequence here should be consistent
 	 * with the uid mappings done for gssd).
 	 */
@@ -385,10 +386,10 @@ krb5_gss_userok(OM_uint32 *minor,
 
 	*user_ok = 0;
 
-	kret = krb5_gss_init_context(&ctxt); 
-	if (kret) { 
-		*minor = kret; 
-		return (GSS_S_FAILURE); 
+	kret = krb5_gss_init_context(&ctxt);
+	if (kret) {
+		*minor = kret;
+		return (GSS_S_FAILURE);
 	}
 
 	if (! kg_validate_name(pname)) {

--- a/usr/src/lib/krb5/dyn/dyn_delete.c
+++ b/usr/src/lib/krb5/dyn/dyn_delete.c
@@ -10,6 +10,7 @@
  *
  * Written by Barr3y Jaspan, Student Information Processing Board (SIPB)
  * and MIT-Project Athena, 1989.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -21,7 +22,7 @@
 /*
  * Checkers!  Get away from that "hard disk erase" button!
  *    (Stupid dog.  He almost did it to me again ...)
- */                                 
+ */
 int DynDelete(obj, idx)
    DynObjectP obj;
    int idx;
@@ -31,7 +32,7 @@ int DynDelete(obj, idx)
 	       fprintf(stderr, "dyn: delete: bad index %d\n", idx);
 	  return DYN_BADINDEX;
      }
-     
+
      if (idx >= obj->num_el) {
 	  if (obj->debug)
 	       fprintf(stderr, "dyn: delete: Highest index is %d.\n",
@@ -49,14 +50,14 @@ int DynDelete(obj, idx)
 	       if (obj->debug)
 		    fprintf(stderr, "dyn: delete: last element, punting.\n");
 	  }
-     }	  
+     }
      else {
 	  if (obj->debug)
 	       fprintf(stderr,
 		       "dyn: delete: copying %d bytes from %d + %d to + %d.\n",
 		       obj->el_size*(obj->num_el - idx), obj->array,
 		       (idx+1)*obj->el_size, idx*obj->el_size);
-	  
+
 #ifdef HAVE_MEMMOVE
 	  memmove(obj->array + idx*obj->el_size,
 		  obj->array + (idx+1)*obj->el_size,
@@ -76,9 +77,9 @@ int DynDelete(obj, idx)
 		     obj->el_size);
 	  }
      }
-     
+
      --obj->num_el;
-     
+
      if (obj->debug)
 	  fprintf(stderr, "dyn: delete: done.\n");
 

--- a/usr/src/lib/libbc/libc/gen/common/ndbm.c
+++ b/usr/src/lib/libbc/libc/gen/common/ndbm.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2002 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -307,7 +308,7 @@ split:
 		return (-1);
 	}
 	dbm_clrdirty(db); /*clear dirty*/
-	(void) lseek(db->dbm_pagf, 
+	(void) lseek(db->dbm_pagf,
 		(long)((db->dbm_blkno+db->dbm_hmask+1)*PBLKSIZ), L_SET);
 	if (write(db->dbm_pagf, ovfbuf, PBLKSIZ) != PBLKSIZ) {
 		db->dbm_flags |= _DBM_IOERR;
@@ -494,7 +495,7 @@ dbm_do_nextkey(DBM *db, datum inkey)
 		else key=nullkey;
 
 	/* the keyptr pagbuf have failed us, the user must
-	be an extra clever moron who depends on 
+	be an extra clever moron who depends on
 	these variables and their former meaning.
 	If we set the variables this would have got
 	us the key for sure! So give him the old algorithm.*/
@@ -517,7 +518,7 @@ dbm_do_nextkey(DBM *db, datum inkey)
 			item.dsize = 0;
 			break; /*from below*/
 		}
-		else { 
+		else {
 			if (i > 0) item.dsize = sp[i] - sp[i+1];
 			else item.dsize = PBLKSIZ - sp[i+1];
 			item.dptr = db->dbm_pagbuf+sp[i+1];
@@ -541,7 +542,7 @@ dbm_do_nextkey(DBM *db, datum inkey)
 			p2 = item.dptr;
 			do
 				if(*p1++ != *p2++)
-					if((*--p1 - *--p2) > 0) goto keep_going; 
+					if((*--p1 - *--p2) > 0) goto keep_going;
 					else continue;
 			while(--n);
 			continue;
@@ -554,7 +555,7 @@ keep_going:
 			continue;*/
 		if (f) {
 			bitem = item;
-			j=i;	
+			j=i;
 			f = 0;
 		}
 		else {
@@ -566,7 +567,7 @@ keep_going:
 			{
 			if((n - item.dsize) <0) {
 					bitem = item;
-					j=i;	
+					j=i;
 				}
 			}
 			else  if (n != 0) {
@@ -576,7 +577,7 @@ keep_going:
 				if(*p1++ != *p2++) {
 					if((*--p1 - *--p2) <0) {
 						bitem = item;
-						j=i;	
+						j=i;
 					}
 					break;
 				}
@@ -591,9 +592,9 @@ keep_going:
 		return (bitem);
 	}
 
-	/*really need hash at this point*/
-	/*if he gave us a key we have already calculated the hash*/
-	/*if not get it*/
+	/* really need hash at this point */
+	/* if it gave us a key we have already calculated the hash */
+	/* if not get the hash */
 	if (inkey.dptr == NULL) hash=dcalchash(key);
 	hash = dbm_hashinc(db,hash);
 
@@ -662,12 +663,12 @@ dbm_access(DBM *db, long hash)
 	}
 }
 
-static int 
+static int
 getbit(DBM *db)
 {
 	long bn;
 	int b, i, n;
-	
+
 
 	if (db->dbm_bitno > db->dbm_maxbno)
 		return (0);

--- a/usr/src/lib/libbsm/common/audit_crontab.c
+++ b/usr/src/lib/libbsm/common/audit_crontab.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
 
@@ -269,7 +270,7 @@ audit_crontab_not_allowed(uid_t ruid, char *user) {
 		if (getpwnam_r(user, &pwd, buffer, PWD_BUFFER_SIZE) == NULL) {
 			rc = 1;			/* deny access if invalid */
 		} else if (ruid == pwd.pw_uid)
-			rc = 0;			/* editing his own crontab */
+			rc = 0;			/* editing their own crontab */
 		else
 			rc = audit_crontab_process_not_audited();
 	}

--- a/usr/src/lib/libc/port/gen/daemon.c
+++ b/usr/src/lib/libc/port/gen/daemon.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "lint.h"
@@ -79,7 +80,7 @@ daemon(int nochdir, int noclose)
 
 		/*
 		 * Also, if any of the descriptor redirects fails we should
-		 * return with error to signal to the caller that his request
+		 * return with error to signal to the caller that its request
 		 * cannot be fulfilled properly. It is up to the caller to
 		 * do the cleanup.
 		 */

--- a/usr/src/lib/libc/port/gen/getgrnam_r.c
+++ b/usr/src/lib/libc/port/gen/getgrnam_r.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "lint.h"
@@ -204,7 +205,7 @@ fgetgrent_r(FILE *f, struct group *result, char *buffer, int buflen)
 	extern void	_nss_XbyY_fgets(FILE *, nss_XbyY_args_t *);
 	nss_XbyY_args_t	arg;
 
-	/* ... but in fgetXXent_r, the caller deserves any +/- entry he gets */
+	/* ... but in fgetXXent_r, the caller deserves any +/- entry it gets */
 
 	/* No key to fill in */
 	NSS_XbyY_INIT(&arg, result, buffer, buflen, str2group);

--- a/usr/src/lib/libc/port/gen/getpwnam_r.c
+++ b/usr/src/lib/libc/port/gen/getpwnam_r.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "lint.h"
@@ -201,7 +202,7 @@ fgetpwent_r(FILE *f, struct passwd *result, char *buffer, int buflen)
 	extern void	_nss_XbyY_fgets(FILE *, nss_XbyY_args_t *);
 	nss_XbyY_args_t	arg;
 
-	/* ... but in fgetXXent_r, the caller deserves any +/- entry he gets */
+	/* ... but in fgetXXent_r, the caller deserves any +/- entry it gets */
 
 	/* No key to fill in */
 	NSS_XbyY_INIT(&arg, result, buffer, buflen, str2passwd);

--- a/usr/src/lib/libc/port/gen/getspent_r.c
+++ b/usr/src/lib/libc/port/gen/getspent_r.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -100,7 +101,7 @@ fgetspent_r(FILE *f, struct spwd *result, char *buffer, int buflen)
 	extern void	_nss_XbyY_fgets(FILE *, nss_XbyY_args_t *);
 	nss_XbyY_args_t	arg;
 
-	/* ... but in fgetXXent_r, the caller deserves any +/- entry he gets */
+	/* ... but in fgetXXent_r, the caller deserves any +/- entry it gets */
 
 	/* No key to fill in */
 	NSS_XbyY_INIT(&arg, result, buffer, buflen, str2spwd);

--- a/usr/src/lib/libc/port/gen/ndbm.c
+++ b/usr/src/lib/libc/port/gen/ndbm.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -599,7 +600,7 @@ dbm_do_nextkey(DBM *db, datum inkey)
 		 * be an extra clever moron who depends on
 		 * these variables and their former meaning.
 		 * If we set the variables this would have got
-		 * us the key for sure! So give him the old algorithm.
+		 * us the key for sure! So give it the old algorithm.
 		 */
 		if (key.dptr == NULL)
 			return (dbm_slow_nextkey(db));
@@ -699,8 +700,8 @@ keep_going:
 	}
 
 	/* really need hash at this point */
-	/* if he gave us a key we have already calculated the hash */
-	/* if not get it */
+	/* if it gave us a key we have already calculated the hash */
+	/* if not get the hash */
 	if (inkey.dptr == NULL)
 		hash = dcalchash(key);
 	hash = dbm_hashinc(db, hash);

--- a/usr/src/lib/libc/port/locale/engine.c
+++ b/usr/src/lib/libc/port/locale/engine.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  * Copyright (c) 1992, 1993, 1994 Henry Spencer.
  * Copyright (c) 1992, 1993, 1994
  *	The Regents of the University of California.  All rights reserved.
@@ -281,7 +282,7 @@ matcher(struct re_guts *g,
 		if (nmatch == 1 && !g->backrefs)
 			break;		/* no further info needed */
 
-		/* oh my, he wants the subexpressions... */
+		/* oh my, it wants the subexpressions... */
 		if (m->pmatch == NULL)
 			m->pmatch = (regmatch_t *)malloc((m->g->nsub + 1) *
 			    sizeof (regmatch_t));

--- a/usr/src/lib/libc/port/threads/rwlock.c
+++ b/usr/src/lib/libc/port/threads/rwlock.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "lint.h"
@@ -620,7 +621,7 @@ rwlock_lock(rwlock_t *rwlp, timespec_t *tsp, int rd_wr)
 			/*
 			 * Do a priority check on the queued waiter (the
 			 * highest priority thread on the queue) to see
-			 * if we should defer to him or just grab the lock.
+			 * if we should defer to it or just grab the lock.
 			 */
 			int our_pri = real_priority(self);
 			int his_pri = real_priority(ulwp);

--- a/usr/src/lib/libc/port/threads/thr.c
+++ b/usr/src/lib/libc/port/threads/thr.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /*
  * Copyright 2016 Joyent, Inc.
@@ -1786,17 +1787,17 @@ force_continue(ulwp_t *ulwp)
 		if (error != 0 && error != EINTR)
 			break;
 		error = 0;
-		if (ulwp->ul_stopping) {	/* he is stopping himself */
-			ts.tv_sec = 0;		/* give him a chance to run */
+		if (ulwp->ul_stopping) {	/* it is stopping itsself */
+			ts.tv_sec = 0;		/* give it a chance to run */
 			ts.tv_nsec = 100000;	/* 100 usecs or clock tick */
 			(void) __nanosleep(&ts, NULL);
 		}
-		if (!ulwp->ul_stopping)		/* he is running now */
+		if (!ulwp->ul_stopping)		/* it is running now */
 			break;			/* so we are done */
 		/*
-		 * He is marked as being in the process of stopping
-		 * himself.  Loop around and continue him again.
-		 * He may not have been stopped the first time.
+		 * It is marked as being in the process of stopping
+		 * itself.  Loop around and continue it again.
+		 * It may not have been stopped the first time.
 		 */
 	}
 }
@@ -2480,7 +2481,7 @@ getlwpstatus(thread_t tid, struct lwpstatus *sp)
 				(void) __close(fd);
 				return (0);
 			}
-			yield();	/* give him a chance to stop */
+			yield();	/* give it a chance to stop */
 		}
 		(void) __close(fd);
 	}

--- a/usr/src/lib/libcpc/common/libcpc.c
+++ b/usr/src/lib/libcpc/common/libcpc.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <libcpc.h>
@@ -44,7 +45,7 @@
 /*
  * The library uses the cpc_lock field of the cpc_t struct to protect access to
  * the linked lists inside the cpc_t, and only the linked lists. It is NOT used
- * to protect against a user shooting his/herself in the foot (such as, for
+ * to protect against users shooting themselves in the foot (such as, for
  * instance, destroying the same set at the same time from different threads.).
  *
  * SIGEMT needs to be blocked while holding the lock, to prevent deadlock among

--- a/usr/src/lib/libcurses/screen/tputs.c
+++ b/usr/src/lib/libcurses/screen/tputs.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 1997 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1988 AT&T	*/
@@ -62,7 +63,7 @@ _tpad(char *cp, int affcnt, int (*outc)(char x))
 	 * in their terminfo entries, as that would break compatibility.
 	 * We therefore, do it here.
 	 *
-	 * When compatibility is to be broken, his will go away
+	 * When compatibility is to be broken, it will go away
 	 * and users will be informed that they MUST use mandatory
 	 * padding for flash and bell.
 	 */

--- a/usr/src/lib/libdevinfo/devinfo_devlink.c
+++ b/usr/src/lib/libdevinfo/devinfo_devlink.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include "libdevinfo.h"
@@ -2000,7 +2001,7 @@ devlink_snapshot(const char *root_dir)
 
 	/*
 	 * We don't need to lock.  If a consumer wants the very latest db
-	 * then he must perform a di_devlink_init with the DI_MAKE_LINK
+	 * then it must perform a di_devlink_init with the DI_MAKE_LINK
 	 * flag to force a sync with devfsadm first.  Otherwise, the
 	 * current database file is opened and mmaped on demand: the rename
 	 * associated with a db update does not change the contents

--- a/usr/src/lib/libdhcpagent/common/dhcpagent_ipc.c
+++ b/usr/src/lib/libdhcpagent/common/dhcpagent_ipc.c
@@ -22,6 +22,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2016 by Delphix. All rights reserved.
+ */
 
 #include <string.h>
 #include <unistd.h>
@@ -266,7 +269,7 @@ dhcp_ipc_recv_reply(int fd, dhcp_ipc_reply_t **reply, int32_t timeout)
 {
 	/*
 	 * If the caller doesn't want to wait forever, and the amount of time
-	 * he wants to wait is expressible as an integer number of milliseconds
+	 * it wants to wait is expressible as an integer number of milliseconds
 	 * (as needed by the msg function), then we wait that amount of time
 	 * plus an extra two seconds for the daemon to do its work.  The extra
 	 * two seconds is arbitrary; it should allow plenty of time for the

--- a/usr/src/lib/libdhcputil/common/dhcp_inittab.c
+++ b/usr/src/lib/libdhcputil/common/dhcp_inittab.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -690,7 +691,7 @@ inittab_encode_e(const dhcp_symbol_t *ie, const char *value, uint16_t *lengthp,
 						/*
 						 * User terminated \D or \DD
 						 * with non-digit.  An error,
-						 * but we can assume he means
+						 * but we can assume they mean
 						 * to treat as \00D or \0DD.
 						 */
 						*optstart++ = val;

--- a/usr/src/lib/libnisdb/db_table.cc
+++ b/usr/src/lib/libnisdb/db_table.cc
@@ -26,6 +26,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2015 RackTop Systems.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -192,7 +193,7 @@ db_free_list::push(entryp tabloc)
  * n1 is the number of entries that should be in the freelist.
  * n2 is the number of entries actually found in the freelist.
  * [loc1...locn] are the entries.   n2 <= n1 because we never count beyond n1.
- * It is up to the caller to free the returned vector when he is through.
+ * It is up to the caller to free the returned vector when it is through.
 */
 long *
 db_free_list::stats(int nslots)
@@ -738,7 +739,7 @@ db_table::delete_entry(entryp where)
 /*
  * Returns statistics of table.
  * [vector_size][table_size][last_used][count][freelist].
- * It is up to the caller to free the returned vector when his is through.
+ * It is up to the caller to free the returned vector when it is through.
  * The free list is included if 'fl' is TRUE.
 */
 long *

--- a/usr/src/lib/libnsl/nss/netdir_inet_sundry.c
+++ b/usr/src/lib/libnsl/nss/netdir_inet_sundry.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * lib/libnsl/nss/netdir_inet_sundry.c
  *
@@ -960,7 +961,7 @@ bindresvport(struct netconfig *nconf, int fd, struct netbuf *addr)
 		return (-1);
 	}
 
-	tbindstr.qlen = 0; /* Always 0; user should change if he wants to */
+	tbindstr.qlen = 0; /* Always 0; user should change if they want to */
 	tbindstr.addr.buf = (char *)u.buf;
 	tbindstr.addr.len = tbindstr.addr.maxlen = __rpc_get_a_size(tinfo.addr);
 

--- a/usr/src/lib/libnsl/rpc/clnt_dg.c
+++ b/usr/src/lib/libnsl/rpc/clnt_dg.c
@@ -26,6 +26,7 @@
  */
 /*
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /* Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -229,7 +230,7 @@ clnt_dg_create(const int fd, struct netbuf *svcaddr, const rpcprog_t program,
 	/*
 	 * By default, closeit is always FALSE. It is users responsibility
 	 * to do a t_close on it, else the user may use clnt_control
-	 * to let clnt_destroy do it for him/her.
+	 * to let clnt_destroy do it for them.
 	 */
 	cu->cu_closeit = FALSE;
 	cu->cu_fd = fd;
@@ -751,7 +752,7 @@ clnt_dg_control(CLIENT *cl, int request, char *info)
 /* LINTED pointer alignment */
 		*(struct timeval *)info = cu->cu_total;
 		break;
-	case CLGET_SERVER_ADDR:		/* Give him the fd address */
+	case CLGET_SERVER_ADDR:		/* Give it the fd address */
 		/* Now obsolete. Only for backword compatibility */
 		(void) memcpy(info, cu->cu_raddr.buf, (size_t)cu->cu_raddr.len);
 		break;

--- a/usr/src/lib/libnsl/rpc/clnt_vc.c
+++ b/usr/src/lib/libnsl/rpc/clnt_vc.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -310,7 +311,7 @@ _clnt_vc_create_timed(int fd, struct netbuf *svcaddr, rpcprog_t prog,
 	/*
 	 * By default, closeit is always FALSE. It is users responsibility
 	 * to do a t_close on it, else the user may use clnt_control
-	 * to let clnt_destroy do it for him/her.
+	 * to let clnt_destroy do it for them.
 	 */
 	ct->ct_closeit = FALSE;
 

--- a/usr/src/lib/libnsl/rpc/svc.c
+++ b/usr/src/lib/libnsl/rpc/svc.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /*
  * Copyright 1993 OpenVision Technologies, Inc., All Rights Reserved.
@@ -886,7 +887,7 @@ svc_reg(const SVCXPRT *xprt, const rpcprog_t prog, const rpcvers_t vers,
 		if (netid)
 			free(netid);
 		if (s->sc_dispatch == dispatch)
-			goto rpcb_it; /* he is registering another xptr */
+			goto rpcb_it; /* it is registering another xptr */
 		(void) rw_unlock(&svc_lock);
 		return (FALSE);
 	}
@@ -995,7 +996,7 @@ svc_register(SVCXPRT *xprt, rpcprog_t prog, rpcvers_t vers,
 		if (netid)
 			free(netid);
 		if (s->sc_dispatch == dispatch)
-			goto pmap_it;  /* he is registering another xptr */
+			goto pmap_it;  /* it is registering another xptr */
 		(void) rw_unlock(&svc_lock);
 		return (FALSE);
 	}

--- a/usr/src/lib/libnsl/rpc/svcauth_des.c
+++ b/usr/src/lib/libnsl/rpc/svcauth_des.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /* Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
 /* All Rights Reserved */
@@ -208,7 +209,7 @@ again:
 		if (!__getpublickey_cached(cred->adc_fullname.name,
 				pkey_data, &from_cache)) {
 			/*
-			 * if the user has no public key, treat him as the
+			 * if the user has no public key, treat them as the
 			 * unauthenticated identity - nobody. If this
 			 * works, it means the client didn't find the
 			 * user's keys and used nobody's secret key

--- a/usr/src/lib/libnsl/yp/yp_enum.c
+++ b/usr/src/lib/libnsl/yp/yp_enum.c
@@ -23,6 +23,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -176,7 +177,7 @@ dofirst(domain, map, pdomb, timeout, key, keylen, val, vallen)
 		retval = ypprot_err(resp.status);
 	}
 
-	/* Get some memory which the user can get rid of as he likes */
+	/* Get some memory which the user can get rid of as they like */
 
 	if (!retval) {
 
@@ -349,7 +350,7 @@ donext(domain, map, inkey, inkeylen, pdomb, timeout, outkey, outkeylen,
 		retval = ypprot_err(resp.status);
 	}
 
-	/* Get some memory which the user can get rid of as he likes */
+	/* Get some memory which the user can get rid of as they like */
 
 	if (!retval) {
 		if ((*outkey = malloc((size_t)

--- a/usr/src/lib/libnsl/yp/yp_master.c
+++ b/usr/src/lib/libnsl/yp/yp_master.c
@@ -23,6 +23,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -201,7 +202,7 @@ domaster(char *domain, char *map, struct dom_binding *pdomb,
 	if (resp.status != YP_TRUE)
 		retval = ypprot_err(resp.status);
 
-	/* Get some memory which the user can get rid of as he likes */
+	/* Get some memory which the user can get rid of as they like */
 
 	if (!retval && ((*master = malloc(strlen(resp.master) + 1)) == NULL))
 		retval = YPERR_RESRC;

--- a/usr/src/lib/libnsl/yp/yp_match.c
+++ b/usr/src/lib/libnsl/yp/yp_match.c
@@ -23,6 +23,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T */
@@ -543,7 +544,7 @@ domatch(char *domain, char *map, char *key, int  keylen,
 		retval = ypprot_err(resp.status);
 	}
 
-	/* Get some memory which the user can get rid of as he likes */
+	/* Get some memory which the user can get rid of as they likes */
 
 	if (!retval && ((*val = malloc((size_t)
 	    resp.valdat.dsize + 2)) == NULL)) {

--- a/usr/src/lib/libscf/common/lowlevel.c
+++ b/usr/src/lib/libscf/common/lowlevel.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013, Joyent, Inc. All rights reserved.
  * Copyright 2016 RackTop Systems.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -110,7 +111,7 @@ static void scf_value_reset_locked(scf_value_t *val, int and_destroy);
 
 /*
  * Hold and release subhandles.  We only allow one thread access to the
- * subhandles at a time, and he can use any subset, grabbing and releasing
+ * subhandles at a time, and it can use any subset, grabbing and releasing
  * them in any order.  The only restrictions are that you cannot hold an
  * already-held subhandle, and all subhandles must be released before
  * returning to the original caller.

--- a/usr/src/lib/libsqlite/src/test1.c
+++ b/usr/src/lib/libsqlite/src/test1.c
@@ -34,7 +34,7 @@
 ** Decode a pointer to an sqlite object.
 */
 static int getDbPointer(Tcl_Interp *interp, const char *zA, sqlite **ppDb){
-  if( sscanf(zA, PTR_FMT, (void**)ppDb)!=1 && 
+  if( sscanf(zA, PTR_FMT, (void**)ppDb)!=1 &&
       (zA[0]!='0' || zA[1]!='x' || sscanf(&zA[2], PTR_FMT, (void**)ppDb)!=1)
   ){
     Tcl_AppendResult(interp, "\"", zA, "\" is not a valid pointer value", 0);
@@ -62,7 +62,7 @@ static int getVmPointer(Tcl_Interp *interp, const char *zArg, sqlite_vm **ppVm){
 ** "%p" you cannot turn around and do a scanf with the same "%p" and
 ** get your pointer back.  You have to prepend a "0x" before it will
 ** work.  Or at least that is what is reported to me (drh).  But this
-** behavior varies from machine to machine.  The solution used her is
+** behavior varies from machine to machine.  The solution used here is
 ** to test the string right after it is generated to see if it can be
 ** understood by scanf, and if not, try prepending an "0x" to see if
 ** that helps.  If nothing works, a fatal error is generated.
@@ -151,7 +151,7 @@ static int test_exec_printf(
   char *zErr = 0;
   char zBuf[30];
   if( argc!=4 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " DB FORMAT STRING", 0);
     return TCL_ERROR;
   }
@@ -169,7 +169,7 @@ static int test_exec_printf(
 /*
 ** Usage:  sqlite_mprintf_z_test  SEPARATOR  ARG0  ARG1 ...
 **
-** Test the %z format of mprintf().  Use multiple mprintf() calls to 
+** Test the %z format of mprintf().  Use multiple mprintf() calls to
 ** concatenate arg0 through argn using separator as the separator.
 ** Return the result.
 */
@@ -212,13 +212,13 @@ static int test_get_table_printf(
   int i;
   char zBuf[30];
   if( argc!=4 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " DB FORMAT STRING", 0);
     return TCL_ERROR;
   }
   if( getDbPointer(interp, argv[1], &db) ) return TCL_ERROR;
   Tcl_DStringInit(&str);
-  rc = sqlite_get_table_printf(db, argv[2], &aResult, &nRow, &nCol, 
+  rc = sqlite_get_table_printf(db, argv[2], &aResult, &nRow, &nCol,
                &zErr, argv[3]);
   sprintf(zBuf, "%d", rc);
   Tcl_AppendElement(interp, zBuf);
@@ -353,15 +353,15 @@ static int execFuncCallback(void *pData, int argc, char **argv, char **NotUsed){
 ** This is illegal and should set the SQLITE_MISUSE flag on the database.
 **
 ** 2004-Jan-07:  We have changed this to make it legal to call sqlite_exec()
-** from within a function call.  
-** 
+** from within a function call.
+**
 ** This routine simulates the effect of having two threads attempt to
 ** use the same database at the same time.
 */
 static void sqliteExecFunc(sqlite_func *context, int argc, const char **argv){
   struct dstr x;
   memset(&x, 0, sizeof(x));
-  sqlite_exec((sqlite*)sqlite_user_data(context), argv[0], 
+  sqlite_exec((sqlite*)sqlite_user_data(context), argv[0],
       execFuncCallback, &x, 0);
   sqlite_set_result_string(context, x.z, x.nUsed);
   sqliteFree(x.z);
@@ -414,7 +414,7 @@ static void countStep(sqlite_func *context, int argc, const char **argv){
   if( (argc==0 || argv[0]) && p ){
     p->n++;
   }
-}   
+}
 static void countFinalize(sqlite_func *context){
   CountCtx *p;
   p = sqlite_aggregate_context(context, sizeof(*p));
@@ -667,7 +667,7 @@ static int test_register_func(
   sqlite *db;
   int rc;
   if( argc!=3 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " DB FUNCTION-NAME", 0);
     return TCL_ERROR;
   }
@@ -720,7 +720,7 @@ static int sqlite_datatypes(
   sqlite *db;
   int rc;
   if( argc!=3 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " DB SQL", 0);
     return TCL_ERROR;
   }
@@ -753,7 +753,7 @@ static int test_compile(
   const char *zTail;
   char zBuf[50];
   if( argc!=3 && argc!=4 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " DB SQL TAILVAR", 0);
     return TCL_ERROR;
   }
@@ -794,7 +794,7 @@ static int test_step(
   char *zRc;
   char zBuf[50];
   if( argc<2 || argc>5 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " VM NVAR VALUEVAR COLNAMEVAR", 0);
     return TCL_ERROR;
   }
@@ -835,7 +835,7 @@ static int test_step(
 }
 
 /*
-** Usage:  sqlite_finalize  VM 
+** Usage:  sqlite_finalize  VM
 **
 ** Shutdown a virtual machine.
 */
@@ -849,7 +849,7 @@ static int test_finalize(
   int rc;
   char *zErrMsg = 0;
   if( argc!=2 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " VM\"", 0);
     return TCL_ERROR;
   }
@@ -866,7 +866,7 @@ static int test_finalize(
 }
 
 /*
-** Usage:  sqlite_reset   VM 
+** Usage:  sqlite_reset   VM
 **
 ** Reset a virtual machine and prepare it to be run again.
 */
@@ -880,7 +880,7 @@ static int test_reset(
   int rc;
   char *zErrMsg = 0;
   if( argc!=2 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " VM\"", 0);
     return TCL_ERROR;
   }
@@ -922,7 +922,7 @@ static int test_bind(
   int rc;
   int idx;
   if( argc!=5 ){
-    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0], 
+    Tcl_AppendResult(interp, "wrong # args: should be \"", argv[0],
        " VM IDX VALUE (null|static|normal)\"", 0);
     return TCL_ERROR;
   }
@@ -1014,13 +1014,13 @@ int Sqlitetest1_Init(Tcl_Interp *interp){
   for(i=0; i<sizeof(aCmd)/sizeof(aCmd[0]); i++){
     Tcl_CreateCommand(interp, aCmd[i].zName, aCmd[i].xProc, 0, 0);
   }
-  Tcl_LinkVar(interp, "sqlite_search_count", 
+  Tcl_LinkVar(interp, "sqlite_search_count",
       (char*)&sqlite_search_count, TCL_LINK_INT);
-  Tcl_LinkVar(interp, "sqlite_interrupt_count", 
+  Tcl_LinkVar(interp, "sqlite_interrupt_count",
       (char*)&sqlite_interrupt_count, TCL_LINK_INT);
-  Tcl_LinkVar(interp, "sqlite_open_file_count", 
+  Tcl_LinkVar(interp, "sqlite_open_file_count",
       (char*)&sqlite_open_file_count, TCL_LINK_INT);
-  Tcl_LinkVar(interp, "sqlite_current_time", 
+  Tcl_LinkVar(interp, "sqlite_current_time",
       (char*)&sqlite_current_time, TCL_LINK_INT);
   Tcl_LinkVar(interp, "sqlite_static_bind_value",
       (char*)&sqlite_static_bind_value, TCL_LINK_STRING);

--- a/usr/src/lib/libtecla/common/getline.c
+++ b/usr/src/lib/libtecla/common/getline.c
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2000, 2001, 2002, 2003, 2004 by Martin C. Shepherd.
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
  * "Software"), to deal in the Software without restriction, including
@@ -12,7 +12,7 @@
  * copyright notice(s) and this permission notice appear in all copies of
  * the Software and that both the above copyright notice(s) and this
  * permission notice appear in supporting documentation.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
@@ -22,7 +22,7 @@
  * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
  * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
  * WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- * 
+ *
  * Except as contained in this notice, the name of a copyright holder
  * shall not be used in advertising or otherwise to promote the sale, use
  * or other dealings in this Software without prior written authorization
@@ -32,6 +32,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -225,7 +226,7 @@ typedef struct {
   KtAction action;           /* The last action function that made a */
                              /*  change to the line. */
   int count;                 /* The repeat count that was passed to the */
-                             /*  above command. */  
+                             /*  above command. */
   int input_curpos;          /* Whenever vi command mode is entered, the */
                              /*  the position at which it was first left */
                              /*  is recorded here. */
@@ -421,7 +422,7 @@ struct GetLine {
                              /*  display the current input line. */
   int buff_mark;             /* A marker location in the buffer */
   int insert_curpos;         /* The cursor position at start of insert */
-  int insert;                /* True in insert mode */ 
+  int insert;                /* True in insert mode */
   int number;                /* If >= 0, a numeric argument is being read */
   int endline;               /* True to tell gl_get_input_line() to return */
                              /*  the current contents of gl->line[] */
@@ -976,7 +977,7 @@ static int _gl_bind_arrow_keys(GetLine *gl);
 
 /*
  * Copy the binding of the specified symbolic arrow-key binding to
- * the terminal specific, and default arrow-key key-sequences. 
+ * the terminal specific, and default arrow-key key-sequences.
  */
 static int _gl_rebind_arrow_key(GetLine *gl, const char *name,
 				const char *term_seq,
@@ -3200,7 +3201,7 @@ static int gl_read_terminal(GetLine *gl, int keep, char *c)
 
 /*.......................................................................
  * Read one or more keypresses from the terminal of an input stream.
- * 
+ *
  * Input:
  *  gl           GetLine *  The resource object of this module.
  *  c               char *  The character that was read is assigned to *c.
@@ -3282,7 +3283,7 @@ static GlReadStatus gl_read_input(GetLine *gl, char *c)
       gl_nonblocking_io(gl, fd);
 /*
  * Now respond to the signal that was caught.
- */      
+ */
     if(gl_check_caught_signal(gl))
       return GL_READ_ERROR;
   };
@@ -3333,7 +3334,7 @@ static int gl_read_unmasked(GetLine *gl, int fd, char *c)
 }
 
 /*.......................................................................
- * Remove a specified number of characters from the start of the 
+ * Remove a specified number of characters from the start of the
  * key-press lookahead buffer, gl->keybuf[], and arrange for the next
  * read to start from the character at the start of the shifted buffer.
  *
@@ -4069,7 +4070,7 @@ static int gl_terminal_move_cursor(GetLine *gl, int n)
  *                    following the one being written.
  * Output:
  *  return    int     0 - OK.
- */ 
+ */
 static int gl_print_char(GetLine *gl, char c, char pad)
 {
   char string[TAB_WIDTH + 4]; /* A work area for composing compound strings */
@@ -7074,7 +7075,7 @@ static KT_KEY_FN(gl_vi_insert_at_bol)
   gl_save_for_undo(gl);
   return gl_beginning_of_line(gl, 0, NULL) ||
          gl_vi_insert(gl, 0, NULL);
-         
+
 }
 
 /*.......................................................................
@@ -8855,7 +8856,7 @@ static int _gl_watch_fd(GetLine *gl, int fd, GlFdEvent event,
  * returns a code which tells gl_get_line() what to do next. Note that
  * each call to gl_inactivity_timeout() replaces any previously installed
  * timeout callback, and that specifying a callback of 0, turns off
- * inactivity timing. 
+ * inactivity timing.
  *
  * Beware that although the timeout argument includes a nano-second
  * component, few computer clocks presently have resolutions finer
@@ -8964,7 +8965,7 @@ static int gl_event_handler(GetLine *gl, int fd)
  */
     struct timeval dt = gl->timer.fn ? gl->timer.dt : zero;
 /*
- * Add the specified user-input file descriptor tot he set that is to
+ * Add the specified user-input file descriptor to the set that is to
  * be watched.
  */
     FD_SET(fd, &rfds);
@@ -9298,7 +9299,7 @@ int gl_show_history(GetLine *gl, FILE *fp, const char *fmt, int all_groups,
 /*
  * Display the specified history group(s) while signals are blocked.
  */
-  status = _glh_show_history(gl->glh, _io_write_stdio, fp, fmt, all_groups, 
+  status = _glh_show_history(gl->glh, _io_write_stdio, fp, fmt, all_groups,
 			     max_lines) || fflush(fp)==EOF;
   if(!status)
     _err_record_msg(gl->err, _glh_last_error(gl->glh), END_ERR_MSG);
@@ -9806,7 +9807,7 @@ static int gl_display_prompt(GetLine *gl)
 	switch(pptr[1]) {
 /*
  * Add or remove a text attribute from the new set of attributes.
- */ 
+ */
 	case 'B': case 'U': case 'S': case 'P': case 'F': case 'V':
 	case 'b': case 'u': case 's': case 'p': case 'f': case 'v':
 	  switch(*++pptr) {
@@ -10331,7 +10332,7 @@ int gl_last_signal(GetLine *gl)
     gl_mask_signals(gl, &oldset);
 /*
  * Access gl now that signals are blocked.
- */    
+ */
     signo = gl->last_signal;
 /*
  * Restore the process signal mask before returning.
@@ -10393,7 +10394,7 @@ static int gl_present_line(GetLine *gl, const char *prompt,
 	gl_truncate_buffer(gl, 0);
       };
       gl->preload_id = 0;
-    }; 
+    };
 /*
  * Present a specified initial line?
  */
@@ -10614,7 +10615,7 @@ GlReturnStatus gl_return_status(GetLine *gl)
     gl_mask_signals(gl, &oldset);
 /*
  * Access gl while signals are blocked.
- */    
+ */
     rtn_status = gl->rtn_status;
 /*
  * Restore the process signal mask before returning.
@@ -10646,7 +10647,7 @@ GlPendingIO gl_pending_io(GetLine *gl)
     gl_mask_signals(gl, &oldset);
 /*
  * Access gl while signals are blocked.
- */    
+ */
     pending_io = gl->pending_io;
 /*
  * Restore the process signal mask before returning.
@@ -10669,7 +10670,7 @@ GlPendingIO gl_pending_io(GetLine *gl)
  * call gl_raw_io() to redisplay the line and resume editing.
  *
  * This function is async signal safe.
- * 
+ *
  * Input:
  *  gl      GetLine *  The line editor resource object.
  * Output:
@@ -10735,7 +10736,7 @@ static int _gl_raw_io(GetLine *gl, int redisplay)
 /*
  * Switch to non-blocking I/O mode?
  */
-  if(gl->io_mode==GL_SERVER_MODE && 
+  if(gl->io_mode==GL_SERVER_MODE &&
      (gl_nonblocking_io(gl, gl->input_fd) ||
       gl_nonblocking_io(gl, gl->output_fd) ||
       (gl->file_fp && gl_nonblocking_io(gl, fileno(gl->file_fp))))) {
@@ -11203,7 +11204,7 @@ int gl_tty_signals(void (*term_handler)(int), void (*susp_handler)(int),
     } else if(sig->attr & GLSA_SIZE) {
       if(gl_set_tty_signal(sig->signo, size_handler))
 	return 1;
-    };      
+    };
   };
   return 0;
 }
@@ -11823,7 +11824,7 @@ static int gl_classify_signal(int signo)
 
 /*.......................................................................
  * When in non-blocking server mode, this function can be used to abandon
- * the current incompletely entered input line, and prepare to start 
+ * the current incompletely entered input line, and prepare to start
  * editing a new line on the next call to gl_get_line().
  *
  * Input:
@@ -12397,7 +12398,7 @@ static int gl_read_stream_char(GetLine *gl)
  *  return          int     0 - OK
  *                          1 - Error.
  */
-int gl_bind_keyseq(GetLine *gl, GlKeyOrigin origin, const char *keyseq, 
+int gl_bind_keyseq(GetLine *gl, GlKeyOrigin origin, const char *keyseq,
 		   const char *action)
 {
   KtBinder binder;  /* The private internal equivalent of 'origin' */

--- a/usr/src/lib/libumem/common/getpcstack.c
+++ b/usr/src/lib/libumem/common/getpcstack.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -89,7 +90,7 @@ getpcstack(uintptr_t *pcstack, int pcstack_limit, int check_signal)
 		 * If size == 0, then ss_sp is the *top* of the stack.
 		 *
 		 * Since we only allow increasing frame pointers, and we
-		 * know our caller set his up correctly, we can treat ss_sp
+		 * know our caller set its up correctly, we can treat ss_sp
 		 * as an upper bound safely.
 		 */
 		base = 0;

--- a/usr/src/lib/libvolmgt/common/volmgt_on_private.c
+++ b/usr/src/lib/libvolmgt/common/volmgt_on_private.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -87,7 +88,7 @@ _dev_mounted(char *path)
 	}
 
 	if ((fp = fopen(MNTTAB, "rF")) == NULL) {
-		/* mtab is gone... let him go */
+		/* mtab is gone... let it go */
 		goto dun;
 	}
 
@@ -418,7 +419,7 @@ get_media_info(char *path, char **mtypep, int *mnump, char **spclp)
 	int		ret_val = FALSE;
 
 	if ((fp = fopen(MNTTAB, "rF")) == NULL) {
-		/* mtab is gone... let him go */
+		/* mtab is gone... let it go */
 		goto dun;
 	}
 

--- a/usr/src/lib/pam_modules/authtok_check/authtok_check.c
+++ b/usr/src/lib/pam_modules/authtok_check/authtok_check.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -482,9 +483,9 @@ check_composition(char *pw, struct pwdefaults *pwdef, pam_handle_t *pamh,
 	 * characters) we give a modified error message. Otherwise, a
 	 * user entering FooBar1234 with PASSLENGTH=6, MINDIGIT=4, while
 	 * we're using the default UNIX crypt (8 chars significant),
-	 * would not understand what's going on when he's told that
+	 * would not understand what's going on when they're told that
 	 * "The password should contain at least 4 digits"...
-	 * Instead, we now well him
+	 * Instead, we now tell them
 	 * "The first 8 characters of the password should contain at least
 	 *  4 digits."
 	 */

--- a/usr/src/lib/pam_modules/sample/sample_acct_mgmt.c
+++ b/usr/src/lib/pam_modules/sample/sample_acct_mgmt.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <syslog.h>
@@ -36,7 +37,7 @@ static int parse_allow_name(char *, char *);
 /*
  * pam_sm_acct_mgmt	main account managment routine.
  *			XXX: The routine just prints out a warning message.
- *			     It may need to force the user to change his/her
+ *			     It may need to force the user to change their
  *			     passwd.
  */
 

--- a/usr/src/lib/pam_modules/unix_account/unix_acct.c
+++ b/usr/src/lib/pam_modules/unix_account/unix_acct.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -198,7 +199,7 @@ perform_passwd_aging_check(
 
 	/*
 	 * if (sp_lstchg == 0), the administrator has forced the
-	 * user to change his/her passwd
+	 * user to change their passwd
 	 */
 	if (shpwd->sp_lstchg == 0)
 		return (PAM_NEW_AUTHTOK_REQD);

--- a/usr/src/lib/passwdutil/files_attr.c
+++ b/usr/src/lib/passwdutil/files_attr.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -810,7 +811,7 @@ files_update(attrlist *items, pwu_repository_t *rep, void *buf)
 				 * We take care not to update lstchg if the
 				 * user has no password, otherwise the user
 				 * might not be required to provide a password
-				 * the next time [s]he logs-in.
+				 * the next time they log-in.
 				 *
 				 * Also, if lstchg != -1 (i.e., not set in
 				 * /etc/shadow), we keep the old value.

--- a/usr/src/lib/passwdutil/ldap_attr.c
+++ b/usr/src/lib/passwdutil/ldap_attr.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <stdio.h>
@@ -185,7 +186,7 @@ free_ldapbuf(ldapbuf_t *p)
  * we can't determine whether the user is "privileged" in the LDAP
  * sense. The operation should be attempted and will succeed if the
  * user had privileges. For our purposes, we say that the user is
- * privileged if he/she is attempting to change another user's
+ * privileged if they are attempting to change another user's
  * password attributes.
  */
 int
@@ -814,7 +815,7 @@ ldap_update(attrlist *items, pwu_repository_t *rep, void *buf)
 				 * We take care not to update lstchg if the
 				 * user has no password, otherwise the user
 				 * might not be required to provide a password
-				 * the next time [s]he logs in.
+				 * the next time they log in.
 				 *
 				 * Also, if lstchg != -1 (i.e., not set)
 				 * we keep the old value.

--- a/usr/src/lib/pkcs11/pkcs11_tpm/common/tpm_specific.c
+++ b/usr/src/lib/pkcs11/pkcs11_tpm/common/tpm_specific.c
@@ -22,6 +22,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <pthread.h>
@@ -1693,7 +1694,7 @@ token_specific_init_pin(TSS_HCONTEXT hContext,
 	 * Since the SO must log in before calling C_InitPIN, we will
 	 * be able to return (CKR_OK) automatically here.
 	 * This is because the USER key structure is created at the
-	 * time of her first login, not at C_InitPIN time.
+	 * time of their first login, not at C_InitPIN time.
 	 */
 	return (CKR_OK);
 }
@@ -1939,7 +1940,7 @@ token_specific_verify_so_pin(TSS_HCONTEXT hContext, CK_CHAR_PTR pPin,
 	if (local_uuid_is_null(&publicRootKeyUUID) &&
 	    find_uuid(TPMTOK_PUBLIC_ROOT_KEY_ID, &publicRootKeyUUID)) {
 		/*
-		 * The SO hasn't set her PIN yet, compare the
+		 * The SO hasn't set their PIN yet, compare the
 		 * login pin with the hard-coded value.
 		 */
 		if (memcmp(default_so_pin_sha, hash_sha,

--- a/usr/src/lib/sasl_plugins/digestmd5/digestmd5.c
+++ b/usr/src/lib/sasl_plugins/digestmd5/digestmd5.c
@@ -1,15 +1,16 @@
 /*
  * Copyright 2003 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /* DIGEST-MD5 SASL plugin
  * Rob Siemborski
  * Tim Martin
- * Alexey Melnikov 
+ * Alexey Melnikov
  * $Id: digestmd5.c,v 1.153 2003/03/30 22:17:06 leg Exp $
  */
-/* 
+/*
  * Copyright (c) 1998-2003 Carnegie Mellon University.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -17,7 +18,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -27,7 +28,7 @@
  * 3. The name "Carnegie Mellon University" must not be used to
  *    endorse or promote products derived from this software without
  *    prior written permission. For permission or any other legal
- *    details, please contact  
+ *    details, please contact
  *      Office of Technology Transfer
  *      Carnegie Mellon University
  *      5000 Forbes Avenue
@@ -162,10 +163,10 @@ typedef int cipher_function_t(struct context *,
 			      unsigned *);
 
 #ifdef _SUN_SDK_
-typedef int cipher_init_t(struct context *, char [16], 
+typedef int cipher_init_t(struct context *, char [16],
                                             char [16]);
 #else
-typedef int cipher_init_t(struct context *, unsigned char [16], 
+typedef int cipher_init_t(struct context *, unsigned char [16],
                                             unsigned char [16]);
 #endif /* _SUN_SDK_ */
 
@@ -211,7 +212,7 @@ typedef struct reauth_cache {
 typedef struct context {
     int state;			/* state in the authentication we are in */
     enum Context_type i_am;	/* are we the client or server? */
-    
+
     reauth_cache_t *reauth;
 
     char *authid;
@@ -221,22 +222,22 @@ typedef struct context {
     unsigned char *cnonce;
 
     char *response_value;
-    
+
     unsigned int seqnum;
     unsigned int rec_seqnum;	/* for checking integrity */
-    
+
     HASH Ki_send;
     HASH Ki_receive;
-    
+
     HASH HA1;		/* Kcc or Kcs */
-    
+
     /* copy of utils from the params structures */
     const sasl_utils_t *utils;
-    
+
     /* For general use */
     char *out_buf;
     unsigned out_buf_len;
-    
+
     /* for encoding/decoding */
     buffer_info_t *enc_in_buf;
     char *encode_buf, *decode_buf, *decode_once_buf;
@@ -245,7 +246,7 @@ typedef struct context {
     unsigned decode_tmp_buf_len;
     char *MAC_buf;
     unsigned MAC_buf_len;
-    
+
     char *buffer;
     char sizebuf[4];
     int cursize;
@@ -253,11 +254,11 @@ typedef struct context {
     /* Layer info */
     unsigned int size; /* Absolute size of buffer */
     unsigned int needsize; /* How much of the size of the buffer is left */
-    
+
     /* Server MaxBuf for Client or Client MaxBuf For Server */
     /* INCOMING */
     unsigned int in_maxbuf;
-    
+
     /* if privacy mode is used use these functions for encode and decode */
     cipher_function_t *cipher_enc;
     cipher_function_t *cipher_dec;
@@ -272,7 +273,7 @@ struct digest_cipher {
     sasl_ssf_t ssf;
     int n; /* bits to make privacy key */
     int flag; /* a bitmask to make things easier for us */
-    
+
     cipher_function_t *cipher_enc;
     cipher_function_t *cipher_dec;
     cipher_init_t *cipher_init;
@@ -305,7 +306,7 @@ static void CvtHex(HASH Bin, HASHHEX Hex)
 {
     unsigned short  i;
     unsigned char   j;
-    
+
     for (i = 0; i < HASHLEN; i++) {
 	j = (Bin[i] >> 4) & 0xf;
 	if (j <= 9)
@@ -343,15 +344,15 @@ DigestCalcResponse(const sasl_utils_t * utils,
     HASH            RespHash;
     HASHHEX         HA2Hex;
     char ncvalue[10];
-    
+
     /* calculate H(A2) */
     utils->MD5Init(&Md5Ctx);
-    
+
     if (pszMethod != NULL) {
 	utils->MD5Update(&Md5Ctx, pszMethod, strlen((char *) pszMethod));
     }
     utils->MD5Update(&Md5Ctx, (unsigned char *) COLON, 1);
-    
+
     /* utils->MD5Update(&Md5Ctx, (unsigned char *) "AUTHENTICATE:", 13); */
     utils->MD5Update(&Md5Ctx, pszDigestUri, strlen((char *) pszDigestUri));
     if (strcasecmp((char *) pszQop, "auth") != 0) {
@@ -361,7 +362,7 @@ DigestCalcResponse(const sasl_utils_t * utils,
     }
     utils->MD5Final(HA2, &Md5Ctx);
     CvtHex(HA2, HA2Hex);
-    
+
     /* calculate response */
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, HA1, HASHHEXLEN);
@@ -389,7 +390,7 @@ DigestCalcResponse(const sasl_utils_t * utils,
 static bool UTF8_In_8859_1(const unsigned char *base, int len)
 {
     const unsigned char *scan, *end;
-    
+
     end = base + len;
     for (scan = base; scan < end; ++scan) {
 	if (*scan > 0xC3)
@@ -399,7 +400,7 @@ static bool UTF8_In_8859_1(const unsigned char *base, int len)
 		break;
 	}
     }
-    
+
     /* if scan >= end, then this is a 8859-1 string. */
     return (scan >= end);
 }
@@ -416,9 +417,9 @@ void MD5_UTF8_8859_1(const sasl_utils_t * utils,
 {
     const unsigned char *scan, *end;
     unsigned char   cbuf;
-    
+
     end = base + len;
-    
+
     /* if we found a character outside 8859-1, don't alter string */
     if (!In_ISO_8859_1) {
 	utils->MD5Update(ctx, base, len);
@@ -446,34 +447,34 @@ static void DigestCalcSecret(const sasl_utils_t * utils,
 			     HASH HA1)
 {
     bool            In_8859_1;
-    
+
     MD5_CTX         Md5Ctx;
-    
+
     /* Chris Newman clarified that the following text in DIGEST-MD5 spec
        is bogus: "if name and password are both in ISO 8859-1 charset"
        We shoud use code example instead */
-    
+
     utils->MD5Init(&Md5Ctx);
-    
+
     /* We have to convert UTF-8 to ISO-8859-1 if possible */
     In_8859_1 = UTF8_In_8859_1(pszUserName, strlen((char *) pszUserName));
     MD5_UTF8_8859_1(utils, &Md5Ctx, In_8859_1,
 		    pszUserName, strlen((char *) pszUserName));
-    
+
     utils->MD5Update(&Md5Ctx, COLON, 1);
-    
+
     if (pszRealm != NULL && pszRealm[0] != '\0') {
 	/* a NULL realm is equivalent to the empty string */
 	utils->MD5Update(&Md5Ctx, pszRealm, strlen((char *) pszRealm));
-    }      
-    
+    }
+
     utils->MD5Update(&Md5Ctx, COLON, 1);
-    
+
     /* We have to convert UTF-8 to ISO-8859-1 if possible */
     In_8859_1 = UTF8_In_8859_1(Password, PasswordLen);
     MD5_UTF8_8859_1(utils, &Md5Ctx, In_8859_1,
 		    Password, PasswordLen);
-    
+
     utils->MD5Final(HA1, &Md5Ctx);
 }
 
@@ -481,30 +482,30 @@ static unsigned char *create_nonce(const sasl_utils_t * utils)
 {
     unsigned char  *base64buf;
     int             base64len;
-    
+
     char           *ret = (char *) utils->malloc(NONCE_SIZE);
     if (ret == NULL)
 	return NULL;
-    
+
 #if defined _DEV_URANDOM && defined _SUN_SDK_
     {
 	int fd = open(_DEV_URANDOM, O_RDONLY);
 	int nread = 0;
 
-  	if (fd != -1) { 
-		nread = read(fd, ret, NONCE_SIZE); 
-		close(fd); 
-	} 
+	if (fd != -1) {
+		nread = read(fd, ret, NONCE_SIZE);
+		close(fd);
+	}
 	if (nread != NONCE_SIZE)
 	    utils->rand(utils->rpool, (char *) ret, NONCE_SIZE);
     }
 #else
     utils->rand(utils->rpool, (char *) ret, NONCE_SIZE);
 #endif /* _DEV_URANDOM && _SUN_SDK_ */
-    
+
     /* base 64 encode it so it has valid chars */
     base64len = (NONCE_SIZE * 4 / 3) + (NONCE_SIZE % 3 ? 4 : 0);
-    
+
     base64buf = (unsigned char *) utils->malloc(base64len + 1);
     if (base64buf == NULL) {
 #ifdef _SUN_SDK_
@@ -515,7 +516,7 @@ static unsigned char *create_nonce(const sasl_utils_t * utils)
 #endif /* _SUN_SDK_ */
 	return NULL;
     }
-    
+
     /*
      * Returns SASL_OK on success, SASL_BUFOVER if result won't fit
      */
@@ -525,7 +526,7 @@ static unsigned char *create_nonce(const sasl_utils_t * utils)
 	return NULL;
     }
     utils->free(ret);
-    
+
     return base64buf;
 }
 
@@ -538,16 +539,16 @@ static int add_to_challenge(const sasl_utils_t *utils,
     int             namesize = strlen(name);
     int             valuesize = strlen((char *) value);
     int             ret;
-    
+
     ret = _plug_buf_alloc(utils, str, buflen,
 			  *curlen + 1 + namesize + 2 + valuesize + 2);
     if(ret != SASL_OK) return ret;
-    
+
     *curlen = *curlen + 1 + namesize + 2 + valuesize + 2;
-    
+
     strcat(*str, ",");
     strcat(*str, name);
-    
+
     if (need_quotes) {
 	strcat(*str, "=\"");
 	strcat(*str, (char *) value);	/* XXX. What about quoting??? */
@@ -556,20 +557,20 @@ static int add_to_challenge(const sasl_utils_t *utils,
 	strcat(*str, "=");
 	strcat(*str, (char *) value);
     }
-    
+
     return SASL_OK;
 }
 
 static char *skip_lws (char *s)
 {
     if(!s) return NULL;
-    
+
     /* skipping spaces: */
     while (s[0] == ' ' || s[0] == HT || s[0] == CR || s[0] == LF) {
 	if (s[0]=='\0') break;
 	s++;
-    }  
-    
+    }
+
     return s;
 }
 
@@ -580,7 +581,7 @@ static char *skip_token (char *s, int caseinsensitive)
 #endif /* _SUN_SDK_ */
 {
     if(!s) return NULL;
-    
+
 #ifdef __SUN_SDK_
     while (((unsigned char *)s)[0]>SP) {
 #else
@@ -603,24 +604,24 @@ static char *skip_token (char *s, int caseinsensitive)
 #endif /* _SUN_SDK_ */
 	}
 	s++;
-    }  
+    }
     return s;
 }
 
-/* NULL - error (unbalanced quotes), 
+/* NULL - error (unbalanced quotes),
    otherwise pointer to the first character after value */
 static char *unquote (char *qstr)
 {
     char *endvalue;
     int   escaped = 0;
     char *outptr;
-    
+
     if(!qstr) return NULL;
-    
+
     if (qstr[0] == '"') {
 	qstr++;
 	outptr = qstr;
-	
+
 	for (endvalue = qstr; endvalue[0] != '\0'; endvalue++, outptr++) {
 	    if (escaped) {
 		outptr[0] = endvalue[0];
@@ -632,16 +633,16 @@ static char *unquote (char *qstr)
 	    }
 	    else if (endvalue[0] == '"') {
 		break;
-	    }      
+	    }
 	    else {
-		outptr[0] = endvalue[0];      
+		outptr[0] = endvalue[0];
 	    }
 	}
-	
+
 	if (endvalue[0] != '"') {
 	    return NULL;
 	}
-	
+
 	while (outptr <= endvalue) {
 	    outptr[0] = '\0';
 	    outptr++;
@@ -651,9 +652,9 @@ static char *unquote (char *qstr)
     else { /* not qouted value (token) */
 	endvalue = skip_token(qstr,0);
     };
-    
-    return endvalue;  
-} 
+
+    return endvalue;
+}
 
 static void get_pair(char **in, char **name, char **value)
 {
@@ -662,58 +663,58 @@ static void get_pair(char **in, char **name, char **value)
     char  *curp = *in;
     *name = NULL;
     *value = NULL;
-    
+
     if (curp == NULL) return;
     if (curp[0] == '\0') return;
-    
+
     /* skipping spaces: */
     curp = skip_lws(curp);
-    
+
     *name = curp;
-    
+
     curp = skip_token(curp,1);
-    
+
     /* strip wierd chars */
     if (curp[0] != '=' && curp[0] != '\0') {
 	*curp++ = '\0';
     };
-    
+
     curp = skip_lws(curp);
-    
-    if (curp[0] != '=') { /* No '=' sign */ 
+
+    if (curp[0] != '=') { /* No '=' sign */
 	*name = NULL;
 	return;
     }
-    
+
     curp[0] = '\0';
     curp++;
-    
-    curp = skip_lws(curp);  
-    
+
+    curp = skip_lws(curp);
+
     *value = (curp[0] == '"') ? curp+1 : curp;
-    
+
     endpair = unquote (curp);
-    if (endpair == NULL) { /* Unbalanced quotes */ 
+    if (endpair == NULL) { /* Unbalanced quotes */
 	*name = NULL;
 	return;
     }
     if (endpair[0] != ',') {
 	if (endpair[0]!='\0') {
-	    *endpair++ = '\0'; 
+	    *endpair++ = '\0';
 	}
     }
-    
+
     endpair = skip_lws(endpair);
-    
-    /* syntax check: MUST be '\0' or ',' */  
+
+    /* syntax check: MUST be '\0' or ',' */
     if (endpair[0] == ',') {
 	endpair[0] = '\0';
 	endpair++; /* skipping <,> */
-    } else if (endpair[0] != '\0') { 
+    } else if (endpair[0] != '\0') {
 	*name = NULL;
 	return;
     }
-    
+
     *in = endpair;
 }
 
@@ -755,7 +756,7 @@ static int dec_3des(context_t *text,
 {
     des_context_t *c = (des_context_t *) text->cipher_dec_context;
     int padding, p;
-    
+
     des_ede2_cbc_encrypt((void *) input,
 			 (void *) output,
 			 inputlen,
@@ -763,7 +764,7 @@ static int dec_3des(context_t *text,
 			 c->keysched2,
 			 &c->ivec,
 			 DES_DECRYPT);
-    
+
     /* now chop off the padding */
     padding = output[inputlen - 11];
     if (padding < 1 || padding > 8) {
@@ -776,13 +777,13 @@ static int dec_3des(context_t *text,
 	    return SASL_FAIL;
 	}
     }
-    
+
     /* chop off the padding */
     *outputlen = inputlen - padding - 10;
-    
+
     /* copy in the HMAC to digest */
     memcpy(digest, output + inputlen - 10, 10);
-    
+
     return SASL_OK;
 }
 
@@ -796,17 +797,17 @@ static int enc_3des(context_t *text,
     des_context_t *c = (des_context_t *) text->cipher_enc_context;
     int len;
     int paddinglen;
-    
+
     /* determine padding length */
     paddinglen = 8 - ((inputlen + 10) % 8);
-    
+
     /* now construct the full stuff to be ciphered */
     memcpy(output, input, inputlen);                /* text */
     memset(output+inputlen, paddinglen, paddinglen);/* pad  */
     memcpy(output+inputlen+paddinglen, digest, 10); /* hmac */
-    
+
     len=inputlen+paddinglen+10;
-    
+
     des_ede2_cbc_encrypt((void *) output,
 			 (void *) output,
 			 len,
@@ -814,13 +815,13 @@ static int enc_3des(context_t *text,
 			 c->keysched2,
 			 &c->ivec,
 			 DES_ENCRYPT);
-    
+
     *outputlen=len;
-    
+
     return SASL_OK;
 }
 
-static int init_3des(context_t *text, 
+static int init_3des(context_t *text,
 		     unsigned char enckey[16],
 		     unsigned char deckey[16])
 {
@@ -848,15 +849,15 @@ static int init_3des(context_t *text,
     slidebits(keybuf, deckey);
     if (des_key_sched((des_cblock *) keybuf, c->keysched) < 0)
 	return SASL_FAIL;
-    
+
     slidebits(keybuf, deckey + 7);
     if (des_key_sched((des_cblock *) keybuf, c->keysched2) < 0)
 	return SASL_FAIL;
-    
+
     memcpy(c->ivec, ((char *) deckey) + 8, 8);
 
     text->cipher_dec_context = (cipher_context_t *) c;
-    
+
     return SASL_OK;
 }
 
@@ -867,7 +868,7 @@ static int init_3des(context_t *text,
  *
  *****************************/
 
-static int dec_des(context_t *text, 
+static int dec_des(context_t *text,
 		   const char *input,
 		   unsigned inputlen,
 		   unsigned char digest[16],
@@ -876,7 +877,7 @@ static int dec_des(context_t *text,
 {
     des_context_t *c = (des_context_t *) text->cipher_dec_context;
     int p, padding = 0;
-    
+
     des_cbc_encrypt((void *) input,
 		    (void *) output,
 		    inputlen,
@@ -887,7 +888,7 @@ static int dec_des(context_t *text,
     /* Update the ivec (des_cbc_encrypt implementations tend to be broken in
        this way) */
     memcpy(c->ivec, input + (inputlen - 8), 8);
-    
+
     /* now chop off the padding */
     padding = output[inputlen - 11];
     if (padding < 1 || padding > 8) {
@@ -900,13 +901,13 @@ static int dec_des(context_t *text,
 	    return SASL_FAIL;
 	}
     }
-    
+
     /* chop off the padding */
     *outputlen = inputlen - padding - 10;
-    
+
     /* copy in the HMAC to digest */
     memcpy(digest, output + inputlen - 10, 10);
-    
+
     return SASL_OK;
 }
 
@@ -920,7 +921,7 @@ static int enc_des(context_t *text,
     des_context_t *c = (des_context_t *) text->cipher_enc_context;
     int len;
     int paddinglen;
-  
+
     /* determine padding length */
     paddinglen = 8 - ((inputlen+10) % 8);
 
@@ -928,22 +929,22 @@ static int enc_des(context_t *text,
     memcpy(output, input, inputlen);                /* text */
     memset(output+inputlen, paddinglen, paddinglen);/* pad  */
     memcpy(output+inputlen+paddinglen, digest, 10); /* hmac */
-    
+
     len = inputlen + paddinglen + 10;
-    
+
     des_cbc_encrypt((void *) output,
                     (void *) output,
                     len,
                     c->keysched,
                     &c->ivec,
                     DES_ENCRYPT);
-    
+
     /* Update the ivec (des_cbc_encrypt implementations tend to be broken in
        this way) */
     memcpy(c->ivec, output + (len - 8), 8);
-    
+
     *outputlen = len;
-    
+
     return SASL_OK;
 }
 
@@ -957,13 +958,13 @@ static int init_des(context_t *text,
     /* allocate enc context */
     c = (des_context_t *) text->utils->malloc(2 * sizeof(des_context_t));
     if (c == NULL) return SASL_NOMEM;
-    
+
     /* setup enc context */
     slidebits(keybuf, enckey);
     des_key_sched((des_cblock *) keybuf, c->keysched);
 
     memcpy(c->ivec, ((char *) enckey) + 8, 8);
-    
+
     text->cipher_enc_context = (cipher_context_t *) c;
 
     /* setup dec context */
@@ -972,7 +973,7 @@ static int init_des(context_t *text,
     des_key_sched((des_cblock *) keybuf, c->keysched);
 
     memcpy(c->ivec, ((char *) deckey) + 8, 8);
-    
+
     text->cipher_dec_context = (cipher_context_t *) c;
 
     return SASL_OK;
@@ -1001,23 +1002,23 @@ static void rc4_init(rc4_context_t *text,
 		     unsigned keylen)
 {
     int i, j;
-    
+
     /* fill in linearly s0=0 s1=1... */
     for (i=0;i<256;i++)
 	text->sbox[i]=i;
-    
+
     j=0;
     for (i = 0; i < 256; i++) {
 	unsigned char tmp;
 	/* j = (j + Si + Ki) mod 256 */
 	j = (j + text->sbox[i] + key[i % keylen]) % 256;
-	
+
 	/* swap Si and Sj */
 	tmp = text->sbox[i];
 	text->sbox[i] = text->sbox[j];
 	text->sbox[j] = tmp;
     }
-    
+
     /* counters initialized to 0 */
     text->i = 0;
     text->j = 0;
@@ -1034,25 +1035,25 @@ static void rc4_encrypt(rc4_context_t *text,
     int t;
     int K;
     const char *input_end = input + len;
-    
+
     while (input < input_end) {
 	i = (i + 1) % 256;
-	
+
 	j = (j + text->sbox[i]) % 256;
-	
+
 	/* swap Si and Sj */
 	tmp = text->sbox[i];
 	text->sbox[i] = text->sbox[j];
 	text->sbox[j] = tmp;
-	
+
 	t = (text->sbox[i] + text->sbox[j]) % 256;
-	
+
 	K = text->sbox[t];
-	
+
 	/* byte K is Xor'ed with plaintext */
 	*output++ = *input++ ^ K;
     }
-    
+
     text->i = i;
     text->j = j;
 }
@@ -1068,25 +1069,25 @@ static void rc4_decrypt(rc4_context_t *text,
     int t;
     int K;
     const char *input_end = input + len;
-    
+
     while (input < input_end) {
 	i = (i + 1) % 256;
-	
+
 	j = (j + text->sbox[i]) % 256;
-	
+
 	/* swap Si and Sj */
 	tmp = text->sbox[i];
 	text->sbox[i] = text->sbox[j];
 	text->sbox[j] = tmp;
-	
+
 	t = (text->sbox[i] + text->sbox[j]) % 256;
-	
+
 	K = text->sbox[t];
-	
+
 	/* byte K is Xor'ed with plaintext */
 	*output++ = *input++ ^ K;
     }
-    
+
     text->i = i;
     text->j = j;
 }
@@ -1103,7 +1104,7 @@ static void free_rc4(context_t *text)
 #endif /* _SUN_SDK_ */
 }
 
-static int init_rc4(context_t *text, 
+static int init_rc4(context_t *text,
 #ifdef _SUN_SDK_
 		    char enckey[16],
 		    char deckey[16])
@@ -1116,7 +1117,7 @@ static int init_rc4(context_t *text,
     text->cipher_enc_context=
 	(cipher_context_t *) text->utils->malloc(sizeof(rc4_context_t));
     if (text->cipher_enc_context == NULL) return SASL_NOMEM;
-    
+
     text->cipher_dec_context=
 	(cipher_context_t *) text->utils->malloc(sizeof(rc4_context_t));
 #ifdef _SUN_SDK_
@@ -1128,13 +1129,13 @@ static int init_rc4(context_t *text,
 #else
     if (text->cipher_dec_context == NULL) return SASL_NOMEM;
 #endif /* _SUN_SDK_ */
-    
+
     /* initialize them */
     rc4_init((rc4_context_t *) text->cipher_enc_context,
              (const unsigned char *) enckey, 16);
     rc4_init((rc4_context_t *) text->cipher_dec_context,
              (const unsigned char *) deckey, 16);
-    
+
     return SASL_OK;
 }
 
@@ -1146,16 +1147,16 @@ static int dec_rc4(context_t *text,
 		   unsigned *outputlen)
 {
     /* decrypt the text part */
-    rc4_decrypt((rc4_context_t *) text->cipher_dec_context, 
+    rc4_decrypt((rc4_context_t *) text->cipher_dec_context,
                 input, output, inputlen-10);
-    
+
     /* decrypt the HMAC part */
-    rc4_decrypt((rc4_context_t *) text->cipher_dec_context, 
+    rc4_decrypt((rc4_context_t *) text->cipher_dec_context,
 		input+(inputlen-10), (char *) digest, 10);
-    
+
     /* no padding so we just subtract the HMAC to get the text length */
     *outputlen = inputlen - 10;
-    
+
     return SASL_OK;
 }
 
@@ -1168,18 +1169,18 @@ static int enc_rc4(context_t *text,
 {
     /* pad is zero */
     *outputlen = inputlen+10;
-    
+
     /* encrypt the text part */
     rc4_encrypt((rc4_context_t *) text->cipher_enc_context,
                 input,
                 output,
                 inputlen);
-    
+
     /* encrypt the HMAC part */
-    rc4_encrypt((rc4_context_t *) text->cipher_enc_context, 
-                (const char *) digest, 
+    rc4_encrypt((rc4_context_t *) text->cipher_enc_context,
+                (const char *) digest,
 		(output)+inputlen, 10);
-    
+
     return SASL_OK;
 }
 
@@ -1242,12 +1243,12 @@ static void slidebits(unsigned char *keybuf, unsigned char *inbuf)
 /*
  * Create encryption and decryption session handle handles for later use.
  * Returns SASL_OK on success - any other return indicates failure.
- * 
+ *
  * free_uef is called to release associated resources by
  *	digestmd5_common_mech_dispose
  */
 
-static int init_uef(context_t *text, 
+static int init_uef(context_t *text,
 		    CK_KEY_TYPE keyType,
 		    CK_MECHANISM_TYPE mech_type,
 		    CK_SLOT_ID slot_id,
@@ -1291,7 +1292,7 @@ static int init_uef(context_t *text,
     enc_context = text->utils->malloc(sizeof (uef_context_t));
     if (enc_context == NULL)
 	return SASL_NOMEM;
-    
+
     rv = C_OpenSession(slot_id, CKF_SERIAL_SESSION, NULL_PTR, NULL_PTR,
 		&enc_context->hSession);
     if (rv != CKR_OK) {
@@ -1380,21 +1381,21 @@ static int init_uef(context_t *text,
     return SASL_OK;
 }
 
-static int init_rc4_uef(context_t *text, 
+static int init_rc4_uef(context_t *text,
 		    char enckey[16],
 		    char deckey[16])
 {
     return init_uef(text, CKK_RC4, CKM_RC4, rc4_slot_id, enckey, deckey);
 }
 
-static int init_des_uef(context_t *text, 
+static int init_des_uef(context_t *text,
 		    char enckey[16],
 		    char deckey[16])
 {
     return init_uef(text, CKK_DES, CKM_DES_CBC, des_slot_id, enckey, deckey);
 }
 
-static int init_3des_uef(context_t *text, 
+static int init_3des_uef(context_t *text,
 		    char enckey[16],
 		    char deckey[16])
 {
@@ -1411,7 +1412,7 @@ free_uef(context_t *text)
     CK_RV		rv;
     unsigned char 	buf[1];
     CK_ULONG		ulLen = 0;
-    
+
 
     if (enc_context != NULL) {
 	rv = C_EncryptFinal(enc_context->hSession, buf, &ulLen);
@@ -1665,54 +1666,54 @@ static int create_layer_keys(context_t *text,
 			     char enckey[16], char deckey[16])
 {
     MD5_CTX Md5Ctx;
-    
+
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, key, keylen);
     if (text->i_am == SERVER) {
-	utils->MD5Update(&Md5Ctx, (const unsigned char *) SEALING_SERVER_CLIENT, 
+	utils->MD5Update(&Md5Ctx, (const unsigned char *) SEALING_SERVER_CLIENT,
 			 strlen(SEALING_SERVER_CLIENT));
     } else {
 	utils->MD5Update(&Md5Ctx, (const unsigned char *) SEALING_CLIENT_SERVER,
 			 strlen(SEALING_CLIENT_SERVER));
     }
     utils->MD5Final((unsigned char *) enckey, &Md5Ctx);
-    
+
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, key, keylen);
     if (text->i_am != SERVER) {
-	utils->MD5Update(&Md5Ctx, (const unsigned char *)SEALING_SERVER_CLIENT, 
+	utils->MD5Update(&Md5Ctx, (const unsigned char *)SEALING_SERVER_CLIENT,
 			 strlen(SEALING_SERVER_CLIENT));
     } else {
 	utils->MD5Update(&Md5Ctx, (const unsigned char *)SEALING_CLIENT_SERVER,
 			 strlen(SEALING_CLIENT_SERVER));
     }
     utils->MD5Final((unsigned char *) deckey, &Md5Ctx);
-    
+
     /* create integrity keys */
     /* sending */
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, text->HA1, HASHLEN);
     if (text->i_am == SERVER) {
-	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_SERVER_CLIENT, 
+	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_SERVER_CLIENT,
 			 strlen(SIGNING_SERVER_CLIENT));
     } else {
 	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_CLIENT_SERVER,
 			 strlen(SIGNING_CLIENT_SERVER));
     }
     utils->MD5Final(text->Ki_send, &Md5Ctx);
-    
+
     /* receiving */
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, text->HA1, HASHLEN);
     if (text->i_am != SERVER) {
-	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_SERVER_CLIENT, 
+	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_SERVER_CLIENT,
 			 strlen(SIGNING_SERVER_CLIENT));
     } else {
 	utils->MD5Update(&Md5Ctx, (const unsigned char *)SIGNING_CLIENT_SERVER,
 			 strlen(SIGNING_CLIENT_SERVER));
     }
     utils->MD5Final(text->Ki_receive, &Md5Ctx);
-    
+
     return SASL_OK;
 }
 
@@ -1735,12 +1736,12 @@ digestmd5_privacy_encode(void *context,
     char *out;
     unsigned char digest[16];
     struct buffer_info *inblob, bufinfo;
-    
+
     if(!context || !invec || !numiov || !output || !outputlen) {
 	PARAMERROR(text->utils);
 	return SASL_BADPARAM;
     }
-    
+
     if (numiov > 1) {
 	ret = _plug_iovec_to_buf(text->utils, invec, numiov, &text->enc_in_buf);
 	if (ret != SASL_OK) return ret;
@@ -1751,7 +1752,7 @@ digestmd5_privacy_encode(void *context,
 	bufinfo.curlen = invec[0].iov_len;
 	inblob = &bufinfo;
     }
-    
+
     /* make sure the output buffer is big enough for this blob */
     ret = _plug_buf_alloc(text->utils, &(text->encode_buf),
 			  &(text->encode_buf_len),
@@ -1762,48 +1763,48 @@ digestmd5_privacy_encode(void *context,
 			   6 +                        /* for padding */
 			   1));                       /* trailing null */
     if(ret != SASL_OK) return ret;
-    
+
     /* skip by the length for now */
     out = (text->encode_buf)+4;
-    
+
     /* construct (seqnum, msg) */
     /* We can just use the output buffer because it's big enough */
     tmpnum = htonl(text->seqnum);
     memcpy(text->encode_buf, &tmpnum, 4);
     memcpy(text->encode_buf + 4, inblob->data, inblob->curlen);
-    
+
     /* HMAC(ki, (seqnum, msg) ) */
     text->utils->hmac_md5((const unsigned char *) text->encode_buf,
-			  inblob->curlen + 4, 
+			  inblob->curlen + 4,
 			  text->Ki_send, HASHLEN, digest);
-    
+
     /* calculate the encrypted part */
     text->cipher_enc(text, inblob->data, inblob->curlen,
 		     digest, out, outputlen);
     out+=(*outputlen);
-    
+
     /* copy in version */
     tmpshort = htons(version);
     memcpy(out, &tmpshort, 2);	/* 2 bytes = version */
-    
+
     out+=2;
     (*outputlen)+=2; /* for version */
-    
+
     /* put in seqnum */
     tmpnum = htonl(text->seqnum);
-    memcpy(out, &tmpnum, 4);	/* 4 bytes = seq # */  
-    
+    memcpy(out, &tmpnum, 4);	/* 4 bytes = seq # */
+
     (*outputlen)+=4; /* for seqnum */
-    
+
     /* put the 1st 4 bytes in */
-    tmp=htonl(*outputlen);  
+    tmp=htonl(*outputlen);
     memcpy(text->encode_buf, &tmp, 4);
-    
+
     (*outputlen)+=4;
-    
+
     *output = text->encode_buf;
     text->seqnum++;
-    
+
     return SASL_OK;
 }
 
@@ -1821,39 +1822,39 @@ digestmd5_privacy_decode_once(void *context,
     unsigned char digest[16];
     int tmpnum;
     int lup;
-    
+
     if (text->needsize>0) /* 4 bytes for how long message is */
 	{
 	    /* if less than 4 bytes just copy those we have into text->size */
-	    if (*inputlen<4) 
+	    if (*inputlen<4)
 		tocopy=*inputlen;
 	    else
 		tocopy=4;
-	    
+
 	    if (tocopy>text->needsize)
 		tocopy=text->needsize;
-	    
+
 	    memcpy(text->sizebuf+4-text->needsize, *input, tocopy);
 	    text->needsize-=tocopy;
-	    
+
 	    *input+=tocopy;
 	    *inputlen-=tocopy;
-	    
+
 	    if (text->needsize==0) /* got all of size */
 	    {
 		memcpy(&(text->size), text->sizebuf, 4);
 		text->cursize=0;
 		text->size=ntohl(text->size);
-		
+
 		if (text->size > text->in_maxbuf) {
 		    return SASL_FAIL; /* too big probably error */
 		}
-		
+
 		if(!text->buffer)
 		    text->buffer=text->utils->malloc(text->size+5);
 		else
 		    text->buffer=text->utils->realloc(text->buffer,
-						      text->size+5);	    
+						      text->size+5);
 		if (text->buffer == NULL) return SASL_NOMEM;
 	    }
 
@@ -1861,16 +1862,16 @@ digestmd5_privacy_decode_once(void *context,
 	    *output=NULL;
 	    if (*inputlen==0) /* have to wait until next time for data */
 		return SASL_OK;
-	    
+
 	    if (text->size==0)  /* should never happen */
 		return SASL_FAIL;
 	}
-    
+
     diff=text->size - text->cursize; /* bytes need for full message */
-    
+
     if (! text->buffer)
 	return SASL_FAIL;
-    
+
     if (*inputlen < diff) /* not enough for a decode */
     {
 	memcpy(text->buffer+text->cursize, *input, *inputlen);
@@ -1881,30 +1882,30 @@ digestmd5_privacy_decode_once(void *context,
 	return SASL_OK;
     } else {
 	memcpy(text->buffer+text->cursize, *input, diff);
-	*input+=diff;      
+	*input+=diff;
 	*inputlen-=diff;
     }
-    
+
     {
 	unsigned short ver;
 	unsigned int seqnum;
 	unsigned char checkdigest[16];
-	
+
 	result = _plug_buf_alloc(text->utils, &text->decode_once_buf,
 				 &text->decode_once_buf_len,
 				 text->size-6);
 	if (result != SASL_OK)
 	    return result;
-	
+
 	*output = text->decode_once_buf;
 	*outputlen = *inputlen;
-	
+
 	result=text->cipher_dec(text,text->buffer,text->size-6,digest,
 				*output, outputlen);
-	
+
 	if (result!=SASL_OK)
 	    return result;
-	
+
 	{
 	    int i;
 	    for(i=10; i; i--) {
@@ -1912,7 +1913,7 @@ digestmd5_privacy_decode_once(void *context,
 		ver=ntohs(ver);
 	    }
 	}
-	
+
 	/* check the version number */
 	memcpy(&ver, text->buffer+text->size-6, 2);
 	ver=ntohs(ver);
@@ -1926,23 +1927,23 @@ digestmd5_privacy_decode_once(void *context,
 #endif /* _INTEGRATED_SOLARIS_ */
 	    return SASL_FAIL;
 	}
-	
+
 	/* check the CMAC */
-	
+
 	/* construct (seqnum, msg) */
 	result = _plug_buf_alloc(text->utils, &text->decode_tmp_buf,
 				 &text->decode_tmp_buf_len, *outputlen + 4);
 	if(result != SASL_OK) return result;
-	
+
 	tmpnum = htonl(text->rec_seqnum);
 	memcpy(text->decode_tmp_buf, &tmpnum, 4);
 	memcpy(text->decode_tmp_buf + 4, *output, *outputlen);
-	
+
 	/* HMAC(ki, (seqnum, msg) ) */
 	text->utils->hmac_md5((const unsigned char *) text->decode_tmp_buf,
-			      (*outputlen) + 4, 
+			      (*outputlen) + 4,
 			      text->Ki_receive, HASHLEN, checkdigest);
-	
+
 	/* now check it */
 	for (lup=0;lup<10;lup++)
 	    if (checkdigest[lup]!=digest[lup])
@@ -1956,12 +1957,12 @@ digestmd5_privacy_decode_once(void *context,
 					  "CMAC doesn't match at byte %d!", lup);
 		    return SASL_FAIL;
 #endif /* _SUN_SDK_ */
-		} 
-	
+		}
+
 	/* check the sequence number */
 	memcpy(&seqnum, text->buffer+text->size-4,4);
 	seqnum=ntohl(seqnum);
-	
+
 	if (seqnum!=text->rec_seqnum)
 	    {
 #ifdef _SUN_SDK_
@@ -1973,12 +1974,12 @@ digestmd5_privacy_decode_once(void *context,
 #endif /* _SUN_SDK_ */
 		return SASL_FAIL;
 	    }
-	
+
 	text->rec_seqnum++; /* now increment it */
     }
-    
+
     text->needsize=4;
-    
+
     return SASL_OK;
 }
 
@@ -1988,13 +1989,13 @@ static int digestmd5_privacy_decode(void *context,
 {
     context_t *text = (context_t *) context;
     int ret;
-    
+
     ret = _plug_decode(text->utils, context, input, inputlen,
 		       &text->decode_buf, &text->decode_buf_len, outputlen,
 		       digestmd5_privacy_decode_once);
-    
+
     *output = text->decode_buf;
-    
+
     return ret;
 }
 
@@ -2011,12 +2012,12 @@ digestmd5_integrity_encode(void *context,
     unsigned short int tmpshort;
     struct buffer_info *inblob, bufinfo;
     int ret;
-    
+
     if(!context || !invec || !numiov || !output || !outputlen) {
 	PARAMERROR( text->utils );
 	return SASL_BADPARAM;
     }
-    
+
     if (numiov > 1) {
 	ret = _plug_iovec_to_buf(text->utils, invec, numiov,
 				 &text->enc_in_buf);
@@ -2028,51 +2029,51 @@ digestmd5_integrity_encode(void *context,
 	bufinfo.curlen = invec[0].iov_len;
 	inblob = &bufinfo;
     }
-    
+
     /* construct output */
     *outputlen = 4 + inblob->curlen + 16;
-    
+
     ret = _plug_buf_alloc(text->utils, &(text->encode_buf),
 			  &(text->encode_buf_len), *outputlen);
     if(ret != SASL_OK) return ret;
-    
+
     /* construct (seqnum, msg) */
     /* we can just use the output buffer */
     tmpnum = htonl(text->seqnum);
     memcpy(text->encode_buf, &tmpnum, 4);
     memcpy(text->encode_buf + 4, inblob->data, inblob->curlen);
-    
+
     /* HMAC(ki, (seqnum, msg) ) */
 #ifdef _SUN_SDK_
     text->utils->hmac_md5((unsigned char *)text->encode_buf,
-			  inblob->curlen + 4, 
+			  inblob->curlen + 4,
 			  text->Ki_send, HASHLEN, MAC);
 #else
-    text->utils->hmac_md5(text->encode_buf, inblob->curlen + 4, 
+    text->utils->hmac_md5(text->encode_buf, inblob->curlen + 4,
 			  text->Ki_send, HASHLEN, MAC);
 #endif /* _SUN_SDK_ */
-    
+
     /* create MAC */
     tmpshort = htons(version);
     memcpy(MAC + 10, &tmpshort, MAC_OFFS);	/* 2 bytes = version */
-    
+
     tmpnum = htonl(text->seqnum);
     memcpy(MAC + 12, &tmpnum, 4);	/* 4 bytes = sequence number */
-    
+
     /* copy into output */
     tmpnum = htonl((*outputlen) - 4);
-    
+
     /* length of message in network byte order */
     memcpy(text->encode_buf, &tmpnum, 4);
     /* the message text */
     memcpy(text->encode_buf + 4, inblob->data, inblob->curlen);
     /* the MAC */
     memcpy(text->encode_buf + 4 + inblob->curlen, MAC, 16);
-    
+
     text->seqnum++;		/* add one to sequence number */
-    
+
     *output = text->encode_buf;
-    
+
     return SASL_OK;
 }
 
@@ -2084,39 +2085,39 @@ create_MAC(context_t * text,
 	   unsigned char MAC[16])
 {
     unsigned int    tmpnum;
-    unsigned short int tmpshort;  
+    unsigned short int tmpshort;
     int ret;
-    
+
     if (inputlen < 0)
 	return SASL_FAIL;
-    
+
     ret = _plug_buf_alloc(text->utils, &(text->MAC_buf),
 			  &(text->MAC_buf_len), inputlen + 4);
     if(ret != SASL_OK) return ret;
-    
+
     /* construct (seqnum, msg) */
     tmpnum = htonl(seqnum);
     memcpy(text->MAC_buf, &tmpnum, 4);
     memcpy(text->MAC_buf + 4, input, inputlen);
-    
+
     /* HMAC(ki, (seqnum, msg) ) */
 #ifdef _SUN_SDK_
-    text->utils->hmac_md5((unsigned char *)text->MAC_buf, inputlen + 4, 
+    text->utils->hmac_md5((unsigned char *)text->MAC_buf, inputlen + 4,
 			  text->Ki_receive, HASHLEN,
 			  MAC);
 #else
-    text->utils->hmac_md5(text->MAC_buf, inputlen + 4, 
+    text->utils->hmac_md5(text->MAC_buf, inputlen + 4,
 			  text->Ki_receive, HASHLEN,
 			  MAC);
 #endif /* _SUN_SDK_ */
-    
+
     /* create MAC */
     tmpshort = htons(version);
     memcpy(MAC + 10, &tmpshort, 2);	/* 2 bytes = version */
-    
+
     tmpnum = htonl(seqnum);
     memcpy(MAC + 12, &tmpnum, 4);	/* 4 bytes = sequence number */
-    
+
     return SASL_OK;
 }
 
@@ -2127,11 +2128,11 @@ check_integrity(context_t * text,
 {
     unsigned char MAC[16];
     int result;
-    
+
     result = create_MAC(text, buf, bufsize - 16, text->rec_seqnum, MAC);
     if (result != SASL_OK)
 	return result;
-    
+
     /* make sure the MAC is right */
     if (strncmp((char *) MAC, buf + bufsize - 16, 16) != 0)
     {
@@ -2144,21 +2145,21 @@ check_integrity(context_t * text,
 	return SASL_FAIL;
 #endif /* _SUN_SDK_ */
     }
-    
+
     text->rec_seqnum++;
-    
+
     /* ok make output message */
     result = _plug_buf_alloc(text->utils, &text->decode_once_buf,
 			     &text->decode_once_buf_len,
 			     bufsize - 15);
     if (result != SASL_OK)
 	return result;
-    
+
     *output = text->decode_once_buf;
     memcpy(*output, buf, bufsize - 16);
     *outputlen = bufsize - 16;
     (*output)[*outputlen] = 0;
-    
+
     return SASL_OK;
 }
 
@@ -2173,7 +2174,7 @@ digestmd5_integrity_decode_once(void *context,
     unsigned int    tocopy;
     unsigned        diff;
     int             result;
-    
+
     if (text->needsize > 0) {	/* 4 bytes for how long message is */
 	/*
 	 * if less than 4 bytes just copy those we have into text->size
@@ -2182,24 +2183,24 @@ digestmd5_integrity_decode_once(void *context,
 	    tocopy = *inputlen;
 	else
 	    tocopy = 4;
-	
+
 	if (tocopy > text->needsize)
 	    tocopy = text->needsize;
-	
+
 	memcpy(text->sizebuf + 4 - text->needsize, *input, tocopy);
 	text->needsize -= tocopy;
-	
+
 	*input += tocopy;
 	*inputlen -= tocopy;
-	
+
 	if (text->needsize == 0) {	/* got all of size */
 	    memcpy(&(text->size), text->sizebuf, 4);
 	    text->cursize = 0;
 	    text->size = ntohl(text->size);
-	    
+
 	    if (text->size > text->in_maxbuf)
 		return SASL_FAIL;	/* too big probably error */
-	    
+
 	    if(!text->buffer)
 		text->buffer=text->utils->malloc(text->size+5);
 	    else
@@ -2210,15 +2211,15 @@ digestmd5_integrity_decode_once(void *context,
 	*output = NULL;
 	if (*inputlen == 0)		/* have to wait until next time for data */
 	    return SASL_OK;
-	
+
 	if (text->size == 0)	/* should never happen */
 	    return SASL_FAIL;
     }
     diff = text->size - text->cursize;	/* bytes need for full message */
-    
+
     if(! text->buffer)
 	return SASL_FAIL;
-    
+
     if (*inputlen < diff) {	/* not enough for a decode */
 	memcpy(text->buffer + text->cursize, *input, *inputlen);
 	text->cursize += *inputlen;
@@ -2231,7 +2232,7 @@ digestmd5_integrity_decode_once(void *context,
 	*input += diff;
 	*inputlen -= diff;
     }
-    
+
     result = check_integrity(text, text->buffer, text->size,
 			     output, outputlen);
     if (result != SASL_OK)
@@ -2239,7 +2240,7 @@ digestmd5_integrity_decode_once(void *context,
 
     /* Reset State */
     text->needsize = 4;
-    
+
     return SASL_OK;
 }
 
@@ -2249,13 +2250,13 @@ static int digestmd5_integrity_decode(void *context,
 {
     context_t *text = (context_t *) context;
     int ret;
-    
+
     ret = _plug_decode(text->utils, context, input, inputlen,
 		       &text->decode_buf, &text->decode_buf_len, outputlen,
 		       digestmd5_integrity_decode_once);
-    
+
     *output = text->decode_buf;
-    
+
     return ret;
 }
 
@@ -2263,19 +2264,19 @@ static void
 digestmd5_common_mech_dispose(void *conn_context, const sasl_utils_t *utils)
 {
     context_t *text = (context_t *) conn_context;
-    
+
     if (!text || !utils) return;
-    
+
     if (text->authid) utils->free(text->authid);
     if (text->realm) utils->free(text->realm);
     if (text->nonce) utils->free(text->nonce);
     if (text->cnonce) utils->free(text->cnonce);
 
     if (text->cipher_free) text->cipher_free(text);
-    
+
     /* free the stuff in the context */
     if (text->response_value) utils->free(text->response_value);
-    
+
     if (text->buffer) utils->free(text->buffer);
     if (text->encode_buf) utils->free(text->encode_buf);
     if (text->decode_buf) utils->free(text->decode_buf);
@@ -2283,12 +2284,12 @@ digestmd5_common_mech_dispose(void *conn_context, const sasl_utils_t *utils)
     if (text->decode_tmp_buf) utils->free(text->decode_tmp_buf);
     if (text->out_buf) utils->free(text->out_buf);
     if (text->MAC_buf) utils->free(text->MAC_buf);
-    
+
     if (text->enc_in_buf) {
 	if (text->enc_in_buf->data) utils->free(text->enc_in_buf->data);
 	utils->free(text->enc_in_buf);
     }
-    
+
     utils->free(conn_context);
 }
 
@@ -2315,7 +2316,7 @@ digestmd5_common_mech_free(void *glob_context, const sasl_utils_t *utils)
 {
     reauth_cache_t *reauth_cache = (reauth_cache_t *) glob_context;
     size_t n;
-    
+
     if (!reauth_cache) return;
 
     for (n = 0; n < reauth_cache->size; n++)
@@ -2347,7 +2348,7 @@ DigestCalcHA1FromSecret(context_t * text,
 			HASHHEX SessionKey)
 {
     MD5_CTX Md5Ctx;
-    
+
     /* calculate session key */
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, HA1, HASHLEN);
@@ -2360,10 +2361,10 @@ DigestCalcHA1FromSecret(context_t * text,
 	utils->MD5Update(&Md5Ctx, authorization_id, strlen((char *) authorization_id));
     }
     utils->MD5Final(HA1, &Md5Ctx);
-    
+
     CvtHex(HA1, SessionKey);
-    
-    
+
+
     /* save HA1 because we need it to make the privacy and integrity keys */
     memcpy(text->HA1, HA1, sizeof(HASH));
 }
@@ -2383,10 +2384,10 @@ static char *create_response(context_t * text,
     HASHHEX         HEntity = "00000000000000000000000000000000";
     HASHHEX         Response;
     char           *result;
-    
+
     if (qop == NULL)
 	qop = "auth";
-    
+
     DigestCalcHA1FromSecret(text,
 			    utils,
 			    Secret,
@@ -2394,7 +2395,7 @@ static char *create_response(context_t * text,
 			    nonce,
 			    cnonce,
 			    SessionKey);
-    
+
     DigestCalcResponse(utils,
 		       SessionKey,/* H(A1) */
 		       nonce,	/* nonce from server */
@@ -2407,7 +2408,7 @@ static char *create_response(context_t * text,
 		       HEntity,	/* H(entity body) if qop="auth-int" */
 		       Response	/* request-digest or response-digest */
 	);
-    
+
     result = utils->malloc(HASHHEXLEN + 1);
 #ifdef _SUN_SDK_
     if (result == NULL)
@@ -2416,7 +2417,7 @@ static char *create_response(context_t * text,
 /* TODO */
     memcpy(result, Response, HASHHEXLEN);
     result[HASHHEXLEN] = 0;
-    
+
     /* response_value (used for reauth i think */
     if (response_value != NULL) {
 	DigestCalcResponse(utils,
@@ -2431,7 +2432,7 @@ static char *create_response(context_t * text,
 			   HEntity,	/* H(entity body) if qop="auth-int" */
 			   Response	/* request-digest or response-digest */
 	    );
-	
+
 	*response_value = utils->malloc(HASHHEXLEN + 1);
 	if (*response_value == NULL)
 	    return NULL;
@@ -2472,7 +2473,7 @@ get_server_realm(sasl_server_params_t * params,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
     return SASL_OK;
 }
 
@@ -2483,7 +2484,7 @@ static int htoi(unsigned char *hexin, unsigned int *res)
 {
     int             lup, inlen;
     inlen = strlen((char *) hexin);
-    
+
     *res = 0;
     for (lup = 0; lup < inlen; lup++) {
 	switch (hexin[lup]) {
@@ -2499,7 +2500,7 @@ static int htoi(unsigned char *hexin, unsigned int *res)
 	case '9':
 	    *res = (*res << 4) + (hexin[lup] - '0');
 	    break;
-	    
+
 	case 'a':
 	case 'b':
 	case 'c':
@@ -2508,7 +2509,7 @@ static int htoi(unsigned char *hexin, unsigned int *res)
 	case 'f':
 	    *res = (*res << 4) + (hexin[lup] - 'a' + 10);
 	    break;
-	    
+
 	case 'A':
 	case 'B':
 	case 'C':
@@ -2517,13 +2518,13 @@ static int htoi(unsigned char *hexin, unsigned int *res)
 	case 'F':
 	    *res = (*res << 4) + (hexin[lup] - 'A' + 10);
 	    break;
-	    
+
 	default:
 	    return SASL_BADPARAM;
 	}
-	
+
     }
-    
+
     return SASL_OK;
 }
 
@@ -2534,17 +2535,17 @@ static int digestmd5_server_mech_new(void *glob_context,
 				     void **conn_context)
 {
     context_t *text;
-    
+
     /* holds state are in -- allocate server size */
     text = sparams->utils->malloc(sizeof(server_context_t));
     if (text == NULL)
 	return SASL_NOMEM;
     memset(text, 0, sizeof(server_context_t));
-    
+
     text->state = 1;
     text->i_am = SERVER;
     text->reauth = glob_context;
-    
+
     *conn_context = text;
     return SASL_OK;
 }
@@ -2568,14 +2569,14 @@ digestmd5_server_mech_step1(server_context_t *stext,
     unsigned       resplen;
     int added_conf = 0;
     char maxbufstr[64];
-    
+
     sparams->utils->log(sparams->utils->conn, SASL_LOG_DEBUG,
 			"DIGEST-MD5 server step 1");
 
     /* get realm */
     result = get_server_realm(sparams, &realm);
     if(result != SASL_OK) return result;
-    
+
     /* what options should we offer the client? */
     qop[0] = '\0';
     cipheropts[0] = '\0';
@@ -2587,7 +2588,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 	if (*qop) strcat(qop, ",");
 	strcat(qop, "auth-int");
     }
-    
+
 #ifdef USE_UEF_SERVER
     cipher = available_ciphers1;
 #else
@@ -2615,18 +2616,18 @@ digestmd5_server_mech_step1(server_context_t *stext,
 	}
 	cipher++;
     }
-    
+
     if (*qop == '\0') {
 	/* we didn't allow anything?!? we'll return SASL_TOOWEAK, since
 	   that's close enough */
 	return SASL_TOOWEAK;
     }
-    
+
     /*
      * digest-challenge  = 1#( realm | nonce | qop-options | stale | maxbuf |
      * charset | cipher-opts | auth-param )
      */
-    
+
 #ifndef _SUN_SDK_
     /* FIXME: get nonce XXX have to clean up after self if fail */
 #endif /* !_SUN_SDK_ */
@@ -2641,7 +2642,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
 #ifdef _SUN_SDK_
     resplen = strlen((char *)nonce) + strlen("nonce") + 5;
 #else
@@ -2657,9 +2658,9 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #else
     if(result != SASL_OK) return result;
 #endif /* _SUN_SDK_ */
-    
+
     sprintf(text->out_buf, "nonce=\"%s\"", nonce);
-    
+
     /* add to challenge; if we chose not to specify a realm, we won't
      * send one to the client */
     if (realm && add_to_challenge(sparams->utils,
@@ -2682,11 +2683,11 @@ digestmd5_server_mech_step1(server_context_t *stext,
      * authentication with integrity protection; the value "auth-conf"
      * indicates authentication with integrity protection and encryption.
      */
-    
+
     /* add qop to challenge */
     if (add_to_challenge(sparams->utils,
 			 &text->out_buf, &text->out_buf_len, &resplen,
-			 "qop", 
+			 "qop",
 			 (unsigned char *) qop, TRUE) != SASL_OK) {
 #ifdef _SUN_SDK_
 	sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -2697,7 +2698,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
     /*
      *  Cipheropts - list of ciphers server supports
      */
@@ -2706,7 +2707,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 	{
 	    if (add_to_challenge(sparams->utils,
 				 &text->out_buf, &text->out_buf_len, &resplen,
-				 "cipher", (unsigned char *) cipheropts, 
+				 "cipher", (unsigned char *) cipheropts,
 				 TRUE) != SASL_OK) {
 #ifdef _SUN_SDK_
 		sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -2719,7 +2720,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 		return SASL_FAIL;
 	    }
 	}
-    
+
     /* "stale" is true if a reauth failed because of a nonce timeout */
     if (stext->stale &&
 	add_to_challenge(sparams->utils,
@@ -2735,7 +2736,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
     /*
      * maxbuf A number indicating the size of the largest buffer the server
      * is able to receive when using "auth-int". If this directive is
@@ -2748,7 +2749,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 		 sparams->props.maxbufsize);
 	if (add_to_challenge(sparams->utils,
 			     &text->out_buf, &text->out_buf_len, &resplen,
-			     "maxbuf", 
+			     "maxbuf",
 			     (unsigned char *) maxbufstr, FALSE) != SASL_OK) {
 #ifdef _SUN_SDK_
 	    sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -2760,11 +2761,11 @@ digestmd5_server_mech_step1(server_context_t *stext,
 	    return SASL_FAIL;
 	}
     }
-    
+
 
     if (add_to_challenge(sparams->utils,
 			 &text->out_buf, &text->out_buf_len, &resplen,
-			 "charset", 
+			 "charset",
 			 (unsigned char *) charset, FALSE) != SASL_OK) {
 #ifdef _SUN_SDK_
 	sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -2775,19 +2776,19 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
-    
+
+
     /*
-     * algorithm 
-     *  This directive is required for backwards compatibility with HTTP 
-     *  Digest., which supports other algorithms. . This directive is 
-     *  required and MUST appear exactly once; if not present, or if multiple 
-     *  instances are present, the client should abort the authentication 
-     *  exchange. 
+     * algorithm
+     *  This directive is required for backwards compatibility with HTTP
+     *  Digest., which supports other algorithms. . This directive is
+     *  required and MUST appear exactly once; if not present, or if multiple
+     *  instances are present, the client should abort the authentication
+     *  exchange.
      *
-     * algorithm         = "algorithm" "=" "md5-sess" 
+     * algorithm         = "algorithm" "=" "md5-sess"
      */
-    
+
     if (add_to_challenge(sparams->utils,
 			 &text->out_buf, &text->out_buf_len, &resplen,
 			 "algorithm",
@@ -2801,7 +2802,7 @@ digestmd5_server_mech_step1(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
     /*
      * The size of a digest-challenge MUST be less than 2048 bytes!!!
      */
@@ -2823,12 +2824,12 @@ digestmd5_server_mech_step1(server_context_t *stext,
     text->nonce_count = 1;
     text->cnonce = NULL;
     stext->timestamp = time(0);
-    
+
     *serveroutlen = strlen(text->out_buf);
     *serverout = text->out_buf;
-    
+
     text->state = 2;
-    
+
     return SASL_CONTINUE;
 }
 
@@ -2854,28 +2855,28 @@ digestmd5_server_mech_step2(server_context_t *stext,
     char           *qop = NULL;
     char           *digesturi = NULL;
     char           *response = NULL;
-    
+
     /* setting the default value (65536) */
     unsigned int    client_maxbuf = 65536;
     int             maxbuf_count = 0;  /* How many maxbuf instaces was found */
-    
+
     char           *charset = NULL;
     char           *cipher = NULL;
     unsigned int   n=0;
-    
+
     HASH            A1;
-    
+
     /* password prop_request */
     const char *password_request[] = { SASL_AUX_PASSWORD,
 				       "*cmusaslsecretDIGEST-MD5",
 				       NULL };
     unsigned len;
     struct propval auxprop_values[2];
-    
+
     /* can we mess with clientin? copy it to be safe */
     char           *in_start = NULL;
-    char           *in = NULL; 
-    
+    char           *in = NULL;
+
     sparams->utils->log(sparams->utils->conn, SASL_LOG_DEBUG,
 			"DIGEST-MD5 server step 2");
 
@@ -2883,29 +2884,29 @@ digestmd5_server_mech_step2(server_context_t *stext,
 #ifdef _SUN_SDK_
     if (!in) return SASL_NOMEM;
 #endif /* _SUN_SDK_ */
-    
+
     memcpy(in, clientin, clientinlen);
     in[clientinlen] = 0;
-    
+
     in_start = in;
-    
-    
+
+
     /* parse what we got */
     while (in[0] != '\0') {
 	char           *name = NULL, *value = NULL;
 	get_pair(&in, &name, &value);
-	
+
 	if (name == NULL)
 	    break;
-	
+
 	/* Extracting parameters */
-	
+
 	/*
 	 * digest-response  = 1#( username | realm | nonce | cnonce |
 	 * nonce-count | qop | digest-uri | response | maxbuf | charset |
 	 * cipher | auth-param )
 	 */
-	
+
 	if (strcasecmp(name, "username") == 0) {
 	    _plug_strdup(sparams->utils, value, &username, NULL);
 	} else if (strcasecmp(name, "authzid") == 0) {
@@ -2947,7 +2948,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    /*
 	     * digest-uri-value  = serv-type "/" host [ "/" serv-name ]
 	     */
- 
+
 	    _plug_strdup(sparams->utils, value, &digesturi, NULL);
 
 	    /* verify digest-uri format */
@@ -2961,14 +2962,14 @@ digestmd5_server_mech_step2(server_context_t *stext,
 		sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
 				    "bad digest-uri: doesn't match service");
 #else
-                SETERROR(sparams->utils, 
+                SETERROR(sparams->utils,
                          "bad digest-uri: doesn't match service");
 #endif /* _SUN_SDK_ */
                 goto FreeAllMem;
             }
 
             /* xxx we don't verify the hostname component */
-            
+
 	} else if (strcasecmp(name, "response") == 0) {
 	    _plug_strdup(sparams->utils, value, &response, NULL);
 	} else if (strcasecmp(name, "cipher") == 0) {
@@ -3025,7 +3026,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 				name, value);
 	}
     }
-    
+
     /*
      * username         = "username" "=" <"> username-value <">
      * username-value   = qdstr-val cnonce           = "cnonce" "=" <">
@@ -3144,7 +3145,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	result = SASL_BADAUTH;
 	goto FreeAllMem;
     }
-	    
+
     result = sparams->utils->prop_request(sparams->propctx, password_request);
     if(result != SASL_OK) {
 #ifdef _SUN_SDK_
@@ -3155,7 +3156,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	goto FreeAllMem;
     }
-    
+
     /* this will trigger the getting of the aux properties */
     /* Note that if we don't have an authorization id, we don't use it... */
     result = sparams->canon_user(sparams->utils->conn,
@@ -3169,7 +3170,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	goto FreeAllMem;
     }
-    
+
     if (!authorization_id || !*authorization_id) {
 	result = sparams->canon_user(sparams->utils->conn,
 				     username, 0, SASL_CU_AUTHZID, oparams);
@@ -3178,7 +3179,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 				     authorization_id, 0, SASL_CU_AUTHZID,
 				     oparams);
     }
-    
+
     if (result != SASL_OK) {
 #ifdef _SUN_SDK_
 	sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -3188,7 +3189,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 #endif /* _SUN_SDK_ */
 	goto FreeAllMem;
     }
-    
+
     result = sparams->utils->prop_getnames(sparams->propctx, password_request,
 					   auxprop_values);
     if (result < 0 ||
@@ -3205,7 +3206,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	result = SASL_NOUSER;
 	goto FreeAllMem;
     }
-    
+
     if (auxprop_values[0].name && auxprop_values[0].values) {
 	len = strlen(auxprop_values[0].values[0]);
 	if (len == 0) {
@@ -3219,7 +3220,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    result = SASL_FAIL;
 	    goto FreeAllMem;
 	}
-	
+
 	sec = sparams->utils->malloc(sizeof(sasl_secret_t) + len);
 	if (!sec) {
 #ifdef _SUN_SDK_
@@ -3231,25 +3232,25 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    result = SASL_FAIL;
 	    goto FreeAllMem;
 	}
-	
+
 	sec->len = len;
 #ifdef _SUN_SDK_
-	strncpy((char *)sec->data, auxprop_values[0].values[0], len + 1); 
+	strncpy((char *)sec->data, auxprop_values[0].values[0], len + 1);
 #else
-	strncpy(sec->data, auxprop_values[0].values[0], len + 1); 
+	strncpy(sec->data, auxprop_values[0].values[0], len + 1);
 #endif /* _SUN_SDK_ */
-	
+
 	/*
 	 * Verifying response obtained from client
-	 * 
+	 *
 	 * H_URP = H({ username-value,":",realm-value,":",passwd}) sec->data
 	 * contains H_URP
 	 */
-	
+
 	/* Calculate the secret from the plaintext password */
 	{
 	    HASH HA1;
-	    
+
 #ifdef _SUN_SDK_
 	    DigestCalcSecret(sparams->utils, (unsigned char *)username,
 			     (unsigned char *)text->realm, sec->data,
@@ -3258,16 +3259,16 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    DigestCalcSecret(sparams->utils, username,
 			     text->realm, sec->data, sec->len, HA1);
 #endif /* _SUN_SDK_ */
-	    
+
 	    /*
 	     * A1 = { H( { username-value, ":", realm-value, ":", passwd } ),
 	     * ":", nonce-value, ":", cnonce-value }
 	     */
-	    
+
 	    memcpy(A1, HA1, HASHLEN);
 	    A1[HASHLEN] = '\0';
 	}
-	
+
 	/* We're done with sec now. Let's get rid of it */
 	_plug_free_secret(sparams->utils, &sec);
     } else if (auxprop_values[1].name && auxprop_values[1].values) {
@@ -3287,18 +3288,18 @@ digestmd5_server_mech_step2(server_context_t *stext,
 #else
 	return SASL_FAIL;
 #endif /* _SUN_SDK_ */
-    } 
-    
+    }
+
     /* defaulting qop to "auth" if not specified */
     if (qop == NULL) {
-	_plug_strdup(sparams->utils, "auth", &qop, NULL);      
+	_plug_strdup(sparams->utils, "auth", &qop, NULL);
     }
-    
+
     /* check which layer/cipher to use */
     if ((!strcasecmp(qop, "auth-conf")) && (cipher != NULL)) {
 	/* see what cipher was requested */
 	struct digest_cipher *cptr;
-	
+
 #ifdef USE_UEF_SERVER
 	cptr = available_ciphers1;
 #else
@@ -3307,7 +3308,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	while (cptr->name) {
 	    /* find the cipher requested & make sure it's one we're happy
 	       with by policy */
-	    if (!strcasecmp(cipher, cptr->name) && 
+	    if (!strcasecmp(cipher, cptr->name) &&
 		stext->requiressf <= cptr->ssf &&
 		stext->limitssf >= cptr->ssf) {
 		/* found it! */
@@ -3315,7 +3316,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    }
 	    cptr++;
 	}
-	
+
 	if (cptr->name) {
 	    text->cipher_enc = cptr->cipher_enc;
 	    text->cipher_dec = cptr->cipher_dec;
@@ -3335,7 +3336,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    result = SASL_FAIL;
 	    goto FreeAllMem;
 	}
-	
+
 	oparams->encode=&digestmd5_privacy_encode;
 	oparams->decode=&digestmd5_privacy_decode;
     } else if (!strcasecmp(qop, "auth-int") &&
@@ -3358,7 +3359,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	result = SASL_FAIL;
 	goto FreeAllMem;
     }
-    
+
     serverresponse = create_response(text,
 				     sparams->utils,
 				     text->nonce,
@@ -3369,7 +3370,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 				     A1,
 				     authorization_id,
 				     &text->response_value);
-    
+
     if (serverresponse == NULL) {
 #ifndef _SUN_SDK_
 	SETERROR(sparams->utils, "internal error: unable to create response");
@@ -3377,7 +3378,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	result = SASL_NOMEM;
 	goto FreeAllMem;
     }
-    
+
     /* if ok verified */
     if (strcmp(serverresponse, response) != 0) {
 #ifdef _INTEGRATED_SOLARIS_
@@ -3388,7 +3389,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 		 "client response doesn't match what we generated");
 #endif /* _INTEGRATED_SOLARIS_ */
 	result = SASL_BADAUTH;
-	
+
 	goto FreeAllMem;
     }
 
@@ -3430,25 +3431,25 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	/* MAC block (integrity) */
 	oparams->maxoutbuf -= 16;
     }
-    
+
     oparams->param_version = 0;
-    
+
     text->seqnum = 0;		/* for integrity/privacy */
     text->rec_seqnum = 0;	/* for integrity/privacy */
     text->in_maxbuf =
        sparams->props.maxbufsize ? sparams->props.maxbufsize : DEFAULT_BUFSIZE;
     text->utils = sparams->utils;
-    
+
     /* used by layers */
     text->needsize = 4;
     text->buffer = NULL;
-    
+
     if (oparams->mech_ssf > 0) {
 	char enckey[16];
 	char deckey[16];
-	
+
 	create_layer_keys(text, sparams->utils,text->HA1,n,enckey,deckey);
-	
+
 	/* initialize cipher if need be */
 #ifdef _SUN_SDK_
 	if (text->cipher_init) {
@@ -3468,13 +3469,13 @@ digestmd5_server_mech_step2(server_context_t *stext,
 	    }
 #endif /* _SUN_SDK_ */
     }
-    
+
     /*
      * The server receives and validates the "digest-response". The server
      * checks that the nonce-count is "00000001". If it supports subsequent
      * authentication, it saves the value of the nonce and the nonce-count.
      */
-    
+
     /*
      * The "username-value", "realm-value" and "passwd" are encoded according
      * to the value of the "charset" directive. If "charset=UTF-8" is
@@ -3483,30 +3484,30 @@ digestmd5_server_mech_step2(server_context_t *stext,
      * UTF-8 before being hashed. A sample implementation of this conversion
      * is in section 8.
      */
-    
+
     /* add to challenge */
     {
 	unsigned resplen =
 	    strlen(text->response_value) + strlen("rspauth") + 3;
-	
+
 	result = _plug_buf_alloc(sparams->utils, &(text->out_buf),
 				 &(text->out_buf_len), resplen);
 	if(result != SASL_OK) {
 	    goto FreeAllMem;
 	}
-	
+
 	sprintf(text->out_buf, "rspauth=%s", text->response_value);
-	
+
 	/* self check */
 	if (strlen(text->out_buf) > 2048) {
 	    result = SASL_FAIL;
 	    goto FreeAllMem;
 	}
     }
-    
+
     *serveroutlen = strlen(text->out_buf);
     *serverout = text->out_buf;
-	
+
     result = SASL_OK;
 
   FreeAllMem:
@@ -3548,7 +3549,7 @@ digestmd5_server_mech_step2(server_context_t *stext,
 
     /* free everything */
     if (in_start) sparams->utils->free (in_start);
-    
+
     if (username != NULL)
 	sparams->utils->free (username);
 #ifdef _SUN_SDK_
@@ -3572,10 +3573,10 @@ digestmd5_server_mech_step2(server_context_t *stext,
     if (digesturi != NULL)
 	sparams->utils->free (digesturi);
     if (qop!=NULL)
-	sparams->utils->free (qop);  
+	sparams->utils->free (qop);
     if (sec)
 	_plug_free_secret(sparams->utils, &sec);
-    
+
     return result;
 }
 
@@ -3590,14 +3591,14 @@ digestmd5_server_mech_step(void *conn_context,
 {
     context_t *text = (context_t *) conn_context;
     server_context_t *stext = (server_context_t *) conn_context;
-    
+
     if (clientinlen > 4096) return SASL_BADPROT;
-    
+
     *serverout = NULL;
     *serveroutlen = 0;
-    
+
     switch (text->state) {
-	
+
     case 1:
 	/* setup SSF limits */
 	if (!sparams->props.maxbufsize) {
@@ -3644,12 +3645,12 @@ digestmd5_server_mech_step(void *conn_context,
 	return digestmd5_server_mech_step1(stext, sparams,
 					   clientin, clientinlen,
 					   serverout, serveroutlen, oparams);
-	
+
     case 2:
 	return digestmd5_server_mech_step2(stext, sparams,
 					   clientin, clientinlen,
 					   serverout, serveroutlen, oparams);
-	
+
     default:
 #ifdef _SUN_SDK_
 	sparams->utils->log(sparams->utils->conn, SASL_LOG_ERR,
@@ -3660,7 +3661,7 @@ digestmd5_server_mech_step(void *conn_context,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
 #ifndef _SUN_SDK_
     return SASL_FAIL; /* should never get here */
 #endif /* !_SUN_SDK_ */
@@ -3670,9 +3671,9 @@ static void
 digestmd5_server_mech_dispose(void *conn_context, const sasl_utils_t *utils)
 {
     server_context_t *stext = (server_context_t *) conn_context;
-    
+
     if (!stext || !utils) return;
-    
+
     digestmd5_common_mech_dispose(conn_context, utils);
 }
 
@@ -3684,7 +3685,7 @@ static sasl_server_plug_t digestmd5_server_plugins[] =
 	128,				/* max_ssf */
 #elif WITH_DES
 	112,
-#else 
+#else
 	0,
 #endif
 	SASL_SEC_NOPLAINTEXT
@@ -3708,7 +3709,7 @@ int digestmd5_server_plug_init(sasl_utils_t *utils,
 			       int maxversion,
 			       int *out_version,
 			       sasl_server_plug_t **pluglist,
-			       int *plugcount) 
+			       int *plugcount)
 {
     reauth_cache_t *reauth_cache;
     const char *timeout = NULL;
@@ -3778,7 +3779,7 @@ int digestmd5_server_plug_init(sasl_utils_t *utils,
     *out_version = SASL_SERVER_PLUG_VERSION;
     *pluglist = digestmd5_server_plugins;
     *plugcount = 1;
-    
+
     return SASL_OK;
 }
 
@@ -3812,14 +3813,14 @@ DigestCalcHA1(context_t * text,
 {
     MD5_CTX         Md5Ctx;
     HASH            HA1;
-    
+
     DigestCalcSecret(utils,
 		     pszUserName,
 		     pszRealm,
 		     (unsigned char *) pszPassword->data,
 		     pszPassword->len,
 		     HA1);
-    
+
     /* calculate the session key */
     utils->MD5Init(&Md5Ctx);
     utils->MD5Update(&Md5Ctx, HA1, HASHLEN);
@@ -3829,18 +3830,18 @@ DigestCalcHA1(context_t * text,
     utils->MD5Update(&Md5Ctx, pszCNonce, strlen((char *) pszCNonce));
     if (pszAuthorization_id != NULL) {
 	utils->MD5Update(&Md5Ctx, COLON, 1);
-	utils->MD5Update(&Md5Ctx, pszAuthorization_id, 
+	utils->MD5Update(&Md5Ctx, pszAuthorization_id,
 			 strlen((char *) pszAuthorization_id));
     }
     utils->MD5Final(HA1, &Md5Ctx);
-    
+
     CvtHex(HA1, SessionKey);
-    
+
     /* xxx rc-* use different n */
-    
+
     /* save HA1 because we'll need it for the privacy and integrity keys */
     memcpy(text->HA1, HA1, sizeof(HASH));
-    
+
 }
 
 static char *calculate_response(context_t * text,
@@ -3860,23 +3861,23 @@ static char *calculate_response(context_t * text,
     HASHHEX         HEntity = "00000000000000000000000000000000";
     HASHHEX         Response;
     char           *result;
-    
+
     /* Verifing that all parameters was defined */
     if(!username || !cnonce || !nonce || !ncvalue || !digesturi || !passwd) {
 	PARAMERROR( utils );
 	return NULL;
     }
-    
+
     if (realm == NULL) {
 	/* a NULL realm is equivalent to the empty string */
 	realm = (unsigned char *) "";
     }
-    
+
     if (qop == NULL) {
 	/* default to a qop of just authentication */
 	qop = "auth";
     }
-    
+
     DigestCalcHA1(text,
 		  utils,
 		  username,
@@ -3886,7 +3887,7 @@ static char *calculate_response(context_t * text,
 		  nonce,
 		  cnonce,
 		  SessionKey);
-    
+
     DigestCalcResponse(utils,
 		       SessionKey,/* H(A1) */
 		       nonce,	/* nonce from server */
@@ -3899,7 +3900,7 @@ static char *calculate_response(context_t * text,
 		       HEntity,	/* H(entity body) if qop="auth-int" */
 		       Response	/* request-digest or response-digest */
 	);
-    
+
     result = utils->malloc(HASHHEXLEN + 1);
 #ifdef _SUN_SDK_
     if (result == NULL)
@@ -3907,7 +3908,7 @@ static char *calculate_response(context_t * text,
 #endif /* _SUN_SDK_ */
     memcpy(result, Response, HASHHEXLEN);
     result[HASHHEXLEN] = 0;
-    
+
     if (response_value != NULL) {
 	DigestCalcResponse(utils,
 			   SessionKey,	/* H(A1) */
@@ -3921,7 +3922,7 @@ static char *calculate_response(context_t * text,
 			   HEntity,	/* H(entity body) if qop="auth-int" */
 			   Response	/* request-digest or response-digest */
 	    );
-	
+
 #ifdef _SUN_SDK_
 	if (*response_value != NULL)
 	    utils->free(*response_value);
@@ -3929,12 +3930,12 @@ static char *calculate_response(context_t * text,
 	*response_value = utils->malloc(HASHHEXLEN + 1);
 	if (*response_value == NULL)
 	    return NULL;
-	
+
 	memcpy(*response_value, Response, HASHHEXLEN);
 	(*response_value)[HASHHEXLEN] = 0;
-	
+
     }
-    
+
     return result;
 }
 
@@ -3957,7 +3958,7 @@ make_client_response(context_t *text,
     switch (ctext->protection) {
     case DIGEST_PRIVACY:
 	qop = "auth-conf";
-	oparams->encode = &digestmd5_privacy_encode; 
+	oparams->encode = &digestmd5_privacy_encode;
 	oparams->decode = &digestmd5_privacy_decode;
 	oparams->mech_ssf = ctext->cipher->ssf;
 
@@ -3988,7 +3989,7 @@ make_client_response(context_t *text,
 	result = SASL_NOMEM;
 	goto FreeAllocatedMem;
     };
-    
+
     /* allocated exactly this. safe */
     strcpy((char *) digesturi, params->service);
     strcat((char *) digesturi, "/");
@@ -4020,22 +4021,22 @@ make_client_response(context_t *text,
 			   (char *) oparams->user : NULL,
 #endif /* _SUN_SDK_ */
 			   &text->response_value);
-    
+
 #ifdef _SUN_SDK_
     if (response == NULL) {
 	result = SASL_NOMEM;
 	goto FreeAllocatedMem;
     }
 #endif /* _SUN_SDK_ */
-    
+
     resplen = strlen(oparams->authid) + strlen("username") + 5;
     result =_plug_buf_alloc(params->utils, &(text->out_buf),
 			    &(text->out_buf_len),
 			    resplen);
     if (result != SASL_OK) goto FreeAllocatedMem;
-    
+
     sprintf(text->out_buf, "username=\"%s\"", oparams->authid);
-    
+
     if (add_to_challenge(params->utils,
 			 &text->out_buf, &text->out_buf_len, &resplen,
 			 "realm", (unsigned char *) text->realm,
@@ -4084,7 +4085,7 @@ make_client_response(context_t *text,
     if (ctext->cipher != NULL) {
 	if (add_to_challenge(params->utils,
 			     &text->out_buf, &text->out_buf_len, &resplen,
-			     "cipher", 
+			     "cipher",
 			     (unsigned char *) ctext->cipher->name,
 			     TRUE) != SASL_OK) {
 	    result = SASL_FAIL;
@@ -4096,7 +4097,7 @@ make_client_response(context_t *text,
 	snprintf(maxbufstr, sizeof(maxbufstr), "%d", params->props.maxbufsize);
 	if (add_to_challenge(params->utils,
 			     &text->out_buf, &text->out_buf_len, &resplen,
-			     "maxbuf", (unsigned char *) maxbufstr, 
+			     "maxbuf", (unsigned char *) maxbufstr,
 			     FALSE) != SASL_OK) {
 #ifdef _SUN_SDK_
 	    params->utils->log(params->utils->conn, SASL_LOG_ERR,
@@ -4108,7 +4109,7 @@ make_client_response(context_t *text,
 	    goto FreeAllocatedMem;
 	}
     }
-    
+
     if (IsUTF8) {
 	if (add_to_challenge(params->utils,
 			     &text->out_buf, &text->out_buf_len, &resplen,
@@ -4128,11 +4129,11 @@ make_client_response(context_t *text,
 			 &text->out_buf, &text->out_buf_len, &resplen,
 			 "response", (unsigned char *) response,
 			 FALSE) != SASL_OK) {
-	
+
 	result = SASL_FAIL;
 	goto FreeAllocatedMem;
     }
-    
+
     /* self check */
     if (strlen(text->out_buf) > 2048) {
 	result = SASL_FAIL;
@@ -4160,25 +4161,25 @@ make_client_response(context_t *text,
 	/* MAC block (integrity) */
 	oparams->maxoutbuf -= 16;
     }
-    
+
     text->seqnum = 0;	/* for integrity/privacy */
     text->rec_seqnum = 0;	/* for integrity/privacy */
     text->utils = params->utils;
-    
+
     text->in_maxbuf =
 	params->props.maxbufsize ? params->props.maxbufsize : DEFAULT_BUFSIZE;
 
     /* used by layers */
     text->needsize = 4;
     text->buffer = NULL;
-    
+
     if (oparams->mech_ssf > 0) {
 	char enckey[16];
 	char deckey[16];
-	
+
 	create_layer_keys(text, params->utils, text->HA1, nbits,
 			  enckey, deckey);
-	
+
 	/* initialize cipher if need be */
 #ifdef _SUN_SDK_
 	if (text->cipher_init) {
@@ -4192,10 +4193,10 @@ make_client_response(context_t *text,
 	}
 #else
 	if (text->cipher_init)
-	    text->cipher_init(text, enckey, deckey);		       
+	    text->cipher_init(text, enckey, deckey);
 #endif /* _SUN_SDK_ */
     }
-    
+
     result = SASL_OK;
 
   FreeAllocatedMem:
@@ -4239,10 +4240,10 @@ static int parse_server_challenge(client_context_t *ctext,
 
     in_start = in = params->utils->malloc(serverinlen + 1);
     if (in == NULL) return SASL_NOMEM;
-    
+
     memcpy(in, serverin, serverinlen);
     in[serverinlen] = 0;
-    
+
     ctext->server_maxbuf = 65536; /* Default value for maxbuf */
 
     /* create a new cnonce */
@@ -4262,9 +4263,9 @@ static int parse_server_challenge(client_context_t *ctext,
     /* parse the challenge */
     while (in[0] != '\0') {
 	char *name, *value;
-	
+
 	get_pair(&in, &name, &value);
-	
+
 	/* if parse error */
 	if (name == NULL) {
 #ifdef _SUN_SDK_
@@ -4276,21 +4277,21 @@ static int parse_server_challenge(client_context_t *ctext,
 	    result = SASL_FAIL;
 	    goto FreeAllocatedMem;
 	}
-	
+
 	if (strcasecmp(name, "realm") == 0) {
 	    nrealm++;
-	    
+
 	    if(!realms)
 		realms = params->utils->malloc(sizeof(char *) * (nrealm + 1));
 	    else
-		realms = params->utils->realloc(realms, 
+		realms = params->utils->realloc(realms,
 						sizeof(char *) * (nrealm + 1));
-	    
+
 	    if (realms == NULL) {
 		result = SASL_NOMEM;
 		goto FreeAllocatedMem;
 	    }
-	    
+
 	    _plug_strdup(params->utils, value, &realms[nrealm-1], NULL);
 	    realms[nrealm] = NULL;
 	} else if (strcasecmp(name, "nonce") == 0) {
@@ -4303,7 +4304,7 @@ static int parse_server_challenge(client_context_t *ctext,
 		if (comma != NULL) {
 		    *comma++ = '\0';
 		}
-		
+
 		if (strcasecmp(value, "auth-conf") == 0) {
 		    protection |= DIGEST_PRIVACY;
 		} else if (strcasecmp(value, "auth-int") == 0) {
@@ -4315,10 +4316,10 @@ static int parse_server_challenge(client_context_t *ctext,
 				       "Server supports unknown layer: %s\n",
 				       value);
 		}
-		
+
 		value = comma;
 	    }
-	    
+
 	    if (protection == 0) {
 		result = SASL_BADAUTH;
 #ifdef _INTEGRATED_SOLARIS_
@@ -4338,11 +4339,11 @@ static int parse_server_challenge(client_context_t *ctext,
 #else
 		struct digest_cipher *cipher = available_ciphers;
 #endif
-		
+
 		if (comma != NULL) {
 		    *comma++ = '\0';
 		}
-		
+
 		/* do we support this cipher? */
 		while (cipher->name) {
 		    if (!strcasecmp(value, cipher->name)) break;
@@ -4355,7 +4356,7 @@ static int parse_server_challenge(client_context_t *ctext,
 				       "Server supports unknown cipher: %s\n",
 				       value);
 		}
-		
+
 		value = comma;
 	    }
 	} else if (strcasecmp(name, "stale") == 0 && ctext->password) {
@@ -4369,10 +4370,10 @@ static int parse_server_challenge(client_context_t *ctext,
 	     * "auth-int". If this directive is missing, the default
 	     * value is 65536. This directive may appear at most once;
 	     * if multiple instances are present, the client should
-	     * abort the authentication exchange.  
+	     * abort the authentication exchange.
 	     */
 	    maxbuf_count++;
-	    
+
 	    if (maxbuf_count != 1) {
 		result = SASL_BADAUTH;
 #ifdef _SUN_SDK_
@@ -4437,7 +4438,7 @@ static int parse_server_challenge(client_context_t *ctext,
 		    result = SASL_FAIL;
 		    goto FreeAllocatedMem;
 		}
-	    
+
 	    algorithm_count++;
 	    if (algorithm_count > 1)
 		{
@@ -4457,7 +4458,7 @@ static int parse_server_challenge(client_context_t *ctext,
 			       name, value);
 	}
     }
-    
+
     if (algorithm_count != 1) {
 #ifdef _SUN_SDK_
 	params->utils->log(params->utils->conn, SASL_LOG_ERR,
@@ -4485,7 +4486,7 @@ static int parse_server_challenge(client_context_t *ctext,
 
     /* get requested ssf */
     external = params->external_ssf;
-    
+
     /* what do we _need_?  how much is too much? */
     if (params->props.maxbufsize == 0) {
 	musthave = 0;
@@ -4502,12 +4503,12 @@ static int parse_server_challenge(client_context_t *ctext,
 	    musthave = 0;
 	}
     }
-    
+
     /* we now go searching for an option that gives us at least "musthave"
        and at most "limit" bits of ssf. */
     if ((limit > 1) && (protection & DIGEST_PRIVACY)) {
 	struct digest_cipher *cipher;
-	
+
 	/* let's find an encryption scheme that we like */
 #ifdef USE_UEF_CLIENT
 	cipher = available_ciphers1;
@@ -4525,7 +4526,7 @@ static int parse_server_challenge(client_context_t *ctext,
 	    }
 	    cipher++;
 	}
-	
+
 	if (ctext->cipher) {
 	    /* we found a cipher we like */
 	    ctext->protection = DIGEST_PRIVACY;
@@ -4540,12 +4541,12 @@ static int parse_server_challenge(client_context_t *ctext,
 #endif /* _INTEGRATED_SOLARIS_ */
 	}
     }
-    
+
     if (ctext->cipher == NULL) {
 	/* we failed to find an encryption layer we liked;
 	   can we use integrity or nothing? */
-	
-	if ((limit >= 1) && (musthave <= 1) 
+
+	if ((limit >= 1) && (musthave <= 1)
 	    && (protection & DIGEST_INTEGRITY)) {
 	    /* integrity */
 	    ctext->protection = DIGEST_INTEGRITY;
@@ -4560,10 +4561,10 @@ static int parse_server_challenge(client_context_t *ctext,
 	    /* See if server supports not having a layer */
 	    if ((protection & DIGEST_NOLAYER) != DIGEST_NOLAYER) {
 #ifdef _INTEGRATED_SOLARIS_
-		params->utils->seterror(params->utils->conn, 0, 
+		params->utils->seterror(params->utils->conn, 0,
 			gettext("Server doesn't support \"no layer\""));
 #else
-		params->utils->seterror(params->utils->conn, 0, 
+		params->utils->seterror(params->utils->conn, 0,
 					"Server doesn't support \"no layer\"");
 #endif /* _INTEGRATED_SOLARIS_ */
 		result = SASL_FAIL;
@@ -4590,11 +4591,11 @@ static int parse_server_challenge(client_context_t *ctext,
 
     if (result != SASL_OK && realms) {
 	int lup;
-	
+
 	/* need to free all the realms */
 	for (lup = 0;lup < nrealm; lup++)
 	    params->utils->free(realms[lup]);
-	
+
 	params->utils->free(realms);
     }
 
@@ -4619,21 +4620,21 @@ static int ask_user_info(client_context_t *ctext,
     /* try to get the authid */
     if (oparams->authid == NULL) {
 	auth_result = _plug_get_authid(params->utils, &authid, prompt_need);
-	
+
 	if ((auth_result != SASL_OK) && (auth_result != SASL_INTERACT)) {
 	    return auth_result;
 	}
     }
-    
+
     /* try to get the userid */
     if (oparams->user == NULL) {
 	user_result = _plug_get_userid(params->utils, &userid, prompt_need);
-	
+
 	if ((user_result != SASL_OK) && (user_result != SASL_INTERACT)) {
 	    return user_result;
 	}
     }
-    
+
     /* try to get the password */
     if (ctext->password == NULL) {
 	pass_result = _plug_get_password(params->utils, &ctext->password,
@@ -4666,15 +4667,15 @@ static int ask_user_info(client_context_t *ctext,
 	    } else {
 		return realm_result;
 	    }
-	}    
+	}
     }
-    
+
     /* free prompts we got */
     if (prompt_need && *prompt_need) {
 	params->utils->free(*prompt_need);
 	*prompt_need = NULL;
     }
-    
+
     /* if there are prompts not filled in */
     if ((user_result == SASL_INTERACT) || (auth_result == SASL_INTERACT) ||
 	(pass_result == SASL_INTERACT) || (realm_result == SASL_INTERACT)) {
@@ -4729,12 +4730,12 @@ static int ask_user_info(client_context_t *ctext,
 			       "Please enter your realm" : NULL,
 			       params->serverFQDN ? params->serverFQDN : NULL);
 #endif /* _INTEGRATED_SOLARIS_ */
-	
+
 	if (result == SASL_OK) return SASL_INTERACT;
 
 	return result;
     }
-    
+
     if (oparams->authid == NULL) {
 	if (!userid || !*userid) {
 	    result = params->canon_user(params->utils->conn, authid, 0,
@@ -4766,17 +4767,17 @@ digestmd5_client_mech_new(void *glob_context,
 			  void **conn_context)
 {
     context_t *text;
-    
+
     /* holds state are in -- allocate client size */
     text = params->utils->malloc(sizeof(client_context_t));
     if (text == NULL)
 	return SASL_NOMEM;
     memset(text, 0, sizeof(client_context_t));
-    
+
     text->state = 1;
     text->i_am = CLIENT;
     text->reauth = glob_context;
-    
+
     *conn_context = text;
 
     return SASL_OK;
@@ -4785,8 +4786,8 @@ digestmd5_client_mech_new(void *glob_context,
 static int
 digestmd5_client_mech_step1(client_context_t *ctext,
 			    sasl_client_params_t *params,
-			    const char *serverin __attribute__((unused)), 
-			    unsigned serverinlen __attribute__((unused)), 
+			    const char *serverin __attribute__((unused)),
+			    unsigned serverinlen __attribute__((unused)),
 			    sasl_interact_t **prompt_need,
 			    const char **clientout,
 			    unsigned *clientoutlen,
@@ -4851,7 +4852,7 @@ digestmd5_client_mech_step1(client_context_t *ctext,
      * (username | realm | nonce | cnonce | nonce-count | qop digest-uri |
      * response | maxbuf | charset | auth-param )
      */
-    
+
     result = make_client_response(text, params, oparams);
     if (result != SASL_OK) return result;
 
@@ -4889,7 +4890,7 @@ digestmd5_client_mech_step2(client_context_t *ctext,
 	result = parse_server_challenge(ctext, params, serverin, serverinlen,
 					&realms, &nrealm);
 	if (result != SASL_OK) goto FreeAllocatedMem;
-    
+
 	if (nrealm == 1) {
 	    /* only one choice! */
 	    text->realm = realms[0];
@@ -4908,7 +4909,7 @@ digestmd5_client_mech_step2(client_context_t *ctext,
      * (username | realm | nonce | cnonce | nonce-count | qop digest-uri |
      * response | maxbuf | charset | auth-param )
      */
-    
+
     result = make_client_response(text, params, oparams);
     if (result != SASL_OK) goto FreeAllocatedMem;
 
@@ -4916,17 +4917,17 @@ digestmd5_client_mech_step2(client_context_t *ctext,
     *clientout = text->out_buf;
 
     text->state = 3;
-    
+
     result = SASL_CONTINUE;
-    
+
   FreeAllocatedMem:
     if (realms) {
 	int lup;
-	
+
 	/* need to free all the realms */
 	for (lup = 0;lup < nrealm; lup++)
 	    params->utils->free(realms[lup]);
-	
+
 	params->utils->free(realms);
     }
 
@@ -4947,22 +4948,22 @@ digestmd5_client_mech_step3(client_context_t *ctext,
     char           *in = NULL;
     char           *in_start;
     int result = SASL_FAIL;
-    
+
     params->utils->log(params->utils->conn, SASL_LOG_DEBUG,
 		       "DIGEST-MD5 client step 3");
 
-    /* Verify that server is really what he claims to be */
+    /* Verify that server is really what they claim to be */
     in_start = in = params->utils->malloc(serverinlen + 1);
     if (in == NULL) return SASL_NOMEM;
 
     memcpy(in, serverin, serverinlen);
     in[serverinlen] = 0;
-    
+
     /* parse the response */
     while (in[0] != '\0') {
 	char *name, *value;
 	get_pair(&in, &name, &value);
-	
+
 	if (name == NULL) {
 #ifdef _SUN_SDK_
 	    params->utils->log(params->utils->conn, SASL_LOG_ERR,
@@ -4973,9 +4974,9 @@ digestmd5_client_mech_step3(client_context_t *ctext,
 #endif /* _SUN_SDK_ */
 	    break;
 	}
-	
+
 	if (strcasecmp(name, "rspauth") == 0) {
-	    
+
 	    if (strcmp(text->response_value, value) != 0) {
 #ifdef _INTEGRATED_SOLARIS_
 		params->utils->seterror(params->utils->conn, 0,
@@ -4988,7 +4989,7 @@ digestmd5_client_mech_step3(client_context_t *ctext,
 	    } else {
 		oparams->doneflag = 1;
 		oparams->param_version = 0;
-		
+
 		result = SASL_OK;
 	    }
 	    break;
@@ -4998,7 +4999,7 @@ digestmd5_client_mech_step3(client_context_t *ctext,
 			       name, value);
 	}
     }
-    
+
     params->utils->free(in_start);
 
     if (params->utils->mutex_lock(text->reauth->mutex) == SASL_OK) { /* LOCK */
@@ -5054,9 +5055,9 @@ digestmd5_client_mech_step(void *conn_context,
     context_t *text = (context_t *) conn_context;
     client_context_t *ctext = (client_context_t *) conn_context;
     unsigned val = hash(params->serverFQDN) % text->reauth->size;
-    
+
     if (serverinlen > 2048) return SASL_BADPROT;
-    
+
     *clientout = NULL;
     *clientoutlen = 0;
 
@@ -5088,9 +5089,9 @@ digestmd5_client_mech_step(void *conn_context,
 		return SASL_CONTINUE;
 	    }
 	}
-	
+
 	/* fall through and respond to challenge */
-	
+
     case 3:
 	if (serverin && !strncasecmp(serverin, "rspauth=", 8)) {
 	    return digestmd5_client_mech_step3(ctext, params,
@@ -5120,7 +5121,7 @@ digestmd5_client_mech_step(void *conn_context,
 	text->realm = text->nonce = text->cnonce = NULL;
 #endif /* _SUN_SDK_ */
 	ctext->cipher = NULL;
-    
+
     case 2:
 	return digestmd5_client_mech_step2(ctext, params,
 					   serverin, serverinlen,
@@ -5138,7 +5139,7 @@ digestmd5_client_mech_step(void *conn_context,
 #endif /* _SUN_SDK_ */
 	return SASL_FAIL;
     }
-    
+
     return SASL_FAIL; /* should never get here */
 }
 
@@ -5146,9 +5147,9 @@ static void
 digestmd5_client_mech_dispose(void *conn_context, const sasl_utils_t *utils)
 {
     client_context_t *ctext = (client_context_t *) conn_context;
-    
+
     if (!ctext || !utils) return;
-    
+
 #ifdef _INTEGRATED_SOLARIS_
     convert_prompt(utils, &ctext->h, NULL);
 #endif /* _INTEGRATED_SOLARIS_ */
@@ -5198,7 +5199,7 @@ int digestmd5_client_plug_init(sasl_utils_t *utils,
 
     if (maxversion < SASL_CLIENT_PLUG_VERSION)
 	return SASL_BADVERS;
-    
+
 #if defined _SUN_SDK_  && defined USE_UEF
     if ((ret = uef_init(utils)) != SASL_OK)
 	return ret;
@@ -5210,7 +5211,7 @@ int digestmd5_client_plug_init(sasl_utils_t *utils,
 	return SASL_NOMEM;
     memset(reauth_cache, 0, sizeof(reauth_cache_t));
     reauth_cache->i_am = CLIENT;
-    
+
     /* mutex */
     reauth_cache->mutex = utils->mutex_alloc();
     if (!reauth_cache->mutex)
@@ -5242,7 +5243,7 @@ int digestmd5_client_plug_init(sasl_utils_t *utils,
     *out_version = SASL_CLIENT_PLUG_VERSION;
     *pluglist = digestmd5_client_plugins;
     *plugcount = 1;
-    
+
     return SASL_OK;
 }
 

--- a/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
+++ b/usr/src/lib/smbsrv/libmlsvc/common/smb_logon.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <unistd.h>
@@ -263,7 +264,7 @@ smb_token_destroy(smb_token_t *token)
  * Token owner should be set to local Administrators group
  * in two cases:
  *   1. The logged on user is a member of Domain Admins group
- *   2. he/she is a member of local Administrators group
+ *   2. They are a member of local Administrators group
  */
 static void
 smb_token_set_owner(smb_token_t *token)

--- a/usr/src/lib/smbsrv/libsmbns/common/smbns_netbios_name.c
+++ b/usr/src/lib/smbsrv/libsmbns/common/smbns_netbios_name.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -190,7 +191,7 @@ smb_end_node_challenge(nbt_name_reply_t *reply_info)
 	/*
 	 * The response packet has in it the address of the presumed owner
 	 * of the name.  Challenge that owner.  If owner either does not
-	 * respond or indicates that he no longer owns the name, claim the
+	 * respond or indicates that they no longer own the name, claim the
 	 * name.  Otherwise, the name cannot be claimed.
 	 */
 
@@ -437,7 +438,7 @@ smb_netbios_process_response(uint16_t tid, addr_entry_t *addr,
 		 * address of the presumed owner of the
 		 * name.  Challenge that owner.  If
 		 * owner either does not respond or
-		 * indicates that he no longer owns the
+		 * indicates that they no longer own the
 		 * name, claim the name.  Otherwise,
 		 * the name cannot be claimed.
 		 */

--- a/usr/src/lib/storage/liba5k/common/mon.c
+++ b/usr/src/lib/storage/liba5k/common/mon.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -1303,7 +1304,7 @@ struct	device_element	*front_elem, *rear_elem;
  * The string can also be NULL. This is the way the user
  * chooses to not have a password.
  *
- * I then tell the photon by giving him 4 NULL bytes.
+ * I then tell the photon by giving it 4 NULL bytes.
  *
  * RETURNS:
  *	0	 O.K.

--- a/usr/src/psm/stand/boot/sparc/common/bootprop.c
+++ b/usr/src/psm/stand/boot/sparc/common/bootprop.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -228,7 +229,7 @@ bgetprop(struct bootops *bop, char *name, void *buf)
 }
 
 /*
- *  If the user wants the first property in the list, he passes in a
+ *  If the user wants the first property in the list, they pass in a
  *  null string.  The routine will always return a ptr to the name of the
  *  next prop, except when there are no more props.  In that case, it will
  *  return a null string.

--- a/usr/src/stand/lib/fs/ufs/ufsops.c
+++ b/usr/src/stand/lib/fs/ufs/ufsops.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -719,7 +720,7 @@ boot_ufs_lseek(int fd, off_t addr, int whence)
 {
 	fileid_t *filep;
 
-	/* Make sure user knows what file he is talking to */
+	/* Make sure user knows what file they're talking to */
 	if (!(filep = find_fp(fd)))
 		return (-1);
 
@@ -792,7 +793,7 @@ boot_ufs_close(int fd)
 {
 	fileid_t *filep;
 
-	/* Make sure user knows what file he is talking to */
+	/* Make sure user knows what file they're talking to */
 	if (!(filep = find_fp(fd)))
 		return (-1);
 

--- a/usr/src/stand/lib/tcp/tcp.c
+++ b/usr/src/stand/lib/tcp/tcp.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * tcp.c, Code implementing the TCP protocol.
  */
@@ -729,7 +730,7 @@ tcp_close_detached(tcp_t *tcp)
 
 /*
  * If we are an eager connection hanging off a listener that hasn't
- * formally accepted the connection yet, get off his list and blow off
+ * formally accepted the connection yet, get off its list and blow off
  * any data that we have accumulated.
  */
 static void

--- a/usr/src/uts/common/avs/ncall/ncall.c
+++ b/usr/src/uts/common/avs/ncall/ncall.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -720,7 +721,7 @@ ncallgetnodes(intptr_t uaddr, int mode, int *rvalp)
 
 	/*
 	 * If the user passes up a null address argument, then
-	 * he/she doesn't want the actual nodes, but the configured
+	 * they don't want the actual nodes, but the configured
 	 * maximum, so space can be correctly allocated.
 	 */
 

--- a/usr/src/uts/common/avs/ns/rdc/rdc_health.c
+++ b/usr/src/uts/common/avs/ns/rdc/rdc_health.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -413,7 +414,7 @@ rdc_lookup_host(char *host)
 
 /*
  * Handle the RDC_LINK_DOWN ioctl.
- * The user specifies which host he is interested in.
+ * The user specifies which host they're interested in.
  * This function is woken up when the link to that host goes down.
  */
 

--- a/usr/src/uts/common/disp/priocntl.c
+++ b/usr/src/uts/common/disp/priocntl.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -800,7 +801,7 @@ proccmp(proc_t *pp, struct pcmpargs *argp)
 		if (*argp->pcmp_retthreadp == NULL) {
 			/*
 			 * First time through for this set.
-			 * keep the mutex held. He might be the one!
+			 * keep the mutex held. It might be the one!
 			 */
 			*argp->pcmp_retthreadp = ty;
 		} else {

--- a/usr/src/uts/common/fs/doorfs/door_sys.c
+++ b/usr/src/uts/common/fs/doorfs/door_sys.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1496,7 +1497,7 @@ out:
 		mutex_enter(&door_knob);
 		DOOR_T_RELEASE(ct);
 
-		/* let the client know we have processed his message */
+		/* let the client know we have processed its message */
 		ct->d_args_done = 1;
 
 		if (error) {

--- a/usr/src/uts/common/fs/namefs/namevno.c
+++ b/usr/src/uts/common/fs/namefs/namevno.c
@@ -24,6 +24,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -304,7 +305,7 @@ nm_setattr(
 	 * bits.
 	 * If the system was configured with the "rstchown" option, the
 	 * owner is not permitted to give away the file, and can change
-	 * the group id only to a group of which he or she is a member.
+	 * the group id only to a group of which they are a member.
 	 */
 	if (mask & AT_UID)
 		nmvap->va_uid = vap->va_uid;

--- a/usr/src/uts/common/fs/nfs/nfs4_srv.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_srv.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2769,7 +2769,7 @@ do_rfs4_op_lookup(char *nm, struct svc_req *req, struct compound_state *cs)
 		/*
 		 * Now we do a checkauth4. The reason is that
 		 * this client/user may not have access to the new
-		 * exported file system, and if he does,
+		 * exported file system, and if they do,
 		 * the client/user may be mapped to a different uid.
 		 *
 		 * We start with a new cr, because the checkauth4 done
@@ -3964,7 +3964,7 @@ rfs4_op_release_lockowner(nfs_argop4 *argop, nfs_resop4 *resop,
 		 * We need to unhide the lockowner so the client can
 		 * try it again. The bad thing here is if the client
 		 * has a logic error that took it here in the first place
-		 * he probably has lost accounting of the locks that it
+		 * they probably have lost accounting of the locks that it
 		 * is holding. So we may have dangling state until the
 		 * open owner state is reaped via close. One scenario
 		 * that could possibly occur is that the client has

--- a/usr/src/uts/common/fs/nfs/nfs_srv.c
+++ b/usr/src/uts/common/fs/nfs/nfs_srv.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 1994, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -829,7 +830,7 @@ rfs_read(struct nfsreadargs *ra, struct nfsrdresult *rr,
 
 	/*
 	 * Get attributes again so we can send the latest access
-	 * time to the client side for his cache.
+	 * time to the client side for its cache.
 	 */
 	va.va_mask = AT_ALL;
 
@@ -1104,7 +1105,7 @@ rfs_write_sync(struct nfswriteargs *wa, struct nfsattrstat *ns,
 	if (!error) {
 		/*
 		 * Get attributes again so we send the latest mod
-		 * time to the client side for his cache.
+		 * time to the client side for its cache.
 		 */
 		va.va_mask = AT_ALL;	/* now we want everything */
 
@@ -1600,7 +1601,7 @@ rfs_write(struct nfswriteargs *wa, struct nfsattrstat *ns,
 			data_written = 1;
 			/*
 			 * Get attributes again so we send the latest mod
-			 * time to the client side for his cache.
+			 * time to the client side for its cache.
 			 */
 			va.va_mask = AT_ALL;	/* now we want everything */
 

--- a/usr/src/uts/common/fs/nfs/nfs_subr.c
+++ b/usr/src/uts/common/fs/nfs/nfs_subr.c
@@ -25,6 +25,7 @@
 
 /*
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -5129,7 +5130,7 @@ nfs_mount_label_policy(vfs_t *vfsp, struct netbuf *addr,
 	 * mounts into the global zone itself; restrict these to
 	 * read-only.)
 	 *
-	 * If the requestor is in some other zone, but his label
+	 * If the requestor is in some other zone, but their label
 	 * dominates the server, then allow read-down.
 	 *
 	 * Otherwise, access is denied.

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_vfsops.c
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_vfsops.c
@@ -35,6 +35,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/systm.h>
@@ -989,7 +990,7 @@ smbfs_mount_label_policy(vfs_t *vfsp, void *ipaddr, int addr_type, cred_t *cr)
 	 * mounts into the global zone itself; restrict these to
 	 * read-only.)
 	 *
-	 * If the requestor is in some other zone, but his label
+	 * If the requestor is in some other zone, but their label
 	 * dominates the server, then allow read-down.
 	 *
 	 * Otherwise, access is denied.

--- a/usr/src/uts/common/fs/smbsrv/smb_ofile.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_ofile.c
@@ -22,6 +22,7 @@
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 Syneto S.R.L. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -153,7 +154,7 @@
  *    number of references to the ofile in other structures (such as an smb
  *    request). The reference count is not incremented in these 2 instances:
  *
- *    1) The ofile is open. An ofile is anchored by his state. If there's
+ *    1) The ofile is open. An ofile is anchored by its state. If there's
  *       no activity involving an ofile currently open, the reference count
  *       of that ofile is zero.
  *

--- a/usr/src/uts/common/fs/smbsrv/smb_tree.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_tree.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -154,7 +155,7 @@
  *    number of references to the tree in other structures (such as an smb
  *    request). The reference count is not incremented in these 2 instances:
  *
- *    1) The tree is connected. An tree is anchored by his state. If there's
+ *    1) The tree is connected. An tree is anchored by its state. If there's
  *       no activity involving a tree currently connected, the reference
  *       count of that tree is zero.
  *

--- a/usr/src/uts/common/fs/smbsrv/smb_user.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_user.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -101,21 +102,21 @@
  * SMB_USER_STATE_LOGGING_ON
  *
  *    While in this state:
- *      - The user is in the list of users for his session.
+ *      - The user is in the list of users for their session.
  *      - References will be given out ONLY for session setup.
  *      - This user can not access anything yet.
  *
  * SMB_USER_STATE_LOGGED_ON
  *
  *    While in this state:
- *      - The user is in the list of users for his session.
+ *      - The user is in the list of users for their session.
  *      - References will be given out if the user is looked up.
  *      - The user can access files and pipes.
  *
  * SMB_USER_STATE_LOGGING_OFF
  *
  *    While in this state:
- *      - The user is in the list of users for his session.
+ *      - The user is in the list of users for their session.
  *      - References will not be given out if the user is looked up.
  *      - The trees the user connected are being disconnected.
  *      - The resources associated with the user remain.
@@ -123,7 +124,7 @@
  * SMB_USER_STATE_LOGGED_OFF
  *
  *    While in this state:
- *      - The user is queued in the list of users of his session.
+ *      - The user is queued in the list of users of their session.
  *      - References will not be given out if the user is looked up.
  *      - The user has no more trees connected.
  *      - The resources associated with the user remain.
@@ -167,7 +168,7 @@
  * --------
  *
  *    The state machine of the user structures is controlled by 3 elements:
- *      - The list of users of the session he belongs to.
+ *      - The list of users of the session they belong to.
  *      - The mutex embedded in the structure itself.
  *      - The reference count.
  *
@@ -191,7 +192,7 @@
  *    number of references to the user in other structures (such as an smb
  *    request). The reference count is not incremented in these 2 instances:
  *
- *    1) The user is logged in. An user is anchored by his state. If there's
+ *    1) The user is logged in. An user is anchored by their state. If there's
  *       no activity involving a user currently logged in, the reference
  *       count of that user is zero.
  *

--- a/usr/src/uts/common/fs/ufs/quota_ufs.c
+++ b/usr/src/uts/common/fs/ufs/quota_ufs.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -313,8 +314,8 @@ chkdq(struct inode *ip, long change, int force, struct cred *cr,
 
 	/*
 	 * Disallow allocation if it would bring the current usage over
-	 * the hard limit or if the user is over his soft limit and his time
-	 * has run out.
+	 * the hard limit or if the user is over their soft limit and their
+	 * time has run out.
 	 */
 	if (dqp->dq_bhardlimit && ncurblocks >= (uint64_t)dqp->dq_bhardlimit &&
 	    !force) {
@@ -512,8 +513,8 @@ chkiq(struct ufsvfs *ufsvfsp, int change, struct inode *ip, uid_t uid,
 
 	/*
 	 * Dissallow allocation if it would bring the current usage over
-	 * the hard limit or if the user is over his soft limit and his time
-	 * has run out.
+	 * the hard limit or if the user is over their soft limit and their
+	 * time has run out.
 	 */
 	if (change == 1 && ncurfiles >= dqp->dq_fhardlimit &&
 	    dqp->dq_fhardlimit && !force) {

--- a/usr/src/uts/common/fs/ufs/ufs_inode.c
+++ b/usr/src/uts/common/fs/ufs/ufs_inode.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1983, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1688,7 +1689,7 @@ ufs_scan_inodes(int rwtry, int (*func)(struct inode *, void *), void *arg,
 			 * ufs_iget().  This works because ufs_iget()
 			 * acquires the contents lock before putting
 			 * the inode into the cache.  If we can lock
-			 * it, then he's done with it.
+			 * it, then ufs_iget() is done with it.
 			 */
 
 			if (rwtry) {

--- a/usr/src/uts/common/fs/ufs/ufs_vnops.c
+++ b/usr/src/uts/common/fs/ufs/ufs_vnops.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1984, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015, Joyent, Inc.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -5439,7 +5440,7 @@ ufs_putapage(
 		}
 		/*
 		 * If the pager is trying to push a page in the bad range
-		 * just tell him to try again later when things are better.
+		 * just tell it to try again later when things are better.
 		 */
 		if (flags & B_ASYNC) {
 			err = EAGAIN;

--- a/usr/src/uts/common/fs/zfs/zfs_dir.c
+++ b/usr/src/uts/common/fs/zfs/zfs_dir.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
  * Copyright 2017 Nexenta Systems, Inc.
  */
 
@@ -287,8 +287,8 @@ zfs_dirent_lock(zfs_dirlock_t **dlpp, znode_t *dzp, char *name, znode_t **zpp,
 		 * dl_name in case the first thread goes away before we do.
 		 * Note that we initialize the new name before storing its
 		 * pointer into dl_name, because the first thread may load
-		 * dl->dl_name at any time.  He'll either see the old value,
-		 * which is his, or the new shared copy; either is OK.
+		 * dl->dl_name at any time.  It'll either see the old value,
+		 * which belongs to it, or the new shared copy; either is OK.
 		 */
 		dl->dl_namesize = strlen(dl->dl_name) + 1;
 		name = kmem_alloc(dl->dl_namesize, KM_SLEEP);

--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -1679,7 +1679,7 @@ zio_reexecute(zio_t *pio)
 	/*
 	 * Now that all children have been reexecuted, execute the parent.
 	 * We don't reexecute "The Godfather" I/O here as it's the
-	 * responsibility of the caller to wait on him.
+	 * responsibility of the caller to wait on it.
 	 */
 	if (!(pio->io_flags & ZIO_FLAG_GODFATHER)) {
 		pio->io_queued_timestamp = gethrtime();

--- a/usr/src/uts/common/inet/ip/ip.c
+++ b/usr/src/uts/common/inet/ip/ip.c
@@ -24,6 +24,7 @@
  * Copyright (c) 1990 Mentat Inc.
  * Copyright (c) 2012 Joyent, Inc. All rights reserved.
  * Copyright (c) 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -10569,7 +10570,7 @@ ip_snmp_get_mib2_ip_route_media(queue_t *q, mblk_t *mpctl, int level,
 
 	/*
 	 * make copies of the original message
-	 *	- mp2ctl is returned unchanged to the caller for his use
+	 *	- mp2ctl is returned unchanged to the caller for its use
 	 *	- mpctl is sent upstream as ipRouteEntryTable
 	 *	- mp3ctl is sent upstream as ipNetToMediaEntryTable
 	 *	- mp4ctl is sent upstream as ipRouteAttributeTable
@@ -10654,7 +10655,7 @@ ip_snmp_get_mib2_ip6_route_media(queue_t *q, mblk_t *mpctl, int level,
 
 	/*
 	 * make copies of the original message
-	 *	- mp2ctl is returned unchanged to the caller for his use
+	 *	- mp2ctl is returned unchanged to the caller for its use
 	 *	- mpctl is sent upstream as ipv6RouteEntryTable
 	 *	- mp3ctl is sent upstream as ipv6NetToMediaEntryTable
 	 *	- mp4ctl is sent upstream as ipv6RouteAttributeTable

--- a/usr/src/uts/common/inet/ip/spd.c
+++ b/usr/src/uts/common/inet/ip/spd.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -5376,7 +5377,7 @@ ipsec_tun_outbound(mblk_t *mp, iptun_t *iptun, ipha_t *inner_ipv4,
 		 * NOTE2:  "negotiate transport" tunnels should match ALL
 		 * inbound packets, but we do not uncomment the ASSERT()
 		 * below because if/when we open PF_POLICY, a user can
-		 * shoot him/her-self in the foot with a 0 priority.
+		 * shoot themself in the foot with a 0 priority.
 		 */
 
 		/* ASSERT(itp->itp_flags & ITPF_P_TUNNEL); */

--- a/usr/src/uts/common/inet/ipnet/ipnet.c
+++ b/usr/src/uts/common/inet/ipnet/ipnet.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1974,7 +1975,7 @@ ipobs_register_hook(netstack_t *ns, pfv_t func)
 	VERIFY(hook != NULL);
 
 	/*
-	 * To register multiple hooks with he same callback function,
+	 * To register multiple hooks with the same callback function,
 	 * a unique name is needed.
 	 */
 	(void) snprintf(name, sizeof (name), "ipobserve_%p", (void *)hook);

--- a/usr/src/uts/common/inet/tcp/tcp.c
+++ b/usr/src/uts/common/inet/tcp/tcp.c
@@ -1258,7 +1258,7 @@ tcp_closei_local(tcp_t *tcp)
 
 	/*
 	 * If we are an eager connection hanging off a listener that
-	 * hasn't formally accepted the connection yet, get off his
+	 * hasn't formally accepted the connection yet, get off its
 	 * list and blow off any data that we have accumulated.
 	 */
 	if (tcp->tcp_listener != NULL) {

--- a/usr/src/uts/common/inet/tcp/tcp_bind.c
+++ b/usr/src/uts/common/inet/tcp/tcp_bind.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -351,7 +352,7 @@ tcp_bind_select_lport(tcp_t *tcp, in_port_t *requested_port_ptr,
 
 		/*
 		 * If the user went through one of the RPC interfaces to create
-		 * this socket and RPC is MLP in this zone, then give him an
+		 * this socket and RPC is MLP in this zone, then give them an
 		 * anonymous MLP.
 		 */
 		if (connp->conn_anon_mlp && is_system_labeled()) {

--- a/usr/src/uts/common/inet/tcp/tcp_input.c
+++ b/usr/src/uts/common/inet/tcp/tcp_input.c
@@ -1062,7 +1062,7 @@ tcp_eager_cleanup(tcp_t *listener, boolean_t q0_only)
 
 /*
  * If we are an eager connection hanging off a listener that hasn't
- * formally accepted the connection yet, get off his list and blow off
+ * formally accepted the connection yet, get off its list and blow off
  * any data that we have accumulated.
  */
 void

--- a/usr/src/uts/common/inet/tcp/tcp_output.c
+++ b/usr/src/uts/common/inet/tcp/tcp_output.c
@@ -1421,7 +1421,7 @@ tcp_output_urgent(void *arg, mblk_t *mp, void *arg2, ip_recv_attr_t *dummy)
 }
 
 /*
- * Called by streams close routine via squeues when our client blows off her
+ * Called by streams close routine via squeues when our client blows off its
  * descriptor, we take this to mean: "close the stream state NOW, close the tcp
  * connection politely" When SO_LINGER is set (with a non-zero linger time and
  * it is not a nonblocking socket) then this routine sleeps until the FIN is

--- a/usr/src/uts/common/io/1394/adapters/hci1394_ohci.c
+++ b/usr/src/uts/common/io/1394/adapters/hci1394_ohci.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -2733,7 +2734,7 @@ hci1394_ohci_resume(hci1394_ohci_handle_t ohci_hdl)
 	/*
 	 * re-setup OHCI bus options and config rom hdr registers. We need to
 	 * read from the config rom using ddi_rep_get8 since it is stored as
-	 * a byte stream. We need to swap he config rom header and bus options
+	 * a byte stream. We need to swap the config rom header and bus options
 	 * on an X86 machine since the data is a byte stream and the OHCI
 	 *  registers expect a big endian 32-bit number.
 	 */

--- a/usr/src/uts/common/io/asy.c
+++ b/usr/src/uts/common/io/asy.c
@@ -26,6 +26,7 @@
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -1802,7 +1803,7 @@ asyclose(queue_t *q, int flag, cred_t *credp)
 	 * write queue and there's a timer running, so we don't have to worry
 	 * about them.  For the untimed case, though, the user obviously made a
 	 * mistake, because these are handled immediately.  We'll terminate the
-	 * break now and honor his implicit request by discarding the rest of
+	 * break now and honor their implicit request by discarding the rest of
 	 * the data.
 	 */
 	if (async->async_flags & ASYNC_OUT_SUSPEND) {

--- a/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/device/lm_recv.c
+++ b/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/device/lm_recv.c
@@ -82,7 +82,7 @@ static void FORCEINLINE lm_rx_set_prods( lm_device_t     *pdev,
 /*******************************************************************************
  * Description:
  *  rx_chain_bd always valid, rx_chain_sge valid only in case we are LAH enabled in this queue
- *  all if() checking will be always done on rx_chain_bd since he is always valid and sge should be consistent
+ *  all if() checking will be always done on rx_chain_bd since it is always valid and sge should be consistent
  *  We verify it in case sge is valid
  *  all bd_xxx operations will be done on both
  * Return:

--- a/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/l4/lm_l4sp.c
+++ b/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/l4/lm_l4sp.c
@@ -546,7 +546,7 @@ lm_status_t lm_tcp_init_resc(struct _lm_device_t *pdev, u8_t b_is_init )
         /* Assign the SCQ chain consumer pointer to the consumer index in the status block. */
         sb_id = RSS_ID_TO_SB_ID(i);
 #ifdef _VBD_
-	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED)) 
+	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED))
 	{
             sb_id = LM_NON_RSS_SB(pdev);
 	}
@@ -575,7 +575,7 @@ lm_status_t lm_tcp_init_resc(struct _lm_device_t *pdev, u8_t b_is_init )
 
 	sb_id = RSS_ID_TO_SB_ID(i);
 #ifdef _VBD_
-	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED)) 
+	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED))
 	{
 	    sb_id = LM_NON_RSS_SB(pdev);
 	}
@@ -695,10 +695,10 @@ static void _lm_tcp_init_cstorm_intmem(lm_device_t *pdev)
         //LM_INTMEM_WRITE8(pdev, CSTORM_TOE_STATUS_BLOCK_ID_OFFSET(LM_TOE_FW_RSS_ID(pdev,drv_toe_rss_id), port), LM_TOE_FW_RSS_ID(pdev,drv_toe_rss_id), BAR_CSTRORM_INTMEM);
 	fw_sb_id = LM_FW_SB_ID(pdev, RSS_ID_TO_SB_ID(drv_toe_rss_id));
 #ifdef _VBD_
-	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED)) 
+	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED))
 	{
 		fw_sb_id = LM_FW_SB_ID(pdev, RSS_ID_TO_SB_ID(LM_NON_RSS_SB(pdev)));
-		if (drv_toe_rss_id != LM_NON_RSS_CHAIN(pdev)) 
+		if (drv_toe_rss_id != LM_NON_RSS_CHAIN(pdev))
 		{
 			DbgBreak();
 		}
@@ -846,11 +846,11 @@ static void _lm_tcp_init_ustorm_intmem(lm_device_t *pdev)
             break;
         }
 #ifdef _VBD_
-	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED)) 
+	if (!CHIP_IS_E1x(pdev) && (pdev->params.l4_enable_rss == L4_RSS_DISABLED))
 	{
 		fw_sb_id = LM_FW_SB_ID(pdev, RSS_ID_TO_SB_ID(LM_NON_RSS_SB(pdev)));
 		sw_sb_id = LM_NON_RSS_SB(pdev);
-		if (drv_toe_rss_id != LM_NON_RSS_CHAIN(pdev)) 
+		if (drv_toe_rss_id != LM_NON_RSS_CHAIN(pdev))
 		{
 			DbgBreak();
 		}
@@ -1056,7 +1056,7 @@ lm_status_t lm_tcp_init_chip_common(lm_device_t *pdev)
     _lm_get_default_l4cli_params(pdev, &l4_params);
 
     pdev->ofld_info.l4_params = l4_params;
-    
+
     /* init common internal memory/hw for each storm
      * (c+u storms do not have common offload params) */
     _lm_set_ofld_params_xstorm_common(pdev, &l4_params);
@@ -1171,7 +1171,7 @@ lm_status_t lm_tcp_init(lm_device_t *pdev)
         DbgMessage(pdev, FATAL, "###lm_tcp_init is not supported for VF\n");
         return LM_STATUS_SUCCESS;
     }
-    
+
     toe_info = &pdev->toe_info;
     mm_memset(toe_info, 0 , sizeof(lm_toe_info_t));
     toe_info->pdev = pdev;
@@ -2586,7 +2586,7 @@ static lm_status_t _lm_tcp_init_xstorm_tcp_context(
         (0 != GET_FLAGS(xtcp_st->ethernet.vlan_params, XSTORM_ETH_CONTEXT_SECTION_CFI))     ||
         (0 != GET_FLAGS(xtcp_st->ethernet.vlan_params, XSTORM_ETH_CONTEXT_SECTION_PRIORITY)))
     {
-        // This fields should be set to 1 whenever an inner VLAN is provided by the OS. 
+        // This fields should be set to 1 whenever an inner VLAN is provided by the OS.
         // This flags is relevant for all function modes.
         SET_FLAGS( xtcp_st->flags, XSTORM_COMMON_CONTEXT_SECTION_VLAN_MODE);
     }
@@ -2612,7 +2612,7 @@ static lm_status_t _lm_tcp_init_xstorm_tcp_context(
 #endif
         src_ip[0] = HTON32(path->path_const.u.ipv4.src_ip);
         dst_ip[0] = HTON32(path->path_const.u.ipv4.dst_ip);
-        pseudo_cs = lm_tcp_calc_tcp_pseudo_checksum(pdev, src_ip, dst_ip, IP_VERSION_IPV4);       
+        pseudo_cs = lm_tcp_calc_tcp_pseudo_checksum(pdev, src_ip, dst_ip, IP_VERSION_IPV4);
     } else {
         /* IPv6*/
         xtcp_st->ip_union.ip_v6.ip_remote_addr_lo_lo = path->path_const.u.ipv6.dst_ip[0];
@@ -3875,7 +3875,7 @@ static lm_status_t lm_tcp_post_invalidate_request(
 /* Desciption:
  *  post slow path request of given type for given tcp state
  * Assumptions:
- *  - caller initialized request->type according to his specific request
+ *  - caller initialized request->type according to its specific request
  *  - caller allocated space for request->data, according to the specific request type
  *  - all previous slow path requests for given tcp state are already completed
  * Returns:
@@ -4395,8 +4395,8 @@ lm_tcp_set_ofld_params(
 
     /* <MichalK> Here we override the ofld info. This in theory effects iscsi as well, however, since ftsk
      * does not really use timers, and passes '0' for ka / rt in delegate/cached params its ok that
-     * we're overriding the parameters here. The correct solution is to maintain this per cli-idx, 
-     * but that will require major changes in l4 context initialization and not worth the effort. 
+     * we're overriding the parameters here. The correct solution is to maintain this per cli-idx,
+     * but that will require major changes in l4 context initialization and not worth the effort.
      */
     *curr_params = *params;
 

--- a/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/l5/lm_l5sp.c
+++ b/usr/src/uts/common/io/bnxe/577xx/drivers/common/lm/l5/lm_l5sp.c
@@ -18,7 +18,7 @@ static lm_status_t lm_sc_post_init_request(
     *command = ISCSI_RAMROD_CMD_ID_INIT;
     *data = iscsi->ctx_phys.as_u64;
 
-    return LM_STATUS_PENDING;   
+    return LM_STATUS_PENDING;
 }
 
 
@@ -40,7 +40,7 @@ static lm_status_t lm_sc_post_update_request(
     spe.data.phy_address.lo = iscsi->sp_req_data.phys_addr.as_u32.low;
     *data = *((u64_t*)(&(spe.data.phy_address)));
 
-    return LM_STATUS_PENDING;   
+    return LM_STATUS_PENDING;
 }
 
 
@@ -48,7 +48,7 @@ static lm_status_t lm_sc_post_update_request(
 /* Desciption:
  *  post slow path request of given type for given iscsi state
  * Assumptions:
- *  - caller initialized request->type according to his specific request
+ *  - caller initialized request->type according to its specific request
  *  - caller allocated space for request->data, according to the specific request type
  *  - all previous slow path requests for given tcp state are already completed
  * Returns:
@@ -61,7 +61,7 @@ lm_status_t lm_sc_post_slow_path_request(
     lm_status_t lm_status = LM_STATUS_SUCCESS;
     u64_t       data      = 0;
     u8_t        command   = 0;
-    
+
     DbgBreakIf(!(pdev && iscsi && request));
     DbgMessage(pdev, VERBOSEl5sp, "### lm_sc_post_slow_path_request cid=%d, type=%d\n", iscsi->cid, request->type);
 
@@ -72,7 +72,7 @@ lm_status_t lm_sc_post_slow_path_request(
         lm_status = lm_sc_post_init_request(pdev, iscsi, request, &command, &data);
         break;
 
-    case SP_REQUEST_SC_UPDATE:    
+    case SP_REQUEST_SC_UPDATE:
         lm_status = lm_sc_post_update_request(pdev, iscsi, request, &command, &data);
         break;
 
@@ -87,10 +87,10 @@ lm_status_t lm_sc_post_slow_path_request(
         DbgMessage(pdev, VERBOSEl5sp,
                    "calling lm_command_post, cid=%d, command=%d, con_type=%d, data=%lx\n",
                    iscsi->cid, command, ISCSI_CONNECTION_TYPE, data);
-        lm_command_post(pdev, iscsi->cid, command, CMD_PRIORITY_NORMAL, ISCSI_CONNECTION_TYPE/*ulp*/, data);  
+        lm_command_post(pdev, iscsi->cid, command, CMD_PRIORITY_NORMAL, ISCSI_CONNECTION_TYPE/*ulp*/, data);
     }
 
-    request->status = lm_status; 
+    request->status = lm_status;
     return lm_status;
 }
 
@@ -117,9 +117,9 @@ lm_status_t lm_sc_init_iscsi_state(
 
     // NirV: sc: future statistics update
 
-    /* the rest of the iscsi state's fields that require initialization value other than 0, 
+    /* the rest of the iscsi state's fields that require initialization value other than 0,
      * will be initialized later (when lm_sc_init_iscsi_context is called) */
-   
+
     return LM_STATUS_SUCCESS;
 }
 
@@ -129,7 +129,7 @@ lm_status_t lm_sc_init_iscsi_state(
  *  delete iscsi state from lm _except_ from actual freeing of memory.
  *  the task of freeing of memory is done in lm_sc_free_iscsi_state()
  * Assumptions:
- *  global toe lock is taken by the caller 
+ *  global toe lock is taken by the caller
  */
 void lm_sc_del_iscsi_state(
     struct _lm_device_t *pdev,
@@ -139,7 +139,7 @@ void lm_sc_del_iscsi_state(
 
     DbgMessage(pdev, VERBOSEl5sp, "###lm_sc_del_iscsi_state\n");
     DbgBreakIf(!(pdev && iscsi));
-    DbgBreakIf(iscsi->hdr.status >= STATE_STATUS_OFFLOAD_PENDING && 
+    DbgBreakIf(iscsi->hdr.status >= STATE_STATUS_OFFLOAD_PENDING &&
                iscsi->hdr.status < STATE_STATUS_UPLOAD_DONE);
 
     /* just a moment before we delete this connection, lets take it's info... */
@@ -151,18 +151,18 @@ void lm_sc_del_iscsi_state(
     /*pdev->iscsi_info.stats.total_upld++;*/
 
 
-  /* tcp->cid could have not been initialized if delete of state 
+  /* tcp->cid could have not been initialized if delete of state
      is a result of a failed initialization */
-    DbgBreakIf(iscsi->hdr.status != STATE_STATUS_UPLOAD_DONE && 
+    DbgBreakIf(iscsi->hdr.status != STATE_STATUS_UPLOAD_DONE &&
                iscsi->hdr.status != STATE_STATUS_INIT_OFFLOAD_ERR);
 
     if (iscsi->hdr.status == STATE_STATUS_INIT_OFFLOAD_ERR) {
         notify_fw = 0;
-    }        
-      
+    }
+
     lm_free_cid_resc(pdev, ISCSI_CONNECTION_TYPE, iscsi->cid, notify_fw);
 
-    iscsi->hdr.state_blk     = NULL;  
+    iscsi->hdr.state_blk     = NULL;
     iscsi->cid = 0;
     iscsi->ctx_virt = NULL;
     iscsi->ctx_phys.as_u64 = 0;
@@ -178,18 +178,18 @@ lm_fc_del_fcoe_state(
     DbgMessage(pdev, VERBOSEl5sp, "###lm_fc_del_fcoe_state\n");
     DbgBreakIf(!(pdev && fcoe));
     /*
-    DbgBreakIf(fcoe->hdr.status >= STATE_STATUS_OFFLOAD_PENDING && 
+    DbgBreakIf(fcoe->hdr.status >= STATE_STATUS_OFFLOAD_PENDING &&
                fcoe->hdr.status < STATE_STATUS_UPLOAD_DONE);
     */
 
     /* remove the lm_fcoe_state from the state list */
     d_list_remove_entry(&pdev->fcoe_info.run_time.fcoe_list, &fcoe->hdr.link);
 
-  /* tcp->cid could have not been initialized if delete of state 
+  /* tcp->cid could have not been initialized if delete of state
      is a result of a failed initialization */
 
     /*
-    DbgBreakIf(fcoe->hdr.status != STATE_STATUS_UPLOAD_DONE && 
+    DbgBreakIf(fcoe->hdr.status != STATE_STATUS_UPLOAD_DONE &&
                fcoe->hdr.status != STATE_STATUS_INIT_OFFLOAD_ERR);
     */
 } /* lm_fc_del_fcoe_state */
@@ -210,27 +210,27 @@ lm_fc_init_fcoe_state(
     fcoe->hdr.status        = STATE_STATUS_INIT;
     d_list_push_tail(&pdev->fcoe_info.run_time.fcoe_list, &fcoe->hdr.link);
 
-    /* the rest of the fcoe state's fields that require initialization value other than 0, 
+    /* the rest of the fcoe state's fields that require initialization value other than 0,
      * will be initialized later (when lm_fc_init_fcoe_context is called) */
-   
+
     return LM_STATUS_SUCCESS;
 }
 
 
 
 void lm_sc_init_sp_req_type(
-    struct _lm_device_t          * pdev, 
-    lm_iscsi_state_t             * iscsi, 
-    lm_iscsi_slow_path_request_t * lm_req, 
+    struct _lm_device_t          * pdev,
+    lm_iscsi_state_t             * iscsi,
+    lm_iscsi_slow_path_request_t * lm_req,
     void                         * req_input_data)
 {
     void *update_kwqe_virt;
     struct protocol_common_spe spe = {0};
 
-    switch(lm_req->type) {  
+    switch(lm_req->type) {
     case SP_REQUEST_SC_INIT:
         break;
-    case SP_REQUEST_SC_UPDATE: 
+    case SP_REQUEST_SC_UPDATE:
 
         spe.data.phy_address.hi = iscsi->sp_req_data.phys_addr.as_u32.high;
         spe.data.phy_address.lo = iscsi->sp_req_data.phys_addr.as_u32.low;

--- a/usr/src/uts/common/io/bridge.c
+++ b/usr/src/uts/common/io/bridge.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2507,7 +2508,7 @@ bridge_xmit_cb(mac_handle_t mh, mac_ring_handle_t rh, mblk_t *mpnext)
 
 		/*
 		 * We have to learn from our own transmitted packets, because
-		 * there may be a Solaris DLPI raw sender (who can specify his
+		 * there may be a Solaris DLPI raw sender (which can specify its
 		 * own source address) using promiscuous mode for receive.  The
 		 * mac layer information won't (and can't) tell us everything
 		 * we need to know.

--- a/usr/src/uts/common/io/busra.c
+++ b/usr/src/uts/common/io/busra.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #if defined(DEBUG)
@@ -675,7 +676,7 @@ ndi_ra_alloc(dev_info_t *dip, ndi_ra_request_t *req, uint64_t *retbasep,
 			if (base >= mapp->ra_base &&
 			    ((base - mapp->ra_base) < mapp->ra_len)) {
 				/*
-				 * This is the node with he requested base in
+				 * This is the node with the requested base in
 				 * its range
 				 */
 				if ((len > mapp->ra_len) ||

--- a/usr/src/uts/common/io/cpqary3/cpqary3_scsi.c
+++ b/usr/src/uts/common/io/cpqary3/cpqary3_scsi.c
@@ -11,6 +11,7 @@
 
 /*
  * Copyright (C) 2013 Hewlett-Packard Development Company, L.P.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/sdt.h>
@@ -767,7 +768,7 @@ cpqary3_synccmd_complete(cpqary3_cmdpvt_t *cpqary3_cmdpvtp)
 		cpqary3_synccmd_cleanup(cpqary3_cmdpvtp);
 		mutex_enter(&(cpqary3p->sw_mutex));
 	} else {
-		/* submitter is waiting; wake him up */
+		/* submitter is waiting; wake it up */
 		cpqary3_cmdpvtp->cmdpvt_flag = 0;
 
 		/*

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_api.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_api.c
@@ -26,6 +26,7 @@
  */
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"Copyright 2010 QLogic Corporation; ql_api.c"
@@ -4929,8 +4930,8 @@ ql_els_plogi(ql_adapter_state_t *ha, fc_packet_t *pkt)
 
 	if (CFG_IST(ha, CFG_CTRL_2425) && ha->topology & QL_N_PORT) {
 		/*
-		 * In p2p topology he sends a PLOGI after determining
-		 * he has the N_Port login initiative.
+		 * In p2p topology it sends a PLOGI after determining
+		 * it has the N_Port login initiative.
 		 */
 		ret = ql_p2p_plogi(ha, pkt);
 	}

--- a/usr/src/uts/common/io/fibre-channel/ulp/fcip.c
+++ b/usr/src/uts/common/io/fibre-channel/ulp/fcip.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -4939,7 +4940,7 @@ fcip_rt_flush(struct fcip *fptr)
  * fcip_global_mutex that protects fcip_port_head must be dropped,
  * our best solution is to return a value that indicates the next
  * port in the list.  This way the caller doesn't need to worry
- * about the race condition where he saves off a pointer to the
+ * about the race condition where it saves off a pointer to the
  * next structure in the list and by the time this routine returns,
  * that next structure has already been freed.
  */

--- a/usr/src/uts/common/io/gld.c
+++ b/usr/src/uts/common/io/gld.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -3475,13 +3476,13 @@ gld_fastpath(gld_t *gld, queue_t *q, mblk_t *mp)
 	}
 
 	/*
-	 * We take his fastpath request as a declaration that he will accept
+	 * We take the fastpath request as a declaration that they will accept
 	 * M_DATA messages from us, whether or not we are willing to accept
-	 * them from him.  This allows us to have fastpath in one direction
+	 * M_DATA from them.  This allows us to have fastpath in one direction
 	 * (flow upstream) even on media with Source Routing, where we are
 	 * unable to provide a fixed MAC header to be prepended to downstream
 	 * flowing packets.  So we set GLD_FAST whether or not we decide to
-	 * allow him to send M_DATA down to us.
+	 * allow them to send M_DATA down to us.
 	 */
 	GLDM_LOCK(macinfo, RW_WRITER);
 	gld->gld_flags |= GLD_FAST;

--- a/usr/src/uts/common/io/gldutil.c
+++ b/usr/src/uts/common/io/gldutil.c
@@ -20,6 +20,7 @@
  *
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -1676,7 +1677,7 @@ gld_unitdata_tr(gld_t *gld, mblk_t *mp)
 
 /*
  * We cannot have our client sending us "fastpath" M_DATA messages,
- * because to do that we must provide to him a fixed MAC header to
+ * because to do that we must provide a fixed MAC header to
  * be prepended to each outgoing packet.  But with Source Routing
  * media, the length and content of the MAC header changes as the
  * routes change, so there is no fixed header we can provide.  So
@@ -2012,9 +2013,9 @@ gld_rcc_send(gld_mac_info_t *macinfo, queue_t *q, uchar_t *dhost,
 	/*
 	 * Our caller has to take the mutex because: to avoid an extra bcopy
 	 * of the RIF on every transmit, we pass back a pointer to our sr
-	 * table entry via rhp.  He has to keep the mutex until he has a
+	 * table entry via rhp.  The caller has to keep the mutex until it has a
 	 * chance to copy the RIF out into the outgoing packet, so that we
-	 * don't modify the entry while he's trying to copy it.  This is a
+	 * don't modify the entry while it's being copied.  This is a
 	 * little ugly, but saves the extra bcopy.
 	 */
 	ASSERT(mutex_owned(GLD_SR_MUTEX(macinfo)));
@@ -2298,11 +2299,11 @@ gld_rde_pdu_ind(gld_mac_info_t *macinfo, struct gld_ri *rh, struct rde_pdu *pdu,
 	ASSERT((rh->len & 1) == 0);
 
 	if (pdu->rde_ptype == RDE_RQR) {
-		/* A reply to our RQC has his address as target mac */
+		/* A reply to our RQC has its address as target mac */
 		otherhost = pdu->rde_target_mac;
 	} else {
 		ASSERT(pdu->rde_ptype == RDE_RS);
-		/* An RS has his address as orig mac */
+		/* An RS has its address as orig mac */
 		otherhost = pdu->rde_orig_mac;
 	}
 

--- a/usr/src/uts/common/io/hook.c
+++ b/usr/src/uts/common/io/hook.c
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2013 Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 #include <sys/param.h>
 #include <sys/types.h>
@@ -345,7 +346,7 @@ hook_fini(void)
  * ability to run and return with an error.
  *
  * "wantedset" is used here to determine who has the right to clear the
- * wanted but from the fw_flags set: only he that sets the flag has the
+ * wanted bit from the fw_flags set: only whomever sets the flag has the
  * right to clear it at the bottom of the loop, even if someone else
  * wants to set it.
  *

--- a/usr/src/uts/common/io/ib/adapters/hermon/hermon_qpmod.c
+++ b/usr/src/uts/common/io/ib/adapters/hermon/hermon_qpmod.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -676,7 +677,7 @@ hermon_qp_modify(hermon_state_t *state, hermon_qphdl_t qp,
 			 * If still draining SQ, then fail transition attempt
 			 * to RTS, even though this is now done is two steps
 			 * (see below) if the consumer has tried this before
-			 * it's drained, let him fail and wait appropriately
+			 * it's drained, let it fail and wait appropriately
 			 */
 			if (qp->qp_sqd_still_draining) {
 				mutex_exit(&qp->qp_lock);

--- a/usr/src/uts/common/io/ib/clients/iser/iser_cm.c
+++ b/usr/src/uts/common/io/ib/clients/iser/iser_cm.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -248,7 +249,7 @@ iser_handle_cm_conn_est(ibt_cm_event_t *evp)
 		if (status != IDM_STATUS_SUCCESS) {
 			/*
 			 * No IDM rsrcs or something equally Bad.
-			 * Return non-SUCCESS to IBCM. He'll give
+			 * Return non-SUCCESS to IBCM. It'll give
 			 * us a CONN_CLOSED, which we'll handle
 			 * below.
 			 */

--- a/usr/src/uts/common/io/ib/clients/iser/iser_cq.c
+++ b/usr/src/uts/common/io/ib/clients/iser/iser_cq.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -199,7 +200,7 @@ iser_ib_poll_send_completions(ibt_cq_hdl_t cq_hdl, iser_chan_t *iser_chan)
 
 			/*
 			 * Tell IDM that the channel has gone down,
-			 * unless he already knows.
+			 * unless it already knows.
 			 */
 			mutex_enter(&iser_conn->ic_lock);
 			switch (iser_conn->ic_stage) {
@@ -414,7 +415,7 @@ iser_ib_poll_recv_completions(ibt_cq_hdl_t cq_hdl, iser_chan_t *iser_chan)
 	if (wc.wc_status != IBT_WC_SUCCESS) {
 		/*
 		 * Tell IDM that the channel has gone down,
-		 * unless he already knows.
+		 * unless it already knows.
 		 */
 		switch (iser_chan->ic_conn->ic_stage) {
 		case ISER_CONN_STAGE_IC_DISCONNECTED:

--- a/usr/src/uts/common/io/ib/clients/rdsv3/rds_recv.c
+++ b/usr/src/uts/common/io/ib/clients/rdsv3/rds_recv.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -362,7 +363,7 @@ rdsv3_notify_queue_get(struct rdsv3_sock *rs, struct msghdr *msghdr)
 	 * in the user provided cmsg buffer. We don't try to copy more, to avoid
 	 * losing notifications - except when the buffer is so small that
 	 * it wouldn't
-	 * even hold a single notification. Then we give him as much of this
+	 * even hold a single notification. Then we give as much of this
 	 * single
 	 * msg as we can squeeze in, and set MSG_CTRUNC.
 	 */

--- a/usr/src/uts/common/io/ib/mgt/ibcm/ibcm_path.c
+++ b/usr/src/uts/common/io/ib/mgt/ibcm/ibcm_path.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/ib/mgt/ibcm/ibcm_impl.h>
@@ -1621,7 +1622,7 @@ ibcm_get_multi_pathrec(ibcm_path_tqargs_t *p_arg, ibtl_cm_port_list_t *sl,
 
 			/*
 			 * If SGID and/or DGID is specified by user, make sure
-			 * he gets his primary-path on those node points.
+			 * they get their primary-path on those node points.
 			 */
 			for (i = 0; i < num_rec; i++, pr_resp++) {
 				IBTF_DPRINTF_L3(cmlog, "ibcm_get_multi_pathrec:"

--- a/usr/src/uts/common/io/mem.c
+++ b/usr/src/uts/common/io/mem.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -903,7 +904,7 @@ mmsegmap(dev_t dev, off_t off, struct as *as, caddr_t *addrp, off_t len,
 		 * Make /dev/mem mappings non-consistent since we can't
 		 * alias pages that don't have page structs behind them,
 		 * such as kernel stack pages. If someone mmap()s a kernel
-		 * stack page and if we give him a tte with cv, a line from
+		 * stack page and if we give them a tte with cv, a line from
 		 * that page can get into both pages of the spitfire d$.
 		 * But snoop from another processor will only invalidate
 		 * the first page. This later caused kernel (xc_attention)

--- a/usr/src/uts/common/io/multidata.c
+++ b/usr/src/uts/common/io/multidata.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1291,7 +1292,7 @@ mmd_addpattr(multidata_t *mmd, pdesc_t *pd, pattrinfo_t *pai,
 		if (tbl == NULL)
 			return (NULL);
 
-		/* if someone got there first, use his table instead */
+		/* if someone got there first, use their table instead */
 		if ((o_tbl = atomic_cas_ptr(tbl_p, NULL, tbl)) != NULL) {
 			kmem_cache_free(pattbl_cache, tbl);
 			tbl = o_tbl;

--- a/usr/src/uts/common/io/myri10ge/drv/myri10ge.c
+++ b/usr/src/uts/common/io/myri10ge/drv/myri10ge.c
@@ -31,6 +31,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	lint
@@ -2138,11 +2139,11 @@ myri10ge_start_locked(struct myri10ge_priv *mgp)
 	}
 
 	/*
-	 * Tell the MCP how many buffers he has, and to
+	 * Tell the MCP how many buffers it has, and to
 	 *  bring the ethernet interface up
 	 *
 	 * Firmware needs the big buff size as a power of 2.  Lie and
-	 * tell him the buffer is larger, because we only use 1
+	 * tell it the buffer is larger, because we only use 1
 	 * buffer/pkt, and the mtu will prevent overruns
 	 */
 	big_pow2 = myri10ge_mtu + MXGEFW_PAD;
@@ -2563,7 +2564,7 @@ myri10ge_tx_done(struct myri10ge_slice_state *ss, uint32_t mcp_index)
 	}
 	if (tx->req == tx->done && tx->stop != NULL) {
 		/*
-		 * Nic has sent all pending requests, allow him
+		 * Nic has sent all pending requests, allow it
 		 * to stop polling this queue
 		 */
 		mutex_enter(&tx->lock);

--- a/usr/src/uts/common/io/pcic.c
+++ b/usr/src/uts/common/io/pcic.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -2646,7 +2647,7 @@ pcic_calc_speed(pcicdev_t *pcic, uint32_t speed)
  * Generally the larger value is taken if 2 are possible.
  */
 static struct pcic_card_times {
-	uint16_t cycle;	/* Speed as found in the atribute space of he card. */
+	uint16_t cycle;	/* Speed as found in the atribute space of the card. */
 	uint16_t setup;	/* Corresponding address setup time. */
 	uint16_t width;	/* Corresponding width, OE or WE. */
 	uint16_t hold;	/* Corresponding data or address hold time. */

--- a/usr/src/uts/common/io/ppp/sppp/sppp.c
+++ b/usr/src/uts/common/io/ppp/sppp/sppp.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation is hereby granted, provided that the above copyright
@@ -201,7 +202,7 @@ sppp_open(queue_t *q, dev_t *devp, int oflag, int sflag, cred_t *credp)
 
 /*
  * Free storage used by a PPA.  This is not called until the last PPA
- * user closes his connection or reattaches to a different PPA.
+ * user closes their connection or reattaches to a different PPA.
  */
 static void
 sppp_free_ppa(sppa_t *ppa)

--- a/usr/src/uts/common/io/ppp/spppasyn/spppasyn.c
+++ b/usr/src/uts/common/io/ppp/spppasyn/spppasyn.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation is hereby granted, provided that the above copyright
@@ -1541,9 +1542,9 @@ ahdlc_decode(queue_t *q, mblk_t  *mp)
 			 * If the peer sends us a character that's in
 			 * our receive character map, then that's
 			 * junk.  Discard it without changing state.
-			 * If he previously sent us an escape
+			 * If they previously sent us an escape
 			 * character, then toggle this one and
-			 * continue.  Otherwise, if he's now sending
+			 * continue.  Otherwise, if they're now sending
 			 * escape, set the flag for next time.
 			 */
 			if (IN_RX_MAP(chr, state->sa_raccm)) {

--- a/usr/src/uts/common/io/ppp/spppcomp/spppcomp.c
+++ b/usr/src/uts/common/io/ppp/spppcomp/spppcomp.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this software and its
  * documentation is hereby granted, provided that the above copyright
@@ -1186,7 +1187,7 @@ spppcomp_rput(queue_t *q, mblk_t *mp)
 				cp->cp_lastfinish = gethrtime();
 			}
 		} else {
-			/* Deferring; give him a clean slate */
+			/* Deferring; provide a clean slate */
 			cp->cp_fastin = 0;
 #ifdef SPC_DEBUG
 			cp->cp_in_queued++;

--- a/usr/src/uts/common/io/pshot.c
+++ b/usr/src/uts/common/io/pshot.c
@@ -24,6 +24,7 @@
  */
 /*
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -38,7 +39,7 @@
  * The pshot driver is rooted at /devices/pshot.  The following commands
  * illustrate the operation of devfs together with pshot's bus_config.
  * The first command demonstrates that, like the magician showing there's
- * nothing up his sleeve, /devices/pshot is empty.  The second command
+ * nothing up their sleeve, /devices/pshot is empty.  The second command
  * conjures up a branch of pshot nodes.  Note that pshot's bus_config is
  * called sequentially by devfs for each node, as part of the pathname
  * resolution, and that each pshot node is fully configured and

--- a/usr/src/uts/common/io/rlmod.c
+++ b/usr/src/uts/common/io/rlmod.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -1000,7 +1001,7 @@ rlwinctl(queue_t *q, mblk_t *mp)
 	TRACE_2(TR_FAC_RLOGINP, TR_RLOGINP_WINCTL_IN, "rlwinctl start: q %p, "
 	    "mp %p", q, mp);
 
-	rmip->oobdata[0] &= ~TIOCPKT_WINDOW; /* we know he heard */
+	rmip->oobdata[0] &= ~TIOCPKT_WINDOW; /* we know they heard */
 
 	if ((rl_msgp = mkiocb(TIOCSWINSZ)) == NULL) {
 		TRACE_2(TR_FAC_RLOGINP, TR_RLOGINP_WINCTL_OUT, "rlwinctl end: "

--- a/usr/src/uts/common/io/rsm/rsm.c
+++ b/usr/src/uts/common/io/rsm/rsm.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2012 Milan Jurik. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -6642,7 +6643,7 @@ rsm_closeconnection(rsmseg_t *seg, void **cookie)
 	 * Disconnect on adapter
 	 *
 	 * The current algorithm is stateless, I don't have to contact
-	 * server when I go away. He only gives me permissions. Of course,
+	 * server when I go away. It only gives me permissions. Of course,
 	 * the adapters will talk to terminate the connect.
 	 *
 	 * disconnect is needed only if we are CONNECTED not in CONN_QUIESCE

--- a/usr/src/uts/common/io/rsm/rsmops.c
+++ b/usr/src/uts/common/io/rsm/rsmops.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -291,7 +292,7 @@ rsm_get_controller(const char *name, uint_t number,
 		 * First check if the driver is registered
 		 */
 		if ((p_drv = find_rsmpi_driver(name)) == NULL) {
-			/* Cannot find the driver.  Try to load him */
+			/* Cannot find the driver.  Try to load it */
 			mutex_exit(&rsmops_lock);
 			if ((error = modload("drv", (char *)name)) == -1) {
 				return (RSMERR_CTLR_NOT_PRESENT);
@@ -462,7 +463,7 @@ rsm_register_controller(const char *name, uint_t number,
 /*
  * This is expected to be called from the driver's detach function
  * if this function returns EBUSY, the driver is supposed to fail
- * his own detach operation
+ * its own detach operation
  */
 int
 rsm_unregister_controller(const char *name, uint_t number)

--- a/usr/src/uts/common/io/scsi/adapters/scsi_vhci/scsi_vhci.c
+++ b/usr/src/uts/common/io/scsi/adapters/scsi_vhci/scsi_vhci.c
@@ -23,6 +23,7 @@
  */
 /*
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -8349,7 +8350,6 @@ vhci_uscsi_send_sense(struct scsi_pkt *pkt, mp_uscsi_cmd_t *mp_uscmdp)
 	if (scsi_pkt_allocated_correctly(rqpkt))
 		rqpkt->pkt_path_instance = 0;
 
-	/* get her done */
 	switch (scsi_transport(rqpkt)) {
 	case TRAN_ACCEPT:
 		VHCI_DEBUG(1, (CE_NOTE, NULL, "vhci_uscsi_send_sense: "

--- a/usr/src/uts/common/io/scsi/impl/scsi_hba.c
+++ b/usr/src/uts/common/io/scsi/impl/scsi_hba.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1994, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/note.h>
@@ -6973,7 +6974,7 @@ typedef struct scsi_lunrpt {
  * to allocate a buffer of sufficient size, and reissue the command. If the
  * first command succeeds, but the second fails, we return whatever we were
  * able to get the first time. We return enough information for the caller to
- * tell whether he got all the LUNs or only a subset.
+ * tell whether they got all the LUNs or only a subset.
  *
  * If successful, we allocate an array of scsi_lun_t to hold the results. The
  * caller must kmem_free(*lunarrayp, *sizep) when finished with it. Upon

--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -24,7 +24,7 @@
  */
 /*
  * Copyright (c) 2011 Bayard G. Bell.  All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
  */
@@ -27655,7 +27655,7 @@ sr_read_all_subcodes(dev_t dev, caddr_t data, int flag)
 		cdb[10] = 1;
 	} else {
 		/*
-		 * Note: A vendor specific command (0xDF) is being used her to
+		 * Note: A vendor specific command (0xDF) is being used here to
 		 * request a read of all subcodes.
 		 */
 		cdb[0] = (char)SCMD_READ_ALL_SUBCODES;

--- a/usr/src/uts/common/io/usb/clients/ugen/ugen.c
+++ b/usr/src/uts/common/io/usb/clients/ugen/ugen.c
@@ -20,6 +20,7 @@
  *
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -30,7 +31,7 @@
  * to  talk to	USB  devices.  This is	very  useful for  Point of Sale sale
  * devices and other simple  devices like  USB	scanner, USB palm  pilot.
  * The UGEN provides a system call interface to USB  devices  enabling
- * a USB device vendor to  write an  application for his
+ * a USB device vendor to write an application for their
  * device instead of  writing a driver. This facilitates the vendor to write
  * device management s/w quickly in userland.
  *

--- a/usr/src/uts/common/io/usb/hcd/ehci/ehci_isoch_util.c
+++ b/usr/src/uts/common/io/usb/hcd/ehci/ehci_isoch_util.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -869,7 +870,7 @@ void ehci_insert_itd_on_itw(
  * ehci_insert_itd_into_active_list:
  *
  * Add current ITD into the active ITD list in reverse order.
- * When he done list is created, remove it in the reverse order.
+ * When the done list is created, remove it in the reverse order.
  */
 void
 ehci_insert_itd_into_active_list(

--- a/usr/src/uts/common/io/usb/hcd/openhci/ohci_polled.c
+++ b/usr/src/uts/common/io/usb/hcd/openhci/ohci_polled.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -326,7 +327,7 @@ ohci_hcdi_polled_read(
 
 	/*
 	 * To make sure after we get the done list from DoneHead,
-	 * every input device get his own TD's in the
+	 * every input device gets its own TD's in the
 	 * ohci_polled_done_list and then clear the interrupt status.
 	 */
 	if (intr & HCR_INTR_WDH) {

--- a/usr/src/uts/common/io/usb/scsa2usb/scsa2usb.c
+++ b/usr/src/uts/common/io/usb/scsa2usb/scsa2usb.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -3889,7 +3890,7 @@ scsa2usb_rw_transport(scsa2usb_state_t *scsa2usbp, struct scsi_pkt *pkt)
 	cmd->cmd_blksize = (int)blk_size;
 
 	/*
-	 * Having figure out the 'partial' xfer len based on he
+	 * Having figured out the 'partial' xfer len based on the
 	 * block size; fill it in to the cmd->cmd_cdb
 	 */
 	cmd->cmd_cdb[SCSA2USB_OPCODE] = (uchar_t)opcode;

--- a/usr/src/uts/common/io/usb/usba/usba_ugen.c
+++ b/usr/src/uts/common/io/usb/usba/usba_ugen.c
@@ -20,6 +20,7 @@
  *
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -36,7 +37,7 @@
  * to  talk to	USB  devices.  This is	very  useful for  Point of Sale sale
  * devices and other simple  devices like  USB	scanner, USB palm  pilot.
  * The UGEN provides a system call interface to USB  devices  enabling
- * a USB device vendor to  write an  application for his
+ * a USB device vendor to write an application for their
  * device instead of  writing a driver. This facilitates the vendor to write
  * device management s/w quickly in userland.
  *

--- a/usr/src/uts/common/klm/nlm_service.c
+++ b/usr/src/uts/common/klm/nlm_service.c
@@ -26,7 +26,7 @@
  */
 
 /*
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2014 Joyent, Inc.  All rights reserved.
  */
@@ -704,7 +704,7 @@ nlm_block(nlm4_lockargs *lockargs,
 		 * Sleeping lock request with given fl is already
 		 * registered by someone else. This means that
 		 * some other thread is handling the request, let
-		 * him to do its work.
+		 * it do its work.
 		 */
 		ASSERT(error == EEXIST);
 		return;

--- a/usr/src/uts/common/netinet/tcp_timer.h
+++ b/usr/src/uts/common/netinet/tcp_timer.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1982, 1986 Regents of the University of California.
  * All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Redistribution and use in source and binary forms are permitted
  * provided that the above copyright notice and this paragraph are
@@ -51,7 +52,7 @@ extern "C" {
  * and the window is too small to bother sending anything, then we start
  * the TCPT_PERSIST timer.  When it expires, if the window is nonzero,
  * we go to transmit state.  Otherwise, at intervals send a single byte
- * into the peer's window to force him to update our window information.
+ * into the peer's window to force it to update our window information.
  * We do this at most as often as TCPT_PERSMIN time intervals,
  * but no more frequently than the current estimate of round-trip
  * packet time.  The TCPT_PERSIST timer is cleared whenever we receive

--- a/usr/src/uts/common/os/bio.c
+++ b/usr/src/uts/common/os/bio.c
@@ -728,7 +728,7 @@ loop:
 
 	/*
 	 * Come here in case of an internal error. At this point we couldn't
-	 * get a buffer, but he have to return one. Hence we allocate some
+	 * get a buffer, but we have to return one. Hence we allocate some
 	 * kind of error reply buffer on the fly. This buffer is marked as
 	 * B_NOCACHE | B_AGE | B_ERROR | B_DONE to assure the following:
 	 *	- B_ERROR will indicate error to the caller.

--- a/usr/src/uts/common/os/callout.c
+++ b/usr/src/uts/common/os/callout.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/callo.h>
@@ -853,7 +854,7 @@ callout_heap_delete(callout_table_t *ct)
  * scanning the heap anyway.
  *
  * If the root gets changed and/or callout lists are expired, return the
- * new expiration to the caller so he can reprogram the cyclic accordingly.
+ * new expiration to the caller so it can reprogram the cyclic accordingly.
  */
 static hrtime_t
 callout_heap_process(callout_table_t *ct, hrtime_t delta, int timechange)

--- a/usr/src/uts/common/os/core.c
+++ b/usr/src/uts/common/os/core.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011, Joyent Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -400,8 +401,8 @@ do_core(char *fp, int sig, enum core_types core_type, struct core_globals *cg)
 	 * For security reasons, we don't want root processes
 	 * to dump core through a symlink because that would
 	 * allow a malicious user to clobber any file on
-	 * the system if s/he could convince a root process,
-	 * perhaps a set-uid root process that s/he started,
+	 * the system if they could convince a root process,
+	 * perhaps a set-uid root process that they started,
 	 * to dump core in a directory writable by that user.
 	 * Similar security reasons apply to hard links.
 	 * For symmetry we do this unconditionally, not

--- a/usr/src/uts/common/os/cpu.c
+++ b/usr/src/uts/common/os/cpu.c
@@ -879,7 +879,7 @@ cpu_pause_free(cpu_t *cp)
 
 	ASSERT(MUTEX_HELD(&cpu_lock));
 	/*
-	 * We have to get the thread and tell him to die.
+	 * We have to get the thread and tell it to die.
 	 */
 	if ((t = cp->cpu_pause_thread) == NULL) {
 		ASSERT(safe_list[cpun] == PAUSE_IDLE);

--- a/usr/src/uts/common/os/devcfg.c
+++ b/usr/src/uts/common/os/devcfg.c
@@ -23,6 +23,7 @@
  * Copyright 2012 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/note.h>
@@ -7698,7 +7699,7 @@ mt_config_children(struct mt_config_handle *hdl)
 			brn = NULL;
 
 		/*
-		 * Hold the child that we are processing so he does not get
+		 * Hold the child that we are processing so it does not get
 		 * removed. The corrisponding ndi_rele_devi() for children
 		 * that are not being skipped is done at the end of
 		 * mt_config_thread().
@@ -7797,7 +7798,7 @@ mt_config_driver(struct mt_config_handle *hdl)
 	dip = devnamesp[par_major].dn_head;
 	while (dip) {
 		/*
-		 * Hold the child that we are processing so he does not get
+		 * Hold the child that we are processing so it does not get
 		 * removed. The corrisponding ndi_rele_devi() for children
 		 * that are not being skipped is done at the end of
 		 * mt_config_thread().

--- a/usr/src/uts/common/os/mutex.c
+++ b/usr/src/uts/common/os/mutex.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -149,7 +150,7 @@
  *
  * In many ways (1) is the cleanest solution, but if a lock is moderately
  * contended it defeats the adaptive spin logic.  If we make some other
- * thread the owner, but he's not ONPROC yet, then all other threads on
+ * thread the owner, but it's not ONPROC yet, then all other threads on
  * other cpus that try to get the lock will conclude that the owner is
  * blocked, so they'll block too.  And so on -- it escalates quickly,
  * with every thread taking the blocking path rather than the spin path.

--- a/usr/src/uts/common/os/pghw.c
+++ b/usr/src/uts/common/os/pghw.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/systm.h>
@@ -577,8 +578,8 @@ pghw_cu_kstat_update(kstat_t *ksp, int rw)
 		return (EACCES);
 
 	/*
-	 * Check whether the caller has priv_cpc_cpu privilege. If he doesn't,
-	 * he will not get hardware utilization data.
+	 * Check whether the caller has priv_cpc_cpu privilege. If it doesn't,
+	 * it will not get hardware utilization data.
 	 */
 
 	has_cpc_privilege = (secpolicy_cpc_cpu(crgetcred()) == 0);

--- a/usr/src/uts/common/os/policy.c
+++ b/usr/src/uts/common/os/policy.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -866,8 +867,8 @@ secpolicy_fs_unmount(cred_t *cr, struct vfs *vfsp)
 }
 
 /*
- * Quotas are a resource, but if one has the ability to mount a filesystem, he
- * should be able to modify quotas on it.
+ * Quotas are a resource, but if one has the ability to mount a filesystem,
+ * they should be able to modify quotas on it.
  */
 int
 secpolicy_fs_quota(const cred_t *cr, const vfs_t *vfsp)

--- a/usr/src/uts/common/os/strsubr.c
+++ b/usr/src/uts/common/os/strsubr.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -6390,7 +6391,7 @@ drain_syncq(syncq_t *sq)
 		sq->sq_svcflags &= ~SQ_SERVICE;
 
 	/*
-	 * If SQ_EXCL is set, someone else is processing this syncq - let him
+	 * If SQ_EXCL is set, someone else is processing this syncq - let them
 	 * finish the job.
 	 */
 	if (flags & SQ_EXCL) {

--- a/usr/src/uts/common/os/task.c
+++ b/usr/src/uts/common/os/task.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2000, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/atomic.h>
@@ -787,7 +788,7 @@ changeproj(proc_t *p, kproject_t *kpj, zone_t *zone, void *projbuf,
 			oldkpj = ttoproj(t);
 
 			/*
-			 * Kick this thread so that he doesn't sit
+			 * Kick this thread so that it doesn't sit
 			 * on a wrong wait queue.
 			 */
 			if (ISWAITING(t))

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015, Joyent Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -6168,7 +6169,7 @@ zone_enter(zoneid_t zoneid)
 		do {
 			thread_lock(t);
 			/*
-			 * Kick this thread so that he doesn't sit
+			 * Kick this thread so that it doesn't sit
 			 * on a wrong wait queue.
 			 */
 			if (ISWAITING(t))
@@ -6358,8 +6359,8 @@ zone_list(zoneid_t *zoneidlist, uint_t *numzones)
 
 	/*
 	 * If user has allocated space for fewer entries than we found, then
-	 * return only up to his limit.  Either way, tell him exactly how many
-	 * we found.
+	 * return only up to their limit.  Either way, tell them exactly how
+	 * many we found.
 	 */
 	if (domi_nzones < user_nzones)
 		user_nzones = domi_nzones;

--- a/usr/src/uts/common/rpc/clnt_cots.c
+++ b/usr/src/uts/common/rpc/clnt_cots.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -3613,7 +3614,7 @@ clnt_dispatch_notifyall(queue_t *q, int32_t msg_type, int32_t reason)
 				e->call_reason = reason;
 			e->call_notified = TRUE;
 			/*
-			 * Let the caller timeout, else he will retry
+			 * Let the caller timeout, else it will retry
 			 * immediately.
 			 */
 			e->call_status = RPC_XPRTFAILED;

--- a/usr/src/uts/common/smbsrv/ntifs.h
+++ b/usr/src/uts/common/smbsrv/ntifs.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef _SMBSRV_NTIFS_H
@@ -439,7 +440,7 @@ typedef struct smb_acl {
  * Security descriptors provide protection for objects, for example
  * files and directories. It identifies the owner and primary group
  * (SIDs) and contains an access control list. When a user tries to
- * access an object his SID is compared to the permissions in the
+ * access an object their SID is compared to the permissions in the
  * DACL to determine if access should be allowed or denied. Note that
  * this is a simplification because there are other factors, such as
  * default behavior and privileges to be taken into account (see also

--- a/usr/src/uts/common/smbsrv/smb_share.h
+++ b/usr/src/uts/common/smbsrv/smb_share.h
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef _SMB_SHARE_H
@@ -181,7 +182,7 @@ extern "C" {
 #define	SMB_SHARE_PRINT_LEN	6
 /*
  * refcnt is currently only used for autohome.  autohome needs a refcnt
- * because a user can map his autohome share from more than one client
+ * because a user can map their autohome share from more than one client
  * at the same time and the share should only be removed when the last
  * one is disconnected
  */

--- a/usr/src/uts/common/sys/ddi_impldefs.h
+++ b/usr/src/uts/common/sys/ddi_impldefs.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 1991, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_DDI_IMPLDEFS_H
@@ -354,7 +355,7 @@ struct dev_info  {
 /*
  * Device state macros.
  * o All SET/CLR/DONE users must protect context with devi_lock.
- * o DEVI_SET_DEVICE_ONLINE users must do his own DEVI_SET_REPORT.
+ * o DEVI_SET_DEVICE_ONLINE users must do their own DEVI_SET_REPORT.
  * o DEVI_SET_DEVICE_{DOWN|DEGRADED|UP} should only be used when !OFFLINE.
  * o DEVI_SET_DEVICE_UP clears DOWN and DEGRADED.
  */

--- a/usr/src/uts/common/sys/esunddi.h
+++ b/usr/src/uts/common/sys/esunddi.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #ifndef	_SYS_ESUNDDI_H
@@ -183,7 +184,7 @@ e_ddi_hold_devi(dev_info_t *);
 
 /*
  * Return the reference count on a devinfo node. The caller can determine,
- * with knowledge of his own holds, if the devinfo node is still in use.
+ * with knowledge of its own holds, if the devinfo node is still in use.
  */
 int
 e_ddi_devi_holdcnt(dev_info_t *dip);

--- a/usr/src/uts/common/syscall/lwpsys.c
+++ b/usr/src/uts/common/syscall/lwpsys.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -300,7 +301,7 @@ lwp_wait(id_t lwpid, id_t *departed)
 					error = EDEADLK;
 					break;
 				}
-				/* who is he waiting for? */
+				/* who are they waiting for? */
 				if ((tid = t->t_waitfor) == -1)
 					break;
 				if (tid == 0) {

--- a/usr/src/uts/common/syscall/poll.c
+++ b/usr/src/uts/common/syscall/poll.c
@@ -28,7 +28,7 @@
 /*	  All Rights Reserved  	*/
 
 /*
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
  * Copyright 2015, Joyent, Inc.
  */
 
@@ -370,8 +370,8 @@ poll_common(pollfd_t *fds, nfds_t nfds, timespec_t *tsp, k_sigset_t *ksetp)
 	}
 
 	/*
-	 * Check to see if this guy just wants to use poll() as a timeout.
-	 * If yes then bypass all the other stuff and make him sleep.
+	 * Check to see if this one just wants to use poll() as a timeout.
+	 * If yes then bypass all the other stuff and make it sleep.
 	 */
 	if (nfds == 0) {
 		/*

--- a/usr/src/uts/common/vm/page_retire.c
+++ b/usr/src/uts/common/vm/page_retire.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -690,7 +691,7 @@ page_retire_transient_ue(page_t *pp)
 	ASSERT(!hat_page_is_mapped(pp));
 
 	/*
-	 * If this page is a repeat offender, retire him under the
+	 * If this page is a repeat offender, retire it under the
 	 * "two strikes and you're out" rule. The caller is responsible
 	 * for scrubbing the page to try to clear the error.
 	 */

--- a/usr/src/uts/common/vm/seg_spt.c
+++ b/usr/src/uts/common/vm/seg_spt.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, Joyent, Inc. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -1112,7 +1113,7 @@ segspt_dismpagelock(struct seg *seg, caddr_t addr, size_t len,
 	}
 	/*
 	 * We can now drop the sptd->spt_lock since the ppa[]
-	 * exists and he have incremented pacachecnt.
+	 * exists and we have incremented pacachecnt.
 	 */
 	mutex_exit(&sptd->spt_lock);
 
@@ -1374,7 +1375,7 @@ segspt_shmpagelock(struct seg *seg, caddr_t addr, size_t len,
 
 	/*
 	 * We can now drop the sptd->spt_lock since the ppa[]
-	 * exists and he have incremented pacachecnt.
+	 * exists and we have incremented pacachecnt.
 	 */
 	mutex_exit(&sptd->spt_lock);
 

--- a/usr/src/uts/i86pc/ml/syscall_asm.s
+++ b/usr/src/uts/i86pc/ml/syscall_asm.s
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1990, 1991 UNIX System Laboratories, Inc.	*/
@@ -160,7 +161,7 @@
 1:	movl	4(%esp), %ebx		/* restore user %gs (re-do if	*/ ;\
 	movw	%bx, %gs		/* branch due to no callback)	*/ ;\
 	movl	8(%esp), %ebx		/* restore user's %ebx		*/ ;\
-	addl	$16, %esp		/* restore stack ptr		*/ 
+	addl	$16, %esp		/* restore stack ptr		*/
 
 #define	MSTATE_TRANSITION(from, to)		\
 	pushl	$to;				\
@@ -343,7 +344,7 @@ __lwptoregs_msg:
  * |------------|
  * | 8 args	| <- %esp	MAXSYSARGS (currently 8) arguments
  * |------------|
- * 
+ *
  */
 #define	SYS_DROP	_CONST(_MUL(MAXSYSARGS, 4))
 
@@ -402,7 +403,7 @@ _watch_do_syscall:
 	popl	%eax
 
 	movl	%gs:CPU_THREAD, %ebx
-	
+
 	ASSERT_LWPTOREGS(%ebx, %esp)
 
 	CHECK_PRESYS_NE(%ebx, %eax)
@@ -496,7 +497,7 @@ _syscall_fault:
  *	mov	$1f, %edx	/ return %eip
  *	mov	%esp, %ecx	/ return %esp
  *	sysenter
- * 1:	
+ * 1:
  *
  * Hardware and (privileged) initialization code have arranged that by
  * the time the sysenter instructions completes:
@@ -520,7 +521,7 @@ _syscall_fault:
  * single-stepping in a debugger.  For most of the system call mechanisms,
  * the CPU automatically clears the single-step flag before we enter the
  * kernel.  The sysenter mechanism does not clear the flag, so a user
- * single-stepping through a libc routine may suddenly find him/herself
+ * single-stepping through a libc routine may suddenly find themself
  * single-stepping through the kernel.  To detect this, kmdb compares the
  * trap %pc to the [brand_]sys_enter addresses on each single-step trap.
  * If it finds that we have single-stepped to a sysenter entry point, it
@@ -608,7 +609,7 @@ _sysenter_done:
 	/
 	/ sysexit uses %edx to restore %eip, so we can't use it
 	/ to return a value, sigh.
-	/ 
+	/
 	movl	%eax, REGOFF_EAX(%esp)
 	/ movl	%edx, REGOFF_EDX(%esp)
 
@@ -656,7 +657,7 @@ void
 sep_save(void *ksp)
 {}
 
-/*ARGSUSED*/			
+/*ARGSUSED*/
 void
 sep_restore(void *ksp)
 {}

--- a/usr/src/uts/i86pc/ml/syscall_asm_amd64.s
+++ b/usr/src/uts/i86pc/ml/syscall_asm_amd64.s
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Joyent, Inc.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/asm_linkage.h>
@@ -227,7 +228,7 @@
 	ORL_SYSCALLTRACE(rtmp);				\
 	orl	T_POST_SYS_AST(t), rtmp;		\
 	cmpl	$0, rtmp
-	
+
 /*
  * Fix up the lwp, thread, and eflags for a successful return
  *
@@ -318,8 +319,8 @@ __no_rupdate_msg:
  * Do the traptrace thing and restore any registers we used
  * in situ.  Assumes that %rsp is pointing at the base of
  * the struct regs, obviously ..
- */	
-#ifdef TRAPTRACE	
+ */
+#ifdef TRAPTRACE
 #define	SYSCALL_TRAPTRACE(ttype)				\
 	TRACE_PTR(%rdi, %rbx, %ebx, %rcx, ttype);		\
 	TRACE_REGS(%rdi, %rsp, %rbx, %rcx);			\
@@ -338,10 +339,10 @@ __no_rupdate_msg:
 	orl	%ebx, %ebx;					\
 	orl	%ecx, %ecx;					\
 	orl	%edx, %edx;					\
-	orl	%edi, %edi	
+	orl	%edi, %edi
 #else	/* TRAPTRACE */
 #define	SYSCALL_TRAPTRACE(ttype)
-#define	SYSCALL_TRAPTRACE32(ttype)	
+#define	SYSCALL_TRAPTRACE32(ttype)
 #endif	/* TRAPTRACE */
 
 /*
@@ -362,7 +363,7 @@ __no_rupdate_msg:
  *	%r12-%r15 contain caller state
  *
  * The syscall instruction arranges that:
- *	
+ *
  *	%rcx contains the return %rip
  *	%r11d contains bottom 32-bits of %rflags
  *	%rflags is masked (as determined by the SFMASK msr)
@@ -500,7 +501,7 @@ noprod_sys_syscall:
 	SYSCALL_TRAPTRACE($TT_SYSC64)
 
 	movq	%rsp, %rbp
-	
+
 	movq	T_LWP(%r15), %r14
 	ASSERT_NO_RUPDATE_PENDING(%r14)
 	ENABLE_INTR_FLAGS
@@ -531,7 +532,7 @@ _syscall_invoke:
 	movq	REGOFF_R9(%rbp), %r9
 
 	cmpl	$NSYSCALL, %eax
-	jae	_syscall_ill	
+	jae	_syscall_ill
 	shll	$SYSENT_SIZE_SHIFT, %eax
 	leaq	sysent(%rax), %rbx
 
@@ -575,7 +576,7 @@ _syscall_invoke:
 	 * find a non-canonical %rip, we opt to go through the full
 	 * _syscall_post path which takes us into an iretq which is not
 	 * susceptible to the same problems sysret is.
-	 * 
+	 *
 	 * We're checking for a canonical address by first doing an arithmetic
 	 * shift. This will fill in the remaining bits with the value of bit 63.
 	 * If the address were canonical, the register would now have either all
@@ -613,7 +614,7 @@ _syscall_invoke:
 	movq	REGOFF_RAX(%rsp), %rax
 	movq	REGOFF_RBX(%rsp), %rbx
 
-	movq	REGOFF_RBP(%rsp), %rbp	
+	movq	REGOFF_RBP(%rsp), %rbp
 	movq	REGOFF_R10(%rsp), %r10
 	/* %r11 used to restore %rfl value */
 	movq	REGOFF_R12(%rsp), %r12
@@ -622,7 +623,7 @@ _syscall_invoke:
 	movq	REGOFF_R14(%rsp), %r14
 	movq	REGOFF_R15(%rsp), %r15
 
-	movq	REGOFF_RIP(%rsp), %rcx	
+	movq	REGOFF_RIP(%rsp), %rcx
 	movl	REGOFF_RFL(%rsp), %r11d
 
 #if defined(__xpv)
@@ -684,7 +685,7 @@ _syscall_pre:
 	/*
 	 * Didn't abort, so reload the syscall args and invoke the handler.
 	 */
-	movzwl	T_SYSNUM(%r15), %eax	
+	movzwl	T_SYSNUM(%r15), %eax
 	jmp	_syscall_invoke
 
 _syscall_ill:
@@ -937,7 +938,7 @@ _full_syscall_postsys32:
  * single-stepping in a debugger.  For most of the system call mechanisms,
  * the CPU automatically clears the single-step flag before we enter the
  * kernel.  The sysenter mechanism does not clear the flag, so a user
- * single-stepping through a libc routine may suddenly find him/herself
+ * single-stepping through a libc routine may suddenly find themself
  * single-stepping through the kernel.  To detect this, kmdb compares the
  * trap %pc to the [brand_]sys_enter addresses on each single-step trap.
  * If it finds that we have single-stepped to a sysenter entry point, it
@@ -1213,7 +1214,7 @@ nopop_syscall_int:
 	SET_SIZE(brand_sys_syscall_int)
 
 #endif	/* __lint */
-	
+
 /*
  * Legacy 32-bit applications and old libc implementations do lcalls;
  * we should never get here because the LDT entry containing the syscall
@@ -1247,7 +1248,7 @@ sys_lcall32()
 	call	panic
 	SET_SIZE(sys_lcall32)
 
-__lcall_panic_str:	
+__lcall_panic_str:
 	.string	"sys_lcall32: shouldn't be here!"
 
 /*

--- a/usr/src/uts/i86pc/os/cms.c
+++ b/usr/src/uts/i86pc/os/cms.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /*
  * Copyright (c) 2010, Intel Corporation.
@@ -385,7 +386,7 @@ cms_load_specific(cmi_hdl_t hdl, void **datap)
 
 		/*
 		 * The module failed or declined to init, so release
-		 * it and potentially change i to be equal to he number
+		 * it and potentially change i to be equal to the number
 		 * of suffices actually used in the last module path.
 		 */
 		cms_rele(cms);

--- a/usr/src/uts/intel/io/drm/radeon_irq.c
+++ b/usr/src/uts/intel/io/drm/radeon_irq.c
@@ -2,6 +2,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 /* radeon_irq.c -- IRQ handling for radeon -*- linux-c -*- */
 /*
@@ -181,7 +182,7 @@ static int radeon_driver_vblank_do_wait(struct drm_device *dev,
 
 	/*
 	 * Assume that the user has missed the current sequence number
-	 * by about a day rather than she wants to wait for years
+	 * by about a day rather than wanting to wait for years
 	 * using vertical blanks...
 	 */
 	DRM_WAIT_ON(ret, &dev->vbl_queue, 3 * DRM_HZ,

--- a/usr/src/uts/sfmmu/ml/sfmmu_asm.s
+++ b/usr/src/uts/sfmmu/ml/sfmmu_asm.s
@@ -21,6 +21,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -82,7 +83,7 @@
 /*
  * Assumes TSBE_TAG is 0
  * Assumes TSBE_INTHI is 0
- * Assumes TSBREG.split is 0	
+ * Assumes TSBREG.split is 0
  */
 
 #if TSBE_TAG != 0
@@ -358,7 +359,7 @@ label:									;\
  *
  * tsbep = pointer to the TSBE to load as va (ro)
  * tteva = pointer to the TTE to load as va (ro)
- * tagtarget = TSBE tag to load (which contains no context), synthesized 
+ * tagtarget = TSBE tag to load (which contains no context), synthesized
  * to match va of MMU tag target register only (ro)
  * tmp1, tmp2 = scratch registers (clobbered)
  * label = label to use for branches (text)
@@ -425,7 +426,7 @@ label/**/1:								;\
 	cmp	tmp1, tmp3		/* if not successful */		;\
 	bne,a,pn %icc, label/**/1	/* start over from the top */	;\
 	  lda	[tsbep]ASI_MEM, tmp1	/* reloading tsbe tag */	;\
-label/**/2:	
+label/**/2:
 
 #else /* UTSB_PHYS */
 
@@ -444,7 +445,7 @@ label/**/1:								;\
 	cmp	tmp1, tmp3		/* if not successful */		;\
 	bne,a,pn %icc, label/**/1	/* start over from the top */	;\
 	  lda	[tsbep]%asi, tmp1	/* reloading tsbe tag */	;\
-label/**/2:	
+label/**/2:
 
 #endif /* UTSB_PHYS */
 
@@ -490,7 +491,7 @@ sfmmu_enable_intrs(uint_t pstate_save)
 int
 sfmmu_alloc_ctx(sfmmu_t *sfmmup, int allocflag, struct cpu *cp, int shflag)
 { return(0); }
-	
+
 /*
  * Use cas, if tte has changed underneath us then reread and try again.
  * In the case of a retry, it will update sttep with the new original.
@@ -557,7 +558,7 @@ sfmmu_panic8:
 	.global	sfmmu_panic9
 sfmmu_panic9:
 	.asciz	"sfmmu_asm: cnum is greater than MAX_SFMMU_CTX_VAL"
-	
+
 	.global	sfmmu_panic10
 sfmmu_panic10:
 	.asciz	"sfmmu_asm: valid SCD with no 3rd scd TSB"
@@ -565,7 +566,7 @@ sfmmu_panic10:
 	.global	sfmmu_panic11
 sfmmu_panic11:
 	.asciz	"sfmmu_asm: ktsb_phys must not be 0 on a sun4v platform"
-	
+
         ENTRY(sfmmu_disable_intrs)
         rdpr    %pstate, %o0
 #ifdef DEBUG
@@ -574,7 +575,7 @@ sfmmu_panic11:
         retl
           wrpr   %o0, PSTATE_IE, %pstate
         SET_SIZE(sfmmu_disable_intrs)
-	
+
 	ENTRY(sfmmu_enable_intrs)
         retl
           wrpr    %g0, %o0, %pstate
@@ -630,9 +631,9 @@ sfmmu_panic11:
 0:
 	PANIC_IF_INTR_ENABLED_PSTR(sfmmu_ei_l1, %g1)
 #endif /* DEBUG */
-	
+
 	mov	%o3, %g1			! save sfmmu pri/sh flag in %g1
-		
+
 	! load global mmu_ctxp info
 	ldx	[%o2 + CPU_MMU_CTXP], %o3		! %o3 = mmu_ctx_t ptr
 
@@ -651,20 +652,20 @@ sfmmu_panic11:
 	cmp	%o4, %g0		! mmu_ctxp->gnum should never be 0
 	bne,pt	%xcc, 3f
 	  nop
-	
+
 	sethi   %hi(panicstr), %g1	! test if panicstr is already set
         ldx     [%g1 + %lo(panicstr)], %g1
         tst     %g1
         bnz,pn  %icc, 1f
           nop
-	
+
 	sethi	%hi(sfmmu_panic8), %o0
 	call	panic
 	  or	%o0, %lo(sfmmu_panic8), %o0
-1:	
+1:
 	retl
 	  mov	%g0, %o0			! %o0 = ret = 0
-3:	
+3:
 #endif
 
 	! load HAT sfmmu_ctxs[mmuid] gnum, cnum
@@ -681,7 +682,7 @@ sfmmu_panic11:
 	 * Fast path code, do a quick check.
 	 */
 	SFMMU_MMUID_GNUM_CNUM(%g2, %g5, %g6, %g4)
-	
+
 	cmp	%g6, INVALID_CONTEXT		! hat cnum == INVALID ??
 	bne,pt	%icc, 1f			! valid hat cnum, check gnum
 	  nop
@@ -709,7 +710,7 @@ sfmmu_panic11:
 	  mov	%g6, %o1
 
 2:
-	/* 
+	/*
 	 * Grab per process (PP) sfmmu_ctx_lock spinlock,
 	 * followed by the 'slow path' code.
 	 */
@@ -808,11 +809,11 @@ sfmmu_panic11:
 	cmp	%o1, %o5
 	ble,pt %icc, 2f
 	  nop
-	
+
 	sethi	%hi(sfmmu_panic9), %o0
 	call	panic
 	  or	%o0, %lo(sfmmu_panic9), %o0
-2:	
+2:
 #endif
 	! update hat gnum and cnum
 	sllx	%o4, SFMMU_MMU_GNUM_RSHIFT, %o4
@@ -821,7 +822,7 @@ sfmmu_panic11:
 
 	membar  #LoadStore|#StoreStore
 	clrb	[%o0 + SFMMU_CTX_LOCK]
-	
+
 	mov	1, %g4			! %g4 = ret = 1
 8:
 	/*
@@ -830,18 +831,18 @@ sfmmu_panic11:
 	 * %o1 = cnum
 	 * %g1 = sfmmu private/shared flag (0:private,  1:shared)
 	 */
-	 
+
 	/*
-	 * When we come here and context is invalid, we want to set both 
+	 * When we come here and context is invalid, we want to set both
 	 * private and shared ctx regs to INVALID. In order to
 	 * do so, we set the sfmmu priv/shared flag to 'private' regardless
 	 * so that private ctx reg will be set to invalid.
 	 * Note that on sun4v values written to private context register are
-	 * automatically written to corresponding shared context register as 
+	 * automatically written to corresponding shared context register as
 	 * well. On sun4u SET_SECCTX() will invalidate shared context register
 	 * when it sets a private secondary context register.
 	 */
-	 
+
 	cmp	%o1, INVALID_CONTEXT
 	be,a,pn	%icc, 9f
 	  clr	%g1
@@ -887,7 +888,7 @@ sfmmu_panic11:
 	cmp	%g3, %g2			/* is modified = current? */
 	be,a,pn %xcc,1f				/* yes, don't write */
 	mov	0, %o1				/* as if cas failed. */
-		
+
 	casx	[%o2], %g1, %g2
 	membar	#StoreLoad
 	cmp	%g1, %g2
@@ -985,7 +986,7 @@ sfmmu_kpm_unload_tsb(caddr_t addr, int vpshift)
 #else /* lint */
 
 #define	I_SIZE		4
-		
+
 	ENTRY_NP(sfmmu_fix_ktlb_traptable)
 	/*
 	 * %o0 = start of patch area
@@ -1046,7 +1047,7 @@ sfmmu_kpm_unload_tsb(caddr_t addr, int vpshift)
 	 * nop
 	 * or      tmp, dest, dest
 	 *
-	 * which differs from the implementation in the 
+	 * which differs from the implementation in the
 	 * "SPARC Architecture Manual"
 	 */
 	/* fixup sethi instruction */
@@ -1229,7 +1230,7 @@ do_patch:
 	sethi	%hi(iktsb4m), %o0
 	call	sfmmu_fix_ktlb_traptable
 	  or	%o0, %lo(iktsb4m), %o0
-	
+
 	sethi	%hi(dktsb4m), %o0
 	call	sfmmu_fix_ktlb_traptable
 	  or	%o0, %lo(dktsb4m), %o0
@@ -1272,7 +1273,7 @@ do_patch:
 	sethi	%hi(iktsb4mbase), %o0
 	call	sfmmu_fixup_setx	! patch value of ktsb4m base addr
 	  or	%o0, %lo(iktsb4mbase), %o0
-	
+
 	sethi	%hi(sfmmu_kprot_patch_ktsb4m_base), %o0
 	call	sfmmu_fixup_setx	! patch value of ktsb4m base addr
 	  or	%o0, %lo(sfmmu_kprot_patch_ktsb4m_base), %o0
@@ -1323,7 +1324,7 @@ do_patch:
 
 	ENTRY_NP(sfmmu_kpm_patch_tsbm)
 	/*
-	 * nop the branch to sfmmu_kpm_dtsb_miss_small 
+	 * nop the branch to sfmmu_kpm_dtsb_miss_small
 	 * in the case where we are using large pages for
 	 * seg_kpm (and hence must probe the second TSB for
 	 * seg_kpm VAs)
@@ -1472,14 +1473,14 @@ do_patch:
 	TSB_UPDATE(%o0, %o2, %o1, %g1, %g2, locked_tsb_l8)
 
 	wrpr	%g0, %o5, %pstate		/* enable interrupts */
-	
+
 	retl
 	membar	#StoreStore|#StoreLoad
 	SET_SIZE(sfmmu_load_tsbe)
 
 	/*
 	 * Flush TSB of a given entry if the tag matches.
-	 */ 
+	 */
 	ENTRY(sfmmu_unload_tsbe)
 	/*
 	 * %o0 = pointer to tsbe to be flushed
@@ -1683,7 +1684,7 @@ label:
 #if defined (lint)
 /*
  * The following routines are jumped to from the mmu trap handlers to do
- * the setting up to call systrap.  They are separate routines instead of 
+ * the setting up to call systrap.  They are separate routines instead of
  * being part of the handlers because the handlers would exceed 32
  * instructions and since this is part of the slow path the jump
  * cost is irrelevant.
@@ -1760,7 +1761,7 @@ test_ptl1_panic:
 	or	%g1, %lo(trap), %g1
 2:
 	ba,pt	%xcc, sys_trap
-	  mov	-1, %g4	
+	  mov	-1, %g4
 	SET_SIZE(sfmmu_pagefault)
 
 	ENTRY_NP(sfmmu_mmu_trap)
@@ -1788,7 +1789,7 @@ test_ptl1_panic:
 	sethi	%hi(sfmmu_tsbmiss_exception), %g1
 	or	%g1, %lo(sfmmu_tsbmiss_exception), %g1
 	ba,pt	%xcc, sys_trap
-	  mov	-1, %g4	
+	  mov	-1, %g4
 	/*NOTREACHED*/
 	SET_SIZE(sfmmu_mmu_trap)
 
@@ -1839,7 +1840,7 @@ test_ptl1_panic:
 	bgeu,pn %xcc, 6f
 	 nop
 	set	fault_rtt_fn1, %g1
-	wrpr	%g0, %g1, %tnpc	
+	wrpr	%g0, %g1, %tnpc
 	ba,a	7f
 6:
 	! must save this trap level before descending trap stack
@@ -1866,7 +1867,7 @@ test_ptl1_panic:
 	wrpr	%g5, %tl
 #endif /* sun4v */
 	and	%g2, WTRAP_TTMASK, %g4
-	cmp	%g4, WTRAP_TYPE	
+	cmp	%g4, WTRAP_TYPE
 	bne,pn	%xcc, 1f
 	 nop
 	/* tpc should be in the trap table */
@@ -1880,7 +1881,7 @@ test_ptl1_panic:
 	 .empty
 	andn	%g1, WTRAP_ALIGN, %g1	/* 128 byte aligned */
 	add	%g1, WTRAP_FAULTOFF, %g1
-	wrpr	%g0, %g1, %tnpc	
+	wrpr	%g0, %g1, %tnpc
 7:
 	/*
 	 * some wbuf handlers will call systrap to resolve the fault
@@ -1985,8 +1986,8 @@ sfmmu_kpm_dtsb_miss_small(void)
 #endif
 
 /*
- * Copies ism mapping for this ctx in param "ism" if this is a ISM 
- * tlb miss and branches to label "ismhit". If this is not an ISM 
+ * Copies ism mapping for this ctx in param "ism" if this is a ISM
+ * tlb miss and branches to label "ismhit". If this is not an ISM
  * process or an ISM tlb miss it falls thru.
  *
  * Checks to see if the vaddr passed in via tagacc is in an ISM segment for
@@ -1995,7 +1996,7 @@ sfmmu_kpm_dtsb_miss_small(void)
  *
  * Also hat_unshare() will set the context for this process to INVALID_CONTEXT
  * so that any other threads of this process will not try and walk the ism
- * maps while they are being changed.  
+ * maps while they are being changed.
  *
  * NOTE: We will never have any holes in our ISM maps. sfmmu_share/unshare
  *       will make sure of that. This means we can terminate our search on
@@ -2045,7 +2046,7 @@ label/**/2:								;\
 	ldxa	[tmp1]ASI_MEM, tmp1		/* check blk->nextpa */	;\
 	brgez,pt tmp1, label/**/1		/* continue if not -1*/	;\
 	  add	tmp1, IBLK_MAPS, ismhat	/* ismhat = &ismblk.map[0]*/	;\
-label/**/3:	
+label/**/3:
 
 /*
  * Returns the hme hash bucket (hmebp) given the vaddr, and the hatid
@@ -2175,12 +2176,12 @@ label/**/4:
 
 /*
  * HMEBLK_TO_HMENT is a macro that given an hmeblk and a vaddr returns
- * he offset for the corresponding hment.
+ * the offset for the corresponding hment.
  * Parameters:
  * In:
  *	vaddr = register with virtual address
  *	hmeblkpa = physical pointer to hme_blk
- * Out:	
+ * Out:
  *	hmentoff = register where hment offset will be stored
  *	hmemisc = hblk_misc
  * Scratch:
@@ -2213,7 +2214,7 @@ label1:
  * tmp		= temp value - clobbered
  * label	= temporary label for branching within macro.
  * foundlabel	= label to jump to when tte is found.
- * suspendlabel= label to jump to when tte is suspended.	
+ * suspendlabel= label to jump to when tte is suspended.
  * exitlabel	= label to jump to when tte is not found.
  *
  */
@@ -2461,15 +2462,15 @@ sfmmu_kprot_patch_ktsb4m_szcode:
 	 * g4 - g7 = scratch registers
 	 */
 	ALTENTRY(sfmmu_uprot_trap)
-#ifdef sun4v 
-	GET_1ST_TSBE_PTR(%g2, %g1, %g4, %g5) 
+#ifdef sun4v
+	GET_1ST_TSBE_PTR(%g2, %g1, %g4, %g5)
 	/* %g1 = first TSB entry ptr now, %g2 preserved */
 
 	GET_UTSBREG(SCRATCHPAD_UTSBREG2, %g3)	/* get 2nd utsbreg */
 	brlz,pt %g3, 9f				/* check for 2nd TSB */
 	  nop
 
-	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5) 
+	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5)
 	/* %g3 = second TSB entry ptr now, %g2 preserved */
 
 #else /* sun4v */
@@ -2479,19 +2480,19 @@ sfmmu_kprot_patch_ktsb4m_szcode:
 	brlz,pt %g3, 9f			/* check for 2nd TSB */
 	  nop
 
-	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5) 
+	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5)
 	/* %g3 = second TSB entry ptr now, %g2 preserved */
 #else /* UTSB_PHYS */
 	brgez,pt %g1, 9f		/* check for 2nd TSB */
 	  mov	-1, %g3			/* set second tsbe ptr to -1 */
 
 	mov	%g2, %g7
-	GET_2ND_TSBE_PTR(%g7, %g1, %g3, %g4, %g5, sfmmu_uprot) 
+	GET_2ND_TSBE_PTR(%g7, %g1, %g3, %g4, %g5, sfmmu_uprot)
 	/* %g3 = second TSB entry ptr now, %g7 clobbered */
 	mov	%g1, %g7
 	GET_1ST_TSBE_PTR(%g7, %g1, %g5, sfmmu_uprot)
 #endif /* UTSB_PHYS */
-#endif /* sun4v */ 
+#endif /* sun4v */
 9:
 	CPU_TSBMISS_AREA(%g6, %g7)
 	HAT_PERCPU_STAT16(%g6, TSBMISS_UPROTS, %g7)
@@ -2698,7 +2699,7 @@ dktsb4m_kpmcheck:
 	 */
 	.align	64
 	ALTENTRY(sfmmu_uitlb_fastpath)
-	
+
 	PROBE_1ST_ITSB(%g1, %g7, uitlb_fast_8k_probefail)
 	/* g4 - g5 = clobbered by PROBE_1ST_ITSB */
 	ba,pn	%xcc, sfmmu_tsb_miss_tt
@@ -2815,7 +2816,7 @@ dktsb4m_kpmcheck:
         PROBE_2ND_ITSB(%g3, %g7, isynth)
 	ba,pn	%xcc, sfmmu_tsb_miss_tt
 	  nop
-	
+
 #endif /* UTSB_PHYS */
 #endif /* sun4v */
 
@@ -2828,7 +2829,7 @@ dktsb4m_kpmcheck:
 
         .align 64
         ALTENTRY(sfmmu_udtlb_slowpath_noismpred)
-	
+
 	/*
          * g1 = tsb8k pointer register
          * g2 = tag access register
@@ -2842,7 +2843,7 @@ dktsb4m_kpmcheck:
          * probe 2ND_TSB (4M index)
          * probe 4TH_TSB (4M index)
          * probe 3RD_TSB (8K index)
-	 * 
+	 *
 	 * We already probed first TSB in DTLB_MISS handler.
 	 */
 
@@ -2876,7 +2877,7 @@ dktsb4m_kpmcheck:
         PROBE_3RD_DTSB(%g6, %g7, udtlb_8k_shctx_probefail)
 	ba,pn	%xcc, sfmmu_tsb_miss_tt
 	  nop
-	  
+
 	.align 64
         ALTENTRY(sfmmu_udtlb_slowpath_ismpred)
 
@@ -3060,7 +3061,7 @@ udtlb_miss_probesecond:
         andn    %g7, HAT_CHKCTX1_FLAG, %g7	/* the previous tsb miss    */
         stub    %g7, [%g6 + TSBMISS_URTTEFLAGS]
 #endif /* sun4v || UTSB_PHYS */
-	
+
 	ISM_CHECK(%g2, %g6, %g3, %g4, %g5, %g7, %g1, tsb_l1, tsb_ism)
 	/*
 	 * The miss wasn't in an ISM segment.
@@ -3103,11 +3104,11 @@ tsb_512K:
 	 */
 	brz,pn	%g5, tsb_4M
 	  nop
-3:	
+3:
 	/*
 	 * 512K hash
 	 */
-	
+
 	GET_TTE(%g2, %g7, %g3, %g4, %g6, %g1,
 		MMU_PAGESHIFT512K, TTE512K, %g5, tsb_l512K, tsb_checktte,
 		sfmmu_suspend_tl, tsb_4M)
@@ -3120,7 +3121,7 @@ tsb_4M:
 	and	%g4, HAT_4M_FLAG, %g5
 	brz,pn	%g5, tsb_32M
 	  nop
-4:	
+4:
 	/*
 	 * 4M hash
 	 */
@@ -3134,14 +3135,14 @@ tsb_32M:
 	sllx	%g2, TAGACC_CTX_LSHIFT, %g5
 #ifdef	sun4v
         brz,pn	%g5, 6f
-#else 
+#else
 	brz,pn  %g5, tsb_pagefault
 #endif
 	  ldub	[%g6 + TSBMISS_UTTEFLAGS], %g4
 	and	%g4, HAT_32M_FLAG, %g5
 	brz,pn	%g5, tsb_256M
 	  nop
-5:	
+5:
 	/*
 	 * 32M hash
 	 */
@@ -3150,7 +3151,7 @@ tsb_32M:
 		MMU_PAGESHIFT32M, TTE32M, %g5, tsb_l32M, tsb_checktte,
 		sfmmu_suspend_tl, tsb_256M)
 	/* NOT REACHED */
-	
+
 #if defined(sun4u) && !defined(UTSB_PHYS)
 #define tsb_shme        tsb_pagefault
 #endif
@@ -3159,11 +3160,11 @@ tsb_256M:
 	and	%g4, HAT_256M_FLAG, %g5
 	brz,pn	%g5, tsb_shme
 	  nop
-6:	
+6:
 	/*
 	 * 256M hash
 	 */
-		
+
 	GET_TTE(%g2, %g7, %g3, %g4, %g6, %g1,
 	    MMU_PAGESHIFT256M, TTE256M, %g5, tsb_l256M, tsb_checktte,
 	    sfmmu_suspend_tl, tsb_shme)
@@ -3213,7 +3214,7 @@ tsb_shme_512K:
 	/*
 	 * 512K hash
 	 */
-	
+
 	GET_SHME_TTE(%g2, %g7, %g3, %g4, %g6, %g1,
 		MMU_PAGESHIFT512K, TTE512K, %g5, tsb_shme_l512K, tsb_shme_checktte,
 		sfmmu_suspend_tl, tsb_shme_4M)
@@ -3224,7 +3225,7 @@ tsb_shme_4M:
 	and	%g4, HAT_4M_FLAG, %g5
 	brz,pn	%g5, tsb_shme_32M
 	  nop
-4:	
+4:
 	/*
 	 * 4M hash
 	 */
@@ -3257,7 +3258,7 @@ tsb_shme_256M:
 	/*
 	 * 256M hash
 	 */
-		
+
 	GET_SHME_TTE(%g2, %g7, %g3, %g4, %g6, %g1,
 	    MMU_PAGESHIFT256M, TTE256M, %g5, tsb_shme_l256M, tsb_shme_checktte,
 	    sfmmu_suspend_tl, tsb_pagefault)
@@ -3281,7 +3282,7 @@ tsb_shme_checktte:
 	  or	%g1, HAT_CHKCTX1_FLAG, %g1
 	stub    %g1, [%g6 + TSBMISS_URTTEFLAGS]
 
-	SAVE_CTX1(%g7, %g2, %g1, tsb_shmel)	
+	SAVE_CTX1(%g7, %g2, %g1, tsb_shmel)
 #endif /* sun4u && !UTSB_PHYS */
 
 tsb_validtte:
@@ -3300,7 +3301,7 @@ tsb_validtte:
 	  nop
 
 	TTE_SET_REFMOD_ML(%g3, %g4, %g6, %g7, %g5, tsb_lset_refmod,
-	    tsb_protfault) 
+	    tsb_protfault)
 
 	GET_MMU_D_TTARGET(%g2, %g7)		/* %g2 = ttarget */
 #ifdef sun4v
@@ -3313,7 +3314,7 @@ tsb_validtte:
 	ba,pt	%xcc, tsb_update_tl1
 	  nop
 4:
-	/* 
+	/*
 	 * If ITLB miss check exec bit.
 	 * If not set treat as invalid TTE.
 	 */
@@ -3331,7 +3332,7 @@ tsb_validtte:
 	/*
 	 * Set reference bit if not already set
 	 */
-	TTE_SET_REF_ML(%g3, %g4, %g6, %g7, %g5, tsb_lset_ref) 
+	TTE_SET_REF_ML(%g3, %g4, %g6, %g7, %g5, tsb_lset_ref)
 
 	/*
 	 * Now, load into TSB/TLB.  At this point:
@@ -3490,7 +3491,7 @@ tsb_user4m:
 	 * saves them in the modified 32M/256M ttes in the TSB. If the tte is
 	 * stored in the DTLB to map a 32M/256M page, the 4M pfn offset bits
 	 * are ignored by the hardware.
-	 * 
+	 *
 	 * Now, load into TSB/TLB.  At this point:
 	 * g2 = tagtarget
 	 * g3 = tte
@@ -3639,12 +3640,12 @@ tsb_ism_32M:
 	/*
 	 * 32M hash.
 	 */
-		
+
 	GET_TTE(%g2, %g7, %g3, %g4, %g6, %g1, MMU_PAGESHIFT32M,
 	    TTE32M, %g5, tsb_ism_l32M, tsb_ism_32M_found, sfmmu_suspend_tl,
 	    tsb_ism_4M)
 	/* NOT REACHED */
-	
+
 tsb_ism_32M_found:
 	brlz,a,pt %g3, tsb_validtte
 	  rdpr	%tt, %g7
@@ -3684,7 +3685,7 @@ tsb_ism_8K:
 	/*
 	 * 8K and 64K hash.
 	 */
-	
+
 	GET_TTE(%g2, %g7, %g3, %g4, %g6, %g1, MMU_PAGESHIFT64K,
 	    TTE64K, %g5, tsb_ism_l8K, tsb_ism_8K_found, sfmmu_suspend_tl,
 	    tsb_pagefault)
@@ -3733,14 +3734,14 @@ tsb_protfault:
 #endif /* sun4v */
 	brnz,pn	%g4, 3f				/* skip if not kernel */
 	  rdpr	%tl, %g5
-	
+
 	add	%sp, STACK_BIAS, %g3
 	srlx	%g3, MMU_PAGESHIFT, %g3
 	srlx	%g2, MMU_PAGESHIFT, %g4
 	cmp	%g3, %g4
 	be,a,pn	%icc, ptl1_panic		/* panic if bad %sp */
 	  mov	PTL1_BAD_STACK, %g1
-	
+
 	cmp	%g5, 1
 	ble,pt	%icc, 2f
 	  nop
@@ -3911,7 +3912,7 @@ sfmmu_kvaszc2pfn(caddr_t vaddr, int hashno)
 	/*
 	 * o0 = vaddr
 	 * o1 = sfmmup
-	 * o2 = ttep	
+	 * o2 = ttep
 	 */
 	CPU_TSBMISS_AREA(%g1, %o5)
 	ldn	[%g1 + TSBMISS_KHATID], %o4
@@ -3944,7 +3945,7 @@ sfmmu_kvaszc2pfn(caddr_t vaddr, int hashno)
 	 */
 	set     TAGACC_CTX_MASK, %g1
 	andn    %o0, %g1, %o0
-	GET_TTE(%o0, %o4, %g1, %g2, %o5, %g4, %g6, %g5, %g3, 
+	GET_TTE(%o0, %o4, %g1, %g2, %o5, %g4, %g6, %g5, %g3,
 		vatopfn_l1, kvtop_hblk_found, tsb_suspend, kvtop_nohblk)
 
 kvtop_hblk_found:
@@ -3960,7 +3961,7 @@ kvtop_hblk_found:
 	 */
 	brgez,a,pn %g1, 6f			/* if tte invalid goto tl0 */
 	  mov	-1, %o0				/* output = -1 (PFN_INVALID) */
-	stx %g1,[%o2]				/* put tte into *ttep */		
+	stx %g1,[%o2]				/* put tte into *ttep */
 	TTETOPFN(%g1, %o0, vatopfn_l2, %g2, %g3, %g4)
 	/*
 	 * o0 = vaddr
@@ -3978,10 +3979,10 @@ kvtop_nohblk:
 	 */
 	ldn	[%o5 + (TSBMISS_SCRATCH + TSB_TAGACC)], %o0
 #ifdef sun4v
-	cmp	%g5, MAX_HASHCNT	        
-#else                
+	cmp	%g5, MAX_HASHCNT
+#else
 	cmp	%g5, DEFAULT_MAX_HASHCNT	/* no 32/256M kernel pages */
-#endif /* sun4v */   
+#endif /* sun4v */
 	be,a,pn	%icc, 6f
 	  mov	-1, %o0				/* output = -1 (PFN_INVALID) */
 	mov	%o1, %o4			/* restore hatid */
@@ -3991,7 +3992,7 @@ kvtop_nohblk:
 	move	%icc, MMU_PAGESHIFT4M, %g6
 	ba,pt	%icc, 1b
 	movne	%icc, MMU_PAGESHIFT256M, %g6
-#else                
+#else
         inc	%g5
 	cmp	%g5, 2
 	move	%icc, MMU_PAGESHIFT512K, %g6
@@ -4010,7 +4011,7 @@ tsb_suspend:
 	 * g1 = tte
 	 * g2 = tte pa
 	 * g3 = tte va
-	 * o2 = tsbmiss area  use o5 instead of o2 for tsbmiss 
+	 * o2 = tsbmiss area  use o5 instead of o2 for tsbmiss
 	 */
 	stx %g1,[%o2]				/* put tte into *ttep */
 	brgez,a,pn %g1, 8f			/* if tte invalid goto 8: */
@@ -4040,7 +4041,7 @@ vatopfn_nokernel:
 	 * %o0 = vaddr
 	 * %o1 = hashno (aka szc)
 	 *
-	 * 
+	 *
 	 * This routine is similar to sfmmu_vatopfn() but will only look for
 	 * a kernel vaddr in the hash structure for the specified rehash value.
 	 * It's just an optimization for the case when pagesize for a given
@@ -4085,7 +4086,7 @@ vatopfn_nokernel:
 	 */
 	srlx	%o0, MMU_PAGESHIFT, %o0
 	sllx	%o0, MMU_PAGESHIFT, %o0
-	GET_TTE(%o0, %o4, %g3, %g4, %g1, %o5, %g6, %o1, %g5, 
+	GET_TTE(%o0, %o4, %g3, %g4, %g1, %o5, %g6, %o1, %g5,
 		kvaszc2pfn_l1, kvaszc2pfn_hblk_found, kvaszc2pfn_nohblk,
 		kvaszc2pfn_nohblk)
 
@@ -4216,7 +4217,7 @@ label/**/_ok:
 	cmp	%g2, %g7
 	blu,pn	%xcc, sfmmu_tsb_miss
 	  ldx	[%g6 + KPMTSBM_VEND], %g5
-	cmp	%g2, %g5	
+	cmp	%g2, %g5
 	bgeu,pn	%xcc, sfmmu_tsb_miss
 	  stx	%g3, [%g6 + KPMTSBM_TSBPTR]
 
@@ -4229,10 +4230,10 @@ label/**/_ok:
 	and	%g4, KPMTSBM_TLTSBM_FLAG, %g3
 	inc	%g5
 	brz,pn	%g3, sfmmu_kpm_exception
-	  st	%g5, [%g6 + KPMTSBM_TSBMISS] 
+	  st	%g5, [%g6 + KPMTSBM_TSBMISS]
 #else
 	inc	%g5
-	st	%g5, [%g6 + KPMTSBM_TSBMISS] 
+	st	%g5, [%g6 + KPMTSBM_TSBMISS]
 #endif
 	/*
 	 * At this point:
@@ -4258,7 +4259,7 @@ label/**/_ok:
 	 */
 	mov	ASI_MEM, %asi
 	PAGE_NUM2MEMSEG_NOLOCK_PA(%g2, %g3, %g6, %g4, %g5, %g7, kpmtsbmp2m)
-	cmp	%g3, MSEG_NULLPTR_PA		
+	cmp	%g3, MSEG_NULLPTR_PA
 	be,pn	%xcc, sfmmu_kpm_exception	/* if mseg not found */
 	  nop
 
@@ -4270,7 +4271,7 @@ label/**/_ok:
 	ldxa	[%g3 + MEMSEG_KPM_PBASE]%asi, %g7
 	srlx	%g2, %g5, %g4
 	sllx	%g4, %g5, %g4
-	sub	%g4, %g7, %g4	
+	sub	%g4, %g7, %g4
 	srlx	%g4, %g5, %g4
 
 	/*
@@ -4324,16 +4325,16 @@ label/**/_ok:
 	 */
 #ifdef sun4v
 	sethi	%hi(TTE_VALID_INT), %g5		/* upper part */
-	sllx	%g5, 32, %g5		
+	sllx	%g5, 32, %g5
 	mov	(TTE_CP_INT|TTE_CV_INT|TTE_PRIV_INT|TTE_HWWR_INT), %g4
 	or	%g4, TTE4M, %g4
 	or	%g5, %g4, %g5
 #else
-	sethi	%hi(TTE_VALID_INT), %g4	
+	sethi	%hi(TTE_VALID_INT), %g4
 	mov	TTE4M, %g5
 	sllx	%g5, TTE_SZ_SHFT_INT, %g5
 	or	%g5, %g4, %g5			/* upper part */
-	sllx	%g5, 32, %g5		
+	sllx	%g5, 32, %g5
 	mov	(TTE_CP_INT|TTE_CV_INT|TTE_PRIV_INT|TTE_HWWR_INT), %g4
 	or	%g5, %g4, %g5
 #endif
@@ -4354,12 +4355,12 @@ label/**/_ok:
 	ldsha	[%g1 + KPMPAGE_REFCNTC]%asi, %g7 /* kp_refcntc */
 	cmp	%g7, -1
 	bne,pn	%xcc, 5f	/* use C-handler if there's no go for dropin */
-	  nop	
+	  nop
 
 #ifdef	DEBUG
 	/* double check refcnt */
 	ldsha	[%g1 + KPMPAGE_REFCNT]%asi, %g7
-	brz,pn	%g7, 5f			/* let C-handler deal with this */ 
+	brz,pn	%g7, 5f			/* let C-handler deal with this */
 	  nop
 #endif
 
@@ -4408,7 +4409,7 @@ locked_tsb_l1:
 0:
 	retry
 5:
-	/* g3=hlck_pa */ 
+	/* g3=hlck_pa */
 	KPMLOCK_EXIT(%g3, ASI_MEM)
 	ba,pt	%icc, sfmmu_kpm_exception
 	  nop
@@ -4442,23 +4443,23 @@ locked_tsb_l1:
 	cmp	%g2, %g7
 	blu,pn	%xcc, sfmmu_tsb_miss
 	  ldx	[%g6 + KPMTSBM_VEND], %g5
-	cmp	%g2, %g5	
+	cmp	%g2, %g5
 	bgeu,pn	%xcc, sfmmu_tsb_miss
 	  stx	%g1, [%g6 + KPMTSBM_TSBPTR]	/* save 8K kpm TSB pointer */
 
 	/*
 	 * check TL tsbmiss handling flag
-	 * bump tsbmiss counter 
+	 * bump tsbmiss counter
 	 */
 	lduw	[%g6 + KPMTSBM_TSBMISS], %g5
 #ifdef	DEBUG
 	and	%g4, KPMTSBM_TLTSBM_FLAG, %g1
 	inc	%g5
 	brz,pn	%g1, sfmmu_kpm_exception
-	  st	%g5, [%g6 + KPMTSBM_TSBMISS] 
+	  st	%g5, [%g6 + KPMTSBM_TSBMISS]
 #else
 	inc	%g5
-	st	%g5, [%g6 + KPMTSBM_TSBMISS] 
+	st	%g5, [%g6 + KPMTSBM_TSBMISS]
 #endif
 	/*
 	 * At this point:
@@ -4537,12 +4538,12 @@ locked_tsb_l1:
 	ldxa	[%g3 + MEMSEG_KPM_NKPMPGS]%asi, %g5
 	cmp	%g4, %g5			/* inx - nkpmpgs */
 	bgeu,pn	%xcc, sfmmu_kpm_exception	/* if out of range */
-	  ld	[%g6 + KPMTSBM_KPMPTABLESZ], %g7 
+	  ld	[%g6 + KPMTSBM_KPMPTABLESZ], %g7
 #else
-	ld	[%g6 + KPMTSBM_KPMPTABLESZ], %g7 
+	ld	[%g6 + KPMTSBM_KPMPTABLESZ], %g7
 #endif
 	/* ksp = &mseg_pa->kpm_spages[inx] */
-	ldxa	[%g3 + MEMSEG_KPM_SPAGES]%asi, %g5	
+	ldxa	[%g3 + MEMSEG_KPM_SPAGES]%asi, %g5
 	add	%g5, %g4, %g5			/* ksp */
 
 	/*
@@ -4580,7 +4581,7 @@ locked_tsb_l1:
 	 * g6=per-CPU kpm tsbmiss area
 	 */
 	sethi	%hi(TTE_VALID_INT), %g5		/* upper part */
-	sllx	%g5, 32, %g5		
+	sllx	%g5, 32, %g5
 	mov	(TTE_CP_INT|TTE_PRIV_INT|TTE_HWWR_INT), %g4
 	or	%g5, %g4, %g5
 	sllx	%g2, MMU_PAGESHIFT, %g4
@@ -4605,7 +4606,7 @@ locked_tsb_l1:
 	and	%g7, KPM_MAPPED_MASK, %g7		/* go */
 	cmp	%g7, KPM_MAPPEDS			/* cacheable ? */
 	be,a,pn	%xcc, 3f
-	  or	%g5, TTE_CV_INT, %g5			/* cacheable */	
+	  or	%g5, TTE_CV_INT, %g5			/* cacheable */
 3:
 #ifndef sun4v
 	ldub	[%g6 + KPMTSBM_FLAGS], %g7
@@ -4652,7 +4653,7 @@ locked_tsb_l2:
 0:
 	retry
 5:
-	/* g3=hlck_pa */ 
+	/* g3=hlck_pa */
 	KPMLOCK_EXIT(%g3, ASI_MEM)
 	ba,pt	%icc, sfmmu_kpm_exception
 	  nop
@@ -4670,7 +4671,7 @@ locked_tsb_l2:
  * Called from C-level, sets/clears "go" indication for trap level handler.
  * khl_lock is a low level spin lock to protect the kp_tsbmtl field.
  * Assumed that &kp->kp_refcntc is checked for zero or -1 at C-level.
- * Assumes khl_mutex is held when called from C-level. 
+ * Assumes khl_mutex is held when called from C-level.
  */
 /* ARGSUSED */
 void
@@ -4680,7 +4681,7 @@ sfmmu_kpm_tsbmtl(short *kp_refcntc, uint_t *khl_lock, int cmd)
 
 /*
  * kpm_smallpages: stores val to byte at address mapped within
- * low level lock brackets. The old value is returned. 
+ * low level lock brackets. The old value is returned.
  * Called from C-level.
  */
 /* ARGSUSED */
@@ -4723,13 +4724,13 @@ sfmmu_kpm_stsbmtl_panic:
 1:
 #endif /* DEBUG */
 	wrpr	%o3, PSTATE_IE, %pstate		/* disable interrupts */
-	
+
 	KPMLOCK_ENTER(%o1, %o4, kpmtsbmtl1, ASI_N)
 	mov	-1, %o5
 	brz,a	%o2, 2f
 	  mov	0, %o5
 2:
-	sth	%o5, [%o0]	
+	sth	%o5, [%o0]
 	KPMLOCK_EXIT(%o1, ASI_N)
 
 	retl
@@ -4757,10 +4758,10 @@ sfmmu_kpm_stsbmtl_panic:
 1:
 #endif /* DEBUG */
 	wrpr	%o3, PSTATE_IE, %pstate		/* disable interrupts */
-	
+
 	KPMLOCK_ENTER(%o1, %o4, kpmstsbmtl1, ASI_N)
 	ldsb	[%o0], %o5
-	stb	%o2, [%o0]	
+	stb	%o2, [%o0]
 	KPMLOCK_EXIT(%o1, ASI_N)
 
 	and	%o5, KPM_MAPPED_MASK, %o0	/* return old val */
@@ -4823,14 +4824,14 @@ sfmmu_dslow_patch_ktsb4m_szcode:
 	 * Get second TSB pointer (or NULL if no second TSB) in %g3
 	 * Branch to sfmmu_tsb_miss_tt to handle it
 	 */
-	GET_1ST_TSBE_PTR(%g2, %g1, %g4, %g5) 
+	GET_1ST_TSBE_PTR(%g2, %g1, %g4, %g5)
 	/* %g1 = first TSB entry ptr now, %g2 preserved */
 
 	GET_UTSBREG(SCRATCHPAD_UTSBREG2, %g3)	/* get 2nd utsbreg */
 	brlz,pt %g3, sfmmu_tsb_miss_tt		/* done if no 2nd TSB */
 	  nop
 
-	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5) 
+	GET_2ND_TSBE_PTR(%g2, %g3, %g4, %g5)
 	/* %g3 = second TSB entry ptr now, %g2 preserved */
 9:
 	ba,a,pt	%xcc, sfmmu_tsb_miss_tt

--- a/usr/src/uts/sparc/v9/os/v9dep.c
+++ b/usr/src/uts/sparc/v9/os/v9dep.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -104,7 +105,7 @@ setfpregs(klwp_t *lwp, fpregset_t *fp)
 		if (!(pfp->fpu_en) && (!(pfp->fpu_fprs & FPRS_FEF)) &&
 		    fpu_exists) {
 			/*
-			 * He's not currently using the FPU but wants to in his
+			 * It's not currently using the FPU but wants to in its
 			 * new context - arrange for this on return to userland.
 			 */
 			pfp->fpu_fprs = (uint32_t)fprs;
@@ -1124,7 +1125,7 @@ sendsig(int sig, k_siginfo_t *sip, void (*hdlr)())
 
 
 	/*
-	 * Since we flushed the user's windows and we are changing his
+	 * Since we flushed the user's windows and we are changing their
 	 * stack pointer, the window that the user will return to will
 	 * be restored from the save area in the frame we are setting up.
 	 * We copy in save area for old stack pointer so that debuggers
@@ -1461,7 +1462,7 @@ sendsig32(int sig, k_siginfo_t *sip, void (*hdlr)())
 
 
 	/*
-	 * Since we flushed the user's windows and we are changing his
+	 * Since we flushed the user's windows and we are changing their
 	 * stack pointer, the window that the user will return to will
 	 * be restored from the save area in the frame we are setting up.
 	 * We copy in save area for old stack pointer so that debuggers

--- a/usr/src/uts/sun/io/fd.c
+++ b/usr/src/uts/sun/io/fd.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -147,7 +148,7 @@
  * doing dma in chunks of 2048 works OK.
  * The reason for making this a global variable is that there could be
  * situations under which the customer would like to get full performance
- * from floppy. He may not be having IFB boards that cause underrun errors.
+ * from floppy. They may not be having IFB boards that cause underrun errors.
  * Under those conditions we could set this value to a much higher value
  * by editing /etc/system file.
  */

--- a/usr/src/uts/sun/io/scsi/adapters/sf.c
+++ b/usr/src/uts/sun/io/scsi/adapters/sf.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2011 Bayard G. Bell. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -3543,7 +3544,7 @@ sf_do_reportlun(struct sf *sf, struct sf_els_hdr *privp,
 	reportlun->fcp_cntl.cntl_qtype = FCP_QTYPE_SIMPLE;
 
 	(void) ddi_dma_sync(lun_dma_handle, 0, 0, DDI_DMA_SYNC_FORDEV);
-	/* We know he's there, so this should be fast */
+	/* We know it's there, so this should be fast */
 	privp->timeout = sf_watchdog_time + SF_FCP_TIMEOUT;
 	if (sf_els_transport(sf, privp) == 1)
 		return (1);

--- a/usr/src/uts/sun/io/zs_async.c
+++ b/usr/src/uts/sun/io/zs_async.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -986,7 +987,7 @@ zsa_close(queue_t *q, int flag)
 	 * write queue and there's a timer running, so we don't have to worry
 	 * about them.  For the untimed case, though, the user obviously made a
 	 * mistake, because these are handled immediately.  We'll terminate the
-	 * break now and honor his implicit request by discarding the rest of
+	 * break now and honor their implicit request by discarding the rest of
 	 * the data.
 	 */
 	if (!(za->za_flags & ZAS_BREAK) && (zs->zs_wreg[5] & ZSWR5_BREAK))

--- a/usr/src/uts/sun4/io/efcode/fc_ddi.c
+++ b/usr/src/uts/sun4/io/efcode/fc_ddi.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -38,7 +39,7 @@
 #include <sys/fcode.h>
 
 /*
- * We want to call the attachment point's dma ctl op, not his parent's
+ * We want to call the attachment point's dma ctl op, not its parent's
  * dma ctl op, so we have to code this ourselves.
  */
 

--- a/usr/src/uts/sun4/io/efcode/fc_ops.c
+++ b/usr/src/uts/sun4/io/efcode/fc_ops.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2000, 2002 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -94,7 +95,7 @@ static struct fc_ops_v fov[] = {
 
 /*
  * Allocate a handle for the ops function .. our handle is a resource list
- * Return the handle to our caller, so he can call us with it when we need it.
+ * Return the handle to our caller, so it can call us with it when we need it.
  */
 /*ARGSUSED*/
 fco_handle_t

--- a/usr/src/uts/sun4/io/su_driver.c
+++ b/usr/src/uts/sun4/io/su_driver.c
@@ -25,6 +25,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -1143,7 +1144,7 @@ asyclose(queue_t *q, int flag)
 	 * write queue and there's a timer running, so we don't have to worry
 	 * about them.  For the untimed case, though, the user obviously made a
 	 * mistake, because these are handled immediately.  We'll terminate the
-	 * break now and honor his implicit request by discarding the rest of
+	 * break now and honor their implicit request by discarding the rest of
 	 * the data.
 	 */
 	if (!(async->async_flags & ASYNC_BREAK)) {

--- a/usr/src/uts/sun4/os/ddi_impl.c
+++ b/usr/src/uts/sun4/os/ddi_impl.c
@@ -25,6 +25,7 @@
  */
 /*
  * Copyright 2014 Garrett D'Amore <garrett@damore.org>
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -1195,7 +1196,7 @@ i_ddi_mem_alloc(dev_info_t *dip, ddi_dma_attr_t *attr,
 	iomin = (attr->dma_attr_burstsizes & 0xffff) |
 	    ((attr->dma_attr_burstsizes >> 16) & 0xffff);
 	/*
-	 * If a driver set burtsizes to 0, we give him byte alignment.
+	 * If a driver set burtsizes to 0, we give it byte alignment.
 	 * Otherwise align at the burtsizes boundary.
 	 */
 	if (iomin == 0)

--- a/usr/src/uts/sun4/os/startup.c
+++ b/usr/src/uts/sun4/os/startup.c
@@ -21,6 +21,7 @@
 
 /*
  * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/machsystm.h>
@@ -3017,7 +3018,7 @@ void
 install_va_to_tte(void)
 {
 	/*
-	 * advise prom that he can use unix-tte
+	 * advise prom that it can use unix-tte
 	 */
 	prom_interpret("' unix-tte is va>tte-data", 0, 0, 0, 0, 0);
 }

--- a/usr/src/uts/sun4u/io/opl_cfg.c
+++ b/usr/src/uts/sun4u/io/opl_cfg.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/conf.h>
@@ -678,7 +679,7 @@ opl_set_node(dev_info_t *node, void *arg, uint_t flags)
  * callbacks. The create() callback is used to set the properties of a
  * newly created node. The other callback is used to return a pointer
  * to the newly created node. The create() callback is passed by the
- * caller of this function based on the kind of node he wishes to
+ * caller of this function based on the kind of node it wishes to
  * create.
  *
  * e_ddi_branch_create() returns with the newly created node held. We

--- a/usr/src/uts/sun4u/serengeti/io/sbdp_cpu.c
+++ b/usr/src/uts/sun4u/serengeti/io/sbdp_cpu.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -325,9 +326,9 @@ sbdp_cpu_poweron(struct cpu *cp)
 
 	/*
 	 * Wait for the cpu to reach its idle thread before
-	 * we zap him with a request to blow away the mappings
-	 * he (might) have for the sbdp_shutdown_asm code
-	 * he may have executed on unconfigure.
+	 * we zap it with a request to blow away the mappings
+	 * it (might) have for the sbdp_shutdown_asm code
+	 * it may have executed on unconfigure.
 	 */
 	while ((cp->cpu_thread != cp->cpu_idle_thread) && (ntries > 0)) {
 		DELAY(sbdp_cpu_delay);

--- a/usr/src/uts/sun4u/starcat/io/dman.c
+++ b/usr/src/uts/sun4u/starcat/io/dman.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 
@@ -710,7 +711,7 @@ static struct streamtab man_maninfo = {
  *
  *	Anyone who needs exclusive outer perimeter permission (changing
  *	global data structures) does so via qwriter() calls. The
- *	background thread does all his work outside of perimeter and
+ *	background thread does all its work outside of perimeter and
  *	submits work via qtimeout() when data structures need to be
  *	modified.
  */
@@ -2852,7 +2853,7 @@ man_dlioc(manstr_t *msp, mblk_t *mp)
 
 /*
  * We catch all DLPI messages that we have to resend to a new AP'ed
- * device to put him in the right state.  We link these messages together
+ * device to put it in the right state.  We link these messages together
  * w/ their b_next fields and hang it off of msp->ms_dl_mp.  We
  * must be careful to restore b_next fields before doing dupmsg/freemsg!
  *
@@ -4168,7 +4169,7 @@ man_iwork()
 
 /*
  * man_dr_detach has submitted a request to DRSWITCH a path.
- * He is in cv_wait_sig(wp->mw_cv). We forward the work request on to
+ * It is in cv_wait_sig(wp->mw_cv). We forward the work request on to
  * man_bwork as a switch request. It should end up back at
  * man_iwork, who will cv_signal(wp->mw_cv) man_dr_detach.
  *
@@ -4318,7 +4319,7 @@ exit:
 
 /*
  * man_dr_detach has submitted a request to DRDETACH a path.
- * He is in cv_wait_sig(wp->mw_cv). We remove the path and
+ * It is in cv_wait_sig(wp->mw_cv). We remove the path and
  * cv_signal(wp->mw_cv) man_dr_detach.
  *
  * Called holding perimeter lock.

--- a/usr/src/uts/sun4u/starcat/io/drmach.c
+++ b/usr/src/uts/sun4u/starcat/io/drmach.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/note.h>
@@ -7203,7 +7204,7 @@ drmach_unconfigure(drmachid_t id, int flags)
 /*
  * Start up a cpu.  It is possible that we're attempting to restart
  * the cpu after an UNCONFIGURE in which case the cpu will be
- * spinning in its cache.  So, all we have to do is wakeup him up.
+ * spinning in its cache.  So, all we have to do is wake it up.
  * Under normal circumstances the cpu will be coming from a previous
  * CONNECT and thus will be spinning in OBP.  In both cases, the
  * startup sequence is the same.

--- a/usr/src/uts/sun4u/starfire/io/drmach.c
+++ b/usr/src/uts/sun4u/starfire/io/drmach.c
@@ -23,6 +23,7 @@
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2011 Bayard G. Bell. All rights reserved.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/debug.h>
@@ -2440,9 +2441,9 @@ drmach_cpu_start(struct cpu *cp)
 
 	/*
 	 * Wait for the cpu to reach its idle thread before
-	 * we zap him with a request to blow away the mappings
-	 * he (might) have for the drmach_shutdown_asm code
-	 * he may have executed on unconfigure.
+	 * we zap it with a request to blow away the mappings
+	 * it (might) have for the drmach_shutdown_asm code
+	 * it may have executed on unconfigure.
 	 */
 	while ((cp->cpu_thread != cp->cpu_idle_thread) && (ntries > 0)) {
 		DELAY(drmach_cpu_delay);
@@ -3692,7 +3693,7 @@ drmach_unconfigure(drmachid_t id, int flags)
 /*
  * Start up a cpu.  It is possible that we're attempting to restart
  * the cpu after an UNCONFIGURE in which case the cpu will be
- * spinning in its cache.  So, all we have to do is wakeup him up.
+ * spinning in its cache.  So, all we have to do is wake it up.
  * Under normal circumstances the cpu will be coming from a previous
  * CONNECT and thus will be spinning in OBP.  In both cases, the
  * startup sequence is the same.

--- a/usr/src/uts/sun4u/starfire/io/idn.c
+++ b/usr/src/uts/sun4u/starfire/io/idn.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -3819,7 +3820,7 @@ idn_timer_stopall(idn_timer_t *tp)
 		 *
 		 * 1. We successfully aborted a timeout call.
 		 *
-		 * 2. We failed to find the given timer.  He
+		 * 2. We failed to find the given timer.  It
 		 *    probably just fired off.
 		 */
 		idn_timer_free(tp);
@@ -4268,7 +4269,7 @@ idn_mainmbox_report(queue_t *wq, mblk_t *mp, caddr_t cp, cred_t *cr)
 
 	/*
 	 * Domain 0 never has a send/recv mainmbox so
-	 * don't bother printing him.
+	 * don't bother printing it.
 	 */
 	for (domid = 1; domid < MAX_DOMAINS; domid++) {
 		idn_domain_t	*dp;

--- a/usr/src/uts/sun4u/starfire/io/idn_proto.c
+++ b/usr/src/uts/sun4u/starfire/io/idn_proto.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -380,7 +381,7 @@ static int idnxs_state_table[4][5][2] = {
  *	LOCAL		Local domain is winner.
  *	REMOTE		Remote domain is winner.
  *	WAIT		Wait for remote to connect to our
- *			master if his is different.
+ *			master if theirs is different.
  *	ERROR		An impossible condition.
  *
  * Index:

--- a/usr/src/uts/sun4u/starfire/io/idn_smr.c
+++ b/usr/src/uts/sun4u/starfire/io/idn_smr.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Inter-Domain Network
  *
@@ -378,7 +379,7 @@ smr_slab_alloc(int domid, smr_slab_t **spp)
 		/*
 		 * Have to make a remote request.
 		 * In order to prevent overwhelming the master
-		 * with a bunch of requests that he won't be able
+		 * with a bunch of requests that it won't be able
 		 * to handle we do a check to see if we're still
 		 * under quota.  Note that the limit is known
 		 * apriori based on the SMR/NWR size and
@@ -563,7 +564,7 @@ smr_slab_garbage_collection(smr_slab_t *sp)
  * IMPORTANT: This routine is going to drop the domain rwlock (drwlock)
  *	      for the domain on whose behalf the request is being
  *	      made.  This routine canNOT block on trying to
- *	      reacquire the drwlock.  If he does block then somebody
+ *	      reacquire the drwlock.  If it does block then somebody
  *	      must have the write lock on the domain which most likely
  *	      means the domain is going south anyway, so just bail on
  *	      this buffer.  Higher levels will retry if needed.
@@ -2161,7 +2162,7 @@ smr_remap(struct as *as, register caddr_t vaddr,
 	 * Map the SMR to the new physical address space,
 	 * presumably a remote pfn.  Cannot use hat_devload
 	 * because it will think pfn represents non-memory,
-	 * i.e. space since it may beyond his physmax.
+	 * since it may extend beyond its physmax.
 	 */
 	for (p = 0; p < npgs; p++) {
 		sfmmu_memtte(&tte, new_pfn, PROT_READ | PROT_WRITE | HAT_NOSYNC,

--- a/usr/src/uts/sun4u/starfire/io/idn_xf.c
+++ b/usr/src/uts/sun4u/starfire/io/idn_xf.c
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -1665,7 +1666,7 @@ idn_cpu_per_board(pda_handle_t ph, cpuset_t cset, struct hwconfig *hwp)
 	 * A NULL post2obp pointer indicates we're checking
 	 * the config of a remote domain.  Since we can't
 	 * look at the post2obp of the remote domain, we'll
-	 * have to trust what he passed us in his config.
+	 * have to trust what it passed us in its config.
 	 */
 	if (ph && !pda_is_valid(ph)) {
 		cmn_err(CE_WARN, "IDN: 508: post2obp checksum invalid");

--- a/usr/src/uts/sun4u/starfire/os/pda.c
+++ b/usr/src/uts/sun4u/starfire/os/pda.c
@@ -22,6 +22,7 @@
 /*
  * Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 #pragma ident	"%Z%%M%	%I%	%E% SMI"
@@ -384,7 +385,7 @@ pda_is_valid(pda_handle_t ph)
  * p2o_update_checksum
  *
  * Calculate checksum for post2obp structure and insert it so
- * when POST reads it he'll be happy.
+ * when POST reads it it'll be happy.
  */
 static void
 p2o_update_checksum(post2obp_info_t *p2o)

--- a/usr/src/uts/sun4u/starfire/sys/idn.h
+++ b/usr/src/uts/sun4u/starfire/sys/idn.h
@@ -21,6 +21,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  *
  * Inter-Domain Network
  */
@@ -1833,7 +1834,7 @@ typedef struct idn_timerq	idn_timerq_t;
  * A fixed-size circular buffer is maintained as a queue of
  * incoming interrupts.  The low-level idn_dmv_handler() waits
  * for an entry to become FREE and will atomically mark it INUSE.
- * Once he has filled in the appropriate fields it will be marked
+ * Once it has filled in the appropriate fields it will be marked
  * as READY.  The high-level idn_handler() will be invoked and will
  * process all messages in the queue that are READY.  Each message
  * is marked PROCESS, a protojob job created and filled in, and


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>
Reviewed by: Chris Williamson <chris.williamson@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

This change removes all gendered language that did not refer specifically
to an individual person or pet. The convention taken was to use
variations on "they" when referring to users and/or human beings, while
using "it" when referring to code, functions, and/or libraries.

Additionally, we took the liberty to fix up any whitespace issues that
were found in any files that were already being modified.

Upstream Bugs: DLPX-45557