### PR TITLE
7816 remove static unused variable in zfs_vfsops.c

### DIFF
--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -96,11 +96,6 @@ static const fs_operation_def_t zfs_vfsops_template[] = {
 	NULL,			NULL
 };
 
-static const fs_operation_def_t zfs_vfsops_eio_template[] = {
-	VFSNAME_FREEVFS,	{ .vfs_freevfs =  zfs_freevfs },
-	NULL,			NULL
-};
-
 /*
  * We need to keep a count of active fs's.
  * This is necessary to prevent our module


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>

issue found by gcc6
