### PR TITLE
7938 Port ZOL #3712 disable LBA weighting on files and SSDs

### DIFF
--- a/usr/src/uts/common/fs/zfs/metaslab.c
+++ b/usr/src/uts/common/fs/zfs/metaslab.c
@@ -1649,7 +1649,7 @@ metaslab_space_weight(metaslab_t *msp)
 	 * In effect, this means that we'll select the metaslab with the most
 	 * free bandwidth rather than simply the one with the most free space.
 	 */
-	if (metaslab_lba_weighting_enabled) {
+	if (!vd->vdev_nonrot && metaslab_lba_weighting_enabled) {
 		weight = 2 * weight - (msp->ms_id * weight) / vd->vdev_ms_count;
 		ASSERT(weight >= space && weight <= 2 * space);
 	}

--- a/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/vdev_impl.h
@@ -152,6 +152,7 @@ struct vdev {
 	vdev_stat_t	vdev_stat;	/* virtual device statistics	*/
 	boolean_t	vdev_expanding;	/* expand the vdev?		*/
 	boolean_t	vdev_reopening;	/* reopen in progress?		*/
+	boolean_t	vdev_nonrot;	/* true if SSD, file, or Virtio	*/
 	int		vdev_open_error; /* error on last open		*/
 	kthread_t	*vdev_open_thread; /* thread opening children	*/
 	uint64_t	vdev_crtxg;	/* txg when top-level was added */

--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -1106,6 +1106,7 @@ vdev_open_child(void *arg)
 	vd->vdev_open_thread = curthread;
 	vd->vdev_open_error = vdev_open(vd);
 	vd->vdev_open_thread = NULL;
+	vd->vdev_parent->vdev_nonrot &= vd->vdev_nonrot;
 }
 
 boolean_t
@@ -1126,15 +1127,19 @@ vdev_open_children(vdev_t *vd)
 	taskq_t *tq;
 	int children = vd->vdev_children;
 
+	vd->vdev_nonrot = B_TRUE;
+
 	/*
 	 * in order to handle pools on top of zvols, do the opens
 	 * in a single thread so that the same thread holds the
 	 * spa_namespace_lock
 	 */
 	if (vdev_uses_zvols(vd)) {
-		for (int c = 0; c < children; c++)
+		for (int c = 0; c < children; c++) {
 			vd->vdev_child[c]->vdev_open_error =
 			    vdev_open(vd->vdev_child[c]);
+			vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;
+		}
 		return;
 	}
 	tq = taskq_create("vdev_open", children, minclsyspri,
@@ -1145,6 +1150,9 @@ vdev_open_children(vdev_t *vd)
 		    TQ_SLEEP) != NULL);
 
 	taskq_destroy(tq);
+
+	for (int c = 0; c < children; c++)
+		vd->vdev_nonrot &= vd->vdev_child[c]->vdev_nonrot;
 }
 
 /*

--- a/usr/src/uts/common/fs/zfs/vdev_file.c
+++ b/usr/src/uts/common/fs/zfs/vdev_file.c
@@ -57,6 +57,10 @@ vdev_file_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 	vattr_t vattr;
 	int error;
 
+	/* Rotational optimizations only make sense on block devices */
+
+	vd->vdev_nonrot = B_TRUE;
+
 	/*
 	 * We must have a pathname, and it must be absolute.
 	 */

--- a/usr/src/uts/intel/io/scsi/adapters/pvscsi/pvscsi.c
+++ b/usr/src/uts/intel/io/scsi/adapters/pvscsi/pvscsi.c
@@ -1170,7 +1170,7 @@ pvscsi_cmd_ext_alloc(pvscsi_softc_t *pvs, pvscsi_cmd_t *cmd, int kf)
 
 	if (cmd->cmdlen > sizeof (cmd->cmd_cdb)) {
 		if ((buf = kmem_zalloc(cmd->cmdlen, kf)) == NULL)
-			return (NULL);
+			return (DDI_FAILURE);
 		pkt->pkt_cdbp = buf;
 		cmd->flags |= PVSCSI_FLAG_CDB_EXT;
 	}
@@ -1195,7 +1195,7 @@ pvscsi_cmd_ext_alloc(pvscsi_softc_t *pvs, pvscsi_cmd_t *cmd, int kf)
 out:
 	pvscsi_cmd_ext_free(cmd);
 
-	return (NULL);
+	return (DDI_FAILURE);
 }
 
 static int


### PR DESCRIPTION
ZFS on Linux has had a feature "Disable LBA weighting on SSD" since August 2015:

http://open-zfs.org/wiki/Features#Disable_LBA_Weighting_on_files_and_SSDs

https://github.com/zfsonlinux/zfs/commit/fb40095f5f0853946f8150481ca22602d1334dfe

This is a relatively straight port of the ZOL feature. illumos does not have the non-rotational property that exists for linux block devices, so there is a little more code in vdev_disk.c
