### PR TITLE
7955 libshare needs to initialize only those datasets being modified by the consumer

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -68,6 +68,7 @@
 #include <aclutils.h>
 #include <directory.h>
 #include <idmap.h>
+#include <libshare.h>
 
 #include "zfs_iter.h"
 #include "zfs_util.h"
@@ -6138,6 +6139,15 @@ share_mount(int op, int argc, char **argv)
 			return (0);
 
 		qsort(dslist, count, sizeof (void *), libzfs_dataset_cmp);
+		sa_init_selective_arg_t sharearg;
+		sharearg.zhandle_arr = dslist;
+		sharearg.zhandle_len = count;
+		if ((ret = zfs_init_libshare_arg(zfs_get_handle(dslist[0]),
+		    SA_INIT_SHARE_API_SELECTIVE, &sharearg)) != SA_OK) {
+			(void) fprintf(stderr,
+			    gettext("Could not initialize libshare, %d"), ret);
+			return (ret);
+		}
 
 		for (i = 0; i < count; i++) {
 			if (verbose)

--- a/usr/src/lib/libshare/Makefile.com
+++ b/usr/src/lib/libshare/Makefile.com
@@ -19,6 +19,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016 by Delphix. All rights reserved.
 #
 LIBRARY =	libshare.a
 VERS =		.1
@@ -42,6 +43,7 @@ $(LINTLIB) :=	SRCS = $(SRCDIR)/$(LINTSRC)
 
 #add nfs/lib directory as part of the include path
 CFLAGS +=	$(CCVERBOSE)
+C99MODE +=	$(C99_ENABLE)
 CERRWARN +=	-_gcc=-Wno-parentheses
 CERRWARN +=	-_gcc=-Wno-uninitialized
 CERRWARN +=	-_gcc=-Wno-switch

--- a/usr/src/lib/libshare/common/libshare_impl.h
+++ b/usr/src/lib/libshare/common/libshare_impl.h
@@ -22,6 +22,7 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright (c) 2016 by Delphix. All rights reserved.
  */
 
 /*
@@ -110,6 +111,7 @@ typedef struct sa_handle_impl {
 	xmlDocPtr	doc;
 	uint64_t	tssharetab;
 	uint64_t	tstrans;
+	int		sa_service;
 } *sa_handle_impl_t;
 
 extern int sa_proto_share(char *, sa_share_t);
@@ -142,7 +144,10 @@ extern void sa_fillshare(sa_share_t share, char *proto, struct share *sh);
 extern void sa_emptyshare(struct share *sh);
 
 /* ZFS functions */
+extern int sa_get_one_zfs_share(sa_handle_t, char *, sa_init_selective_arg_t *,
+    char ***, size_t *);
 extern int sa_get_zfs_shares(sa_handle_t, char *);
+extern int sa_get_zfs_share_for_name(sa_handle_t, char *, const char *, char *);
 extern int sa_zfs_update(sa_share_t);
 extern int sa_share_zfs(sa_share_t, sa_resource_t, char *, share_t *,
     void *, zfs_share_op_t);

--- a/usr/src/lib/libshare/common/libshare_zfs.c
+++ b/usr/src/lib/libshare/common/libshare_zfs.c
@@ -264,6 +264,10 @@ get_legacy_mountpoint(const char *path, char *dataset, size_t dlen,
 }
 
 
+/*
+ * Verifies that a specific zfs filesystem handle meets the criteria necessary
+ * to be used by libshare operations. See get_zfs_dataset.
+ */
 static char *
 verify_zfs_handle(zfs_handle_t *hdl, const char *path, boolean_t search_mnttab)
 {
@@ -338,19 +342,16 @@ get_zfs_dataset(sa_handle_impl_t impl_handle, char *path,
 
 	assert(impl_handle->zfs_libhandle != NULL);
 	libzfs_print_on_error(impl_handle->zfs_libhandle, B_FALSE);
-	if ((handle_from_path = zfs_open(impl_handle->zfs_libhandle, cutpath,
-	    ZFS_TYPE_FILESYSTEM)) != NULL) {
-		if ((ret = verify_zfs_handle(handle_from_path, path,
-		    search_mnttab)) != NULL) {
-			zfs_close(handle_from_path);
-			libzfs_print_on_error(impl_handle->zfs_libhandle,
-			    B_TRUE);
+	handle_from_path = zfs_open(impl_handle->zfs_libhandle, cutpath,
+	    ZFS_TYPE_FILESYSTEM);
+	libzfs_print_on_error(impl_handle->zfs_libhandle, B_TRUE);
+	if (handle_from_path != NULL) {
+		ret = verify_zfs_handle(handle_from_path, path, search_mnttab);
+		zfs_close(handle_from_path);
+		if (ret != NULL) {
 			return (ret);
 		}
-		zfs_close(handle_from_path);
 	}
-	libzfs_print_on_error(impl_handle->zfs_libhandle, B_TRUE);
-
 	/*
 	 * Couldn't find a filesystem optimistically, check all the handles we
 	 * can.
@@ -764,8 +765,6 @@ sa_zfs_process_share(sa_handle_t handle, sa_group_t group, sa_share_t share,
 }
 
 /*
- * sa_get_zfs_shares(handle, groupname)
- *
  * Walk the mnttab for all zfs mounts and determine which are
  * shared. Find or create the appropriate group/sub-group to contain
  * the shares.
@@ -778,35 +777,183 @@ sa_zfs_process_share(sa_handle_t handle, sa_group_t group, sa_share_t share,
  * a sub-group must be formed at the lower level for both
  * protocols. That is the nature of the problem in CR 6667349.
  */
+static int
+sa_get_zfs_share_common(sa_handle_t handle, zfs_handle_t *fs_handle, char *path,
+    sa_group_t zfsgroup)
+{
+	boolean_t smb, nfs;
+	boolean_t smb_inherited, nfs_inherited;
+	char nfsshareopts[ZFS_MAXPROPLEN];
+	char smbshareopts[ZFS_MAXPROPLEN];
+	char nfssourcestr[ZFS_MAXPROPLEN];
+	char smbsourcestr[ZFS_MAXPROPLEN];
+	char mountpoint[ZFS_MAXPROPLEN];
+	int err = SA_OK;
+	zprop_source_t source;
+	sa_share_t share;
+	char *dataset;
 
+	source = ZPROP_SRC_ALL;
+	/* If no mountpoint, skip. */
+	if (zfs_prop_get(fs_handle, ZFS_PROP_MOUNTPOINT,
+	    mountpoint, sizeof (mountpoint), NULL, NULL, 0,
+	    B_FALSE) != 0)
+		return (SA_SYSTEM_ERR);
+
+	if (path != NULL)
+		(void) strncpy(path, mountpoint, sizeof (mountpoint));
+	/*
+	 * zfs_get_name value must not be freed. It is just a
+	 * pointer to a value in the handle.
+	 */
+	if ((dataset = (char *)zfs_get_name(fs_handle)) == NULL)
+		return (SA_SYSTEM_ERR);
+
+	/*
+	 * only deal with "mounted" file systems since
+	 * unmounted file systems can't actually be shared.
+	 */
+
+	if (!zfs_is_mounted(fs_handle, NULL))
+		return (SA_SYSTEM_ERR);
+
+	nfs = nfs_inherited = B_FALSE;
+
+	if (zfs_prop_get(fs_handle, ZFS_PROP_SHARENFS, nfsshareopts,
+	    sizeof (nfsshareopts), &source, nfssourcestr,
+	    ZFS_MAXPROPLEN, B_FALSE) == 0 &&
+	    strcmp(nfsshareopts, "off") != 0) {
+		if (source & ZPROP_SRC_INHERITED)
+			nfs_inherited = B_TRUE;
+		else
+			nfs = B_TRUE;
+	}
+
+	smb = smb_inherited = B_FALSE;
+	if (zfs_prop_get(fs_handle, ZFS_PROP_SHARESMB, smbshareopts,
+	    sizeof (smbshareopts), &source, smbsourcestr,
+	    ZFS_MAXPROPLEN, B_FALSE) == 0 &&
+	    strcmp(smbshareopts, "off") != 0) {
+		if (source & ZPROP_SRC_INHERITED)
+			smb_inherited = B_TRUE;
+		else
+			smb = B_TRUE;
+	}
+
+	/*
+	 * If the mountpoint is already shared, it must be a
+	 * non-ZFS share. We want to remove the share from its
+	 * parent group and reshare it under ZFS.
+	 */
+	share = sa_find_share(handle, mountpoint);
+	if (share != NULL &&
+	    (nfs || smb || nfs_inherited || smb_inherited)) {
+		err = sa_remove_share(share);
+		share = NULL;
+	}
+
+	/*
+	 * At this point, we have the information needed to
+	 * determine what to do with the share.
+	 *
+	 * If smb or nfs is set, we have a new sub-group.
+	 * If smb_inherit and/or nfs_inherit is set, then
+	 * place on an existing sub-group. If both are set,
+	 * the existing sub-group is the closest up the tree.
+	 */
+	if (nfs || smb) {
+		/*
+		 * Non-inherited is the straightforward
+		 * case. sa_zfs_process_share handles it
+		 * directly. Make sure that if the "other"
+		 * protocol is inherited, that we treat it as
+		 * non-inherited as well.
+		 */
+		if (nfs || nfs_inherited) {
+			err = sa_zfs_process_share(handle, zfsgroup,
+			    share, mountpoint, "nfs",
+			    0, nfsshareopts,
+			    nfssourcestr, dataset);
+			share = sa_find_share(handle, mountpoint);
+		}
+		if (smb || smb_inherited) {
+			err = sa_zfs_process_share(handle, zfsgroup,
+			    share, mountpoint, "smb",
+			    0, smbshareopts,
+			    smbsourcestr, dataset);
+		}
+	} else if (nfs_inherited || smb_inherited) {
+		char *grpdataset;
+		/*
+		 * If we only have inherited groups, it is
+		 * important to find the closer of the two if
+		 * the protocols are set at different
+		 * levels. The closest sub-group is the one we
+		 * want to work with.
+		 */
+		if (nfs_inherited && smb_inherited) {
+			if (strcmp(nfssourcestr, smbsourcestr) <= 0)
+				grpdataset = nfssourcestr;
+			else
+				grpdataset = smbsourcestr;
+		} else if (nfs_inherited) {
+			grpdataset = nfssourcestr;
+		} else if (smb_inherited) {
+			grpdataset = smbsourcestr;
+		}
+		if (nfs_inherited) {
+			err = sa_zfs_process_share(handle, zfsgroup,
+			    share, mountpoint, "nfs",
+			    ZPROP_SRC_INHERITED, nfsshareopts,
+			    grpdataset, dataset);
+			share = sa_find_share(handle, mountpoint);
+		}
+		if (smb_inherited) {
+			err = sa_zfs_process_share(handle, zfsgroup,
+			    share, mountpoint, "smb",
+			    ZPROP_SRC_INHERITED, smbshareopts,
+			    grpdataset, dataset);
+		}
+	}
+	return (err);
+}
+
+/*
+ * Handles preparing generic objects such as the libzfs handle and group for
+ * sa_get_one_zfs_share, sa_get_zfs_share_for_name, and sa_get_zfs_shares.
+ */
+static int
+prep_zfs_handle_and_group(sa_handle_t handle, char *groupname,
+    libzfs_handle_t **zfs_libhandle, sa_group_t *zfsgroup, int *err)
+{
+	/*
+	 * If we can't access libzfs, don't bother doing anything.
+	 */
+	*zfs_libhandle = ((sa_handle_impl_t)handle)->zfs_libhandle;
+	if (*zfs_libhandle == NULL)
+		return (SA_SYSTEM_ERR);
+
+	*zfsgroup = find_or_create_group(handle, groupname, NULL, err);
+	return (SA_OK);
+}
+
+/*
+ * The O.G. zfs share preparation function. This initializes all zfs shares for
+ * use with libshare.
+ */
 int
 sa_get_zfs_shares(sa_handle_t handle, char *groupname)
 {
 	sa_group_t zfsgroup;
-	boolean_t nfs;
-	boolean_t nfs_inherited;
-	boolean_t smb;
-	boolean_t smb_inherited;
 	zfs_handle_t **zlist;
-	char nfsshareopts[ZFS_MAXPROPLEN];
-	char smbshareopts[ZFS_MAXPROPLEN];
-	sa_share_t share;
-	zprop_source_t source;
-	char nfssourcestr[ZFS_MAXPROPLEN];
-	char smbsourcestr[ZFS_MAXPROPLEN];
-	char mountpoint[ZFS_MAXPROPLEN];
-	size_t count = 0, i;
+	size_t count = 0;
 	libzfs_handle_t *zfs_libhandle;
-	int err = SA_OK;
+	int err;
 
-	/*
-	 * If we can't access libzfs, don't bother doing anything.
-	 */
-	zfs_libhandle = ((sa_handle_impl_t)handle)->zfs_libhandle;
-	if (zfs_libhandle == NULL)
-		return (SA_SYSTEM_ERR);
-
-	zfsgroup = find_or_create_group(handle, groupname, NULL, &err);
+	if ((err = prep_zfs_handle_and_group(handle, groupname, &zfs_libhandle,
+	    &zfsgroup, &err)) != SA_OK) {
+		return (err);
+	}
 	/* Not an error, this could be a legacy condition */
 	if (zfsgroup == NULL)
 		return (SA_OK);
@@ -818,129 +965,8 @@ sa_get_zfs_shares(sa_handle_t handle, char *groupname)
 	get_all_filesystems((sa_handle_impl_t)handle, &zlist, &count);
 	qsort(zlist, count, sizeof (void *), mountpoint_compare);
 
-	for (i = 0; i < count; i++) {
-		char *dataset;
-
-		source = ZPROP_SRC_ALL;
-		/* If no mountpoint, skip. */
-		if (zfs_prop_get(zlist[i], ZFS_PROP_MOUNTPOINT,
-		    mountpoint, sizeof (mountpoint), NULL, NULL, 0,
-		    B_FALSE) != 0)
-			continue;
-
-		/*
-		 * zfs_get_name value must not be freed. It is just a
-		 * pointer to a value in the handle.
-		 */
-		if ((dataset = (char *)zfs_get_name(zlist[i])) == NULL)
-			continue;
-
-		/*
-		 * only deal with "mounted" file systems since
-		 * unmounted file systems can't actually be shared.
-		 */
-
-		if (!zfs_is_mounted(zlist[i], NULL))
-			continue;
-
-		nfs = nfs_inherited = B_FALSE;
-
-		if (zfs_prop_get(zlist[i], ZFS_PROP_SHARENFS, nfsshareopts,
-		    sizeof (nfsshareopts), &source, nfssourcestr,
-		    ZFS_MAXPROPLEN, B_FALSE) == 0 &&
-		    strcmp(nfsshareopts, "off") != 0) {
-			if (source & ZPROP_SRC_INHERITED)
-				nfs_inherited = B_TRUE;
-			else
-				nfs = B_TRUE;
-		}
-
-		smb = smb_inherited = B_FALSE;
-		if (zfs_prop_get(zlist[i], ZFS_PROP_SHARESMB, smbshareopts,
-		    sizeof (smbshareopts), &source, smbsourcestr,
-		    ZFS_MAXPROPLEN, B_FALSE) == 0 &&
-		    strcmp(smbshareopts, "off") != 0) {
-			if (source & ZPROP_SRC_INHERITED)
-				smb_inherited = B_TRUE;
-			else
-				smb = B_TRUE;
-		}
-
-		/*
-		 * If the mountpoint is already shared, it must be a
-		 * non-ZFS share. We want to remove the share from its
-		 * parent group and reshare it under ZFS.
-		 */
-		share = sa_find_share(handle, mountpoint);
-		if (share != NULL &&
-		    (nfs || smb || nfs_inherited || smb_inherited)) {
-			err = sa_remove_share(share);
-			share = NULL;
-		}
-
-		/*
-		 * At this point, we have the information needed to
-		 * determine what to do with the share.
-		 *
-		 * If smb or nfs is set, we have a new sub-group.
-		 * If smb_inherit and/or nfs_inherit is set, then
-		 * place on an existing sub-group. If both are set,
-		 * the existing sub-group is the closest up the tree.
-		 */
-		if (nfs || smb) {
-			/*
-			 * Non-inherited is the straightforward
-			 * case. sa_zfs_process_share handles it
-			 * directly. Make sure that if the "other"
-			 * protocol is inherited, that we treat it as
-			 * non-inherited as well.
-			 */
-			if (nfs || nfs_inherited) {
-				err = sa_zfs_process_share(handle, zfsgroup,
-				    share, mountpoint, "nfs",
-				    0, nfsshareopts,
-				    nfssourcestr, dataset);
-				share = sa_find_share(handle, mountpoint);
-			}
-			if (smb || smb_inherited) {
-				err = sa_zfs_process_share(handle, zfsgroup,
-				    share, mountpoint, "smb",
-				    0, smbshareopts,
-				    smbsourcestr, dataset);
-			}
-		} else if (nfs_inherited || smb_inherited) {
-			char *grpdataset;
-			/*
-			 * If we only have inherited groups, it is
-			 * important to find the closer of the two if
-			 * the protocols are set at different
-			 * levels. The closest sub-group is the one we
-			 * want to work with.
-			 */
-			if (nfs_inherited && smb_inherited) {
-				if (strcmp(nfssourcestr, smbsourcestr) <= 0)
-					grpdataset = nfssourcestr;
-				else
-					grpdataset = smbsourcestr;
-			} else if (nfs_inherited) {
-				grpdataset = nfssourcestr;
-			} else if (smb_inherited) {
-				grpdataset = smbsourcestr;
-			}
-			if (nfs_inherited) {
-				err = sa_zfs_process_share(handle, zfsgroup,
-				    share, mountpoint, "nfs",
-				    ZPROP_SRC_INHERITED, nfsshareopts,
-				    grpdataset, dataset);
-				share = sa_find_share(handle, mountpoint);
-			}
-			if (smb_inherited) {
-				err = sa_zfs_process_share(handle, zfsgroup,
-				    share, mountpoint, "smb",
-				    ZPROP_SRC_INHERITED, smbshareopts,
-				    grpdataset, dataset);
-			}
-		}
+	for (int i = 0; i < count; i++) {
+		err = sa_get_zfs_share_common(handle, zlist[i], NULL, zfsgroup);
 	}
 	/*
 	 * Don't need to free the "zlist" variable since it is only a
@@ -949,6 +975,73 @@ sa_get_zfs_shares(sa_handle_t handle, char *groupname)
 	 */
 	return (err);
 }
+
+/*
+ * Initializes only the handles specified in the sharearg for use with libshare.
+ * This is used as a performance optimization relative to sa_get_zfs_shares.
+ */
+int
+sa_get_one_zfs_share(sa_handle_t handle, char *groupname,
+    sa_init_selective_arg_t *sharearg, char ***paths, size_t *paths_len)
+{
+	sa_group_t zfsgroup;
+	libzfs_handle_t *zfs_libhandle;
+	int err;
+
+	if ((err = prep_zfs_handle_and_group(handle, groupname, &zfs_libhandle,
+	    &zfsgroup, &err)) != SA_OK) {
+		return (err);
+	}
+	/* Not an error, this could be a legacy condition */
+	if (zfsgroup == NULL)
+		return (SA_OK);
+
+	*paths_len = sharearg->zhandle_len;
+	*paths = malloc(sizeof (char *) * (*paths_len));
+	for (int i = 0; i < sharearg->zhandle_len; ++i) {
+		zfs_handle_t *fs_handle =
+		    ((zfs_handle_t **)(sharearg->zhandle_arr))[i];
+		if (fs_handle == NULL) {
+			return (SA_SYSTEM_ERR);
+		}
+		(*paths)[i] = malloc(sizeof (char) * ZFS_MAXPROPLEN);
+		err |= sa_get_zfs_share_common(handle, fs_handle, (*paths)[i],
+		    zfsgroup);
+	}
+	return (err);
+}
+
+/*
+ * Initializes only the share with the specified sharename for use with
+ * libshare.
+ */
+int
+sa_get_zfs_share_for_name(sa_handle_t handle, char *groupname,
+    const char *sharename, char *outpath)
+{
+	sa_group_t zfsgroup;
+	libzfs_handle_t *zfs_libhandle;
+	int err;
+
+	if ((err = prep_zfs_handle_and_group(handle, groupname, &zfs_libhandle,
+	    &zfsgroup, &err)) != SA_OK) {
+		return (err);
+	}
+	/* Not an error, this could be a legacy condition */
+	if (zfsgroup == NULL)
+		return (SA_OK);
+
+	zfs_handle_t *fs_handle = zfs_open(zfs_libhandle,
+	    sharename + strspn(sharename, "/"), ZFS_TYPE_DATASET);
+	if (fs_handle == NULL)
+		return (SA_SYSTEM_ERR);
+
+	err = sa_get_zfs_share_common(handle, fs_handle, outpath, zfsgroup);
+	zfs_close(fs_handle);
+	return (err);
+}
+
+
 
 #define	COMMAND		"/usr/sbin/zfs"
 

--- a/usr/src/lib/libshare/common/mapfile-vers
+++ b/usr/src/lib/libshare/common/mapfile-vers
@@ -20,6 +20,7 @@
 #
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
 #
@@ -112,6 +113,7 @@ SYMBOL_VERSION SUNWprivate {
 	sa_get_next_security;
 	sa_get_protocol_status;
 	sa_init;
+	sa_init_arg;
 	sa_find_share;
 	sa_set_protocol_property;
 	sa_fini;

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -783,6 +783,17 @@ extern int zpool_fru_set(zpool_handle_t *, uint64_t, const char *);
 
 extern int zfs_get_hole_count(const char *, uint64_t *, uint64_t *);
 
+/* Allow consumers to initialize libshare externally for optimal performance */
+extern int zfs_init_libshare_arg(libzfs_handle_t *, int, void *);
+/*
+ * For most consumers, zfs_init_libshare_arg is sufficient on its own, and
+ * zfs_uninit_libshare is unnecessary. zfs_uninit_libshare should only be called
+ * if the caller has already initialized libshare for one set of zfs handles,
+ * and wishes to share or unshare filesystems outside of that set. In that case,
+ * the caller should uninitialize libshare, and then re-initialize it with the
+ * new handles being shared or unshared.
+ */
+extern void zfs_uninit_libshare(libzfs_handle_t *);
 #ifdef	__cplusplus
 }
 #endif

--- a/usr/src/lib/libzfs/common/libzfs_changelist.c
+++ b/usr/src/lib/libzfs/common/libzfs_changelist.c
@@ -24,7 +24,7 @@
  * Use is subject to license terms.
  *
  * Portions Copyright 2007 Ramprakash Jelari
- * Copyright (c) 2014, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  */
 
@@ -162,6 +162,9 @@ changelist_postfix(prop_changelist_t *clp)
 	char shareopts[ZFS_MAXPROPLEN];
 	int errors = 0;
 	libzfs_handle_t *hdl;
+	size_t num_datasets = 0, i;
+	zfs_handle_t **zhandle_arr;
+	sa_init_selective_arg_t sharearg;
 
 	/*
 	 * If we're changing the mountpoint, attempt to destroy the underlying
@@ -186,8 +189,31 @@ changelist_postfix(prop_changelist_t *clp)
 		hdl = cn->cn_handle->zfs_hdl;
 		assert(hdl != NULL);
 		zfs_uninit_libshare(hdl);
-	}
 
+		/*
+		 * For efficiencies sake, we initialize libshare for only a few
+		 * shares (the ones affected here). Future initializations in
+		 * this process should just use the cached initialization.
+		 */
+		for (cn = uu_list_last(clp->cl_list); cn != NULL;
+		    cn = uu_list_prev(clp->cl_list, cn)) {
+			num_datasets++;
+		}
+
+		zhandle_arr = zfs_alloc(hdl,
+		    num_datasets * sizeof (zfs_handle_t *));
+		for (i = 0, cn = uu_list_last(clp->cl_list); cn != NULL;
+		    cn = uu_list_prev(clp->cl_list, cn)) {
+			zhandle_arr[i++] = cn->cn_handle;
+			zfs_refresh_properties(cn->cn_handle);
+		}
+		assert(i == num_datasets);
+		sharearg.zhandle_arr = zhandle_arr;
+		sharearg.zhandle_len = num_datasets;
+		errors = zfs_init_libshare_arg(hdl, SA_INIT_SHARE_API_SELECTIVE,
+		    &sharearg);
+		free(zhandle_arr);
+	}
 	/*
 	 * We walk the datasets in reverse, because we want to mount any parent
 	 * datasets before mounting the children.  We walk all datasets even if
@@ -211,8 +237,6 @@ changelist_postfix(prop_changelist_t *clp)
 		if (!cn->cn_needpost)
 			continue;
 		cn->cn_needpost = B_FALSE;
-
-		zfs_refresh_properties(cn->cn_handle);
 
 		if (ZFS_IS_VOLUME(cn->cn_handle))
 			continue;

--- a/usr/src/lib/libzfs/common/libzfs_impl.h
+++ b/usr/src/lib/libzfs/common/libzfs_impl.h
@@ -203,7 +203,6 @@ void namespace_clear(libzfs_handle_t *);
  */
 
 extern int zfs_init_libshare(libzfs_handle_t *, int);
-extern void zfs_uninit_libshare(libzfs_handle_t *);
 extern int zfs_parse_options(char *, zfs_share_proto_t);
 
 extern int zfs_unshare_proto(zfs_handle_t *,

--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -567,6 +567,7 @@ zfs_is_shared_smb(zfs_handle_t *zhp, char **where)
  */
 
 static sa_handle_t (*_sa_init)(int);
+static sa_handle_t (*_sa_init_arg)(int, void *);
 static void (*_sa_fini)(sa_handle_t);
 static sa_share_t (*_sa_find_share)(sa_handle_t, char *);
 static int (*_sa_enable_share)(sa_share_t, char *);
@@ -606,6 +607,8 @@ _zfs_init_libshare(void)
 
 	if ((libshare = dlopen(path, RTLD_LAZY | RTLD_GLOBAL)) != NULL) {
 		_sa_init = (sa_handle_t (*)(int))dlsym(libshare, "sa_init");
+		_sa_init_arg = (sa_handle_t (*)(int, void *))dlsym(libshare,
+		    "sa_init_arg");
 		_sa_fini = (void (*)(sa_handle_t))dlsym(libshare, "sa_fini");
 		_sa_find_share = (sa_share_t (*)(sa_handle_t, char *))
 		    dlsym(libshare, "sa_find_share");
@@ -625,14 +628,15 @@ _zfs_init_libshare(void)
 		    char *, char *))dlsym(libshare, "sa_zfs_process_share");
 		_sa_update_sharetab_ts = (void (*)(sa_handle_t))
 		    dlsym(libshare, "sa_update_sharetab_ts");
-		if (_sa_init == NULL || _sa_fini == NULL ||
-		    _sa_find_share == NULL || _sa_enable_share == NULL ||
-		    _sa_disable_share == NULL || _sa_errorstr == NULL ||
-		    _sa_parse_legacy_options == NULL ||
+		if (_sa_init == NULL || _sa_init_arg == NULL ||
+		    _sa_fini == NULL || _sa_find_share == NULL ||
+		    _sa_enable_share == NULL || _sa_disable_share == NULL ||
+		    _sa_errorstr == NULL || _sa_parse_legacy_options == NULL ||
 		    _sa_needs_refresh == NULL || _sa_get_zfs_handle == NULL ||
 		    _sa_zfs_process_share == NULL ||
 		    _sa_update_sharetab_ts == NULL) {
 			_sa_init = NULL;
+			_sa_init_arg = NULL;
 			_sa_fini = NULL;
 			_sa_disable_share = NULL;
 			_sa_enable_share = NULL;
@@ -655,8 +659,8 @@ _zfs_init_libshare(void)
  * service value is which part(s) of the API to initialize and is a
  * direct map to the libshare sa_init(service) interface.
  */
-int
-zfs_init_libshare(libzfs_handle_t *zhandle, int service)
+static int
+zfs_init_libshare_impl(libzfs_handle_t *zhandle, int service, void *arg)
 {
 	if (_sa_init == NULL)
 		return (SA_CONFIG_ERR);
@@ -672,17 +676,29 @@ zfs_init_libshare(libzfs_handle_t *zhandle, int service)
 	if (_sa_needs_refresh != NULL &&
 	    _sa_needs_refresh(zhandle->libzfs_sharehdl)) {
 		zfs_uninit_libshare(zhandle);
-		zhandle->libzfs_sharehdl = _sa_init(service);
+		zhandle->libzfs_sharehdl = _sa_init_arg(service, arg);
 	}
 
 	if (zhandle && zhandle->libzfs_sharehdl == NULL)
-		zhandle->libzfs_sharehdl = _sa_init(service);
+		zhandle->libzfs_sharehdl = _sa_init_arg(service, arg);
 
 	if (zhandle->libzfs_sharehdl == NULL)
 		return (SA_NO_MEMORY);
 
 	return (SA_OK);
 }
+int
+zfs_init_libshare(libzfs_handle_t *zhandle, int service)
+{
+	return (zfs_init_libshare_impl(zhandle, service, NULL));
+}
+
+int
+zfs_init_libshare_arg(libzfs_handle_t *zhandle, int service, void *arg)
+{
+	return (zfs_init_libshare_impl(zhandle, service, arg));
+}
+
 
 /*
  * zfs_uninit_libshare(zhandle)
@@ -787,8 +803,8 @@ zfs_share_proto(zfs_handle_t *zhp, zfs_share_proto_t *proto)
 		    ZFS_MAXPROPLEN, B_FALSE) != 0 ||
 		    strcmp(shareopts, "off") == 0)
 			continue;
-
-		ret = zfs_init_libshare(hdl, SA_INIT_SHARE_API);
+		ret = zfs_init_libshare_arg(hdl, SA_INIT_ONE_SHARE_FROM_HANDLE,
+		    zhp);
 		if (ret != SA_OK) {
 			(void) zfs_error_fmt(hdl, EZFS_SHARENFSFAILED,
 			    dgettext(TEXT_DOMAIN, "cannot share '%s': %s"),
@@ -882,6 +898,7 @@ unshare_one(libzfs_handle_t *hdl, const char *name, const char *mountpoint,
 	sa_share_t share;
 	int err;
 	char *mntpt;
+
 	/*
 	 * Mountpoint could get trashed if libshare calls getmntany
 	 * which it does during API initialization, so strdup the
@@ -889,8 +906,14 @@ unshare_one(libzfs_handle_t *hdl, const char *name, const char *mountpoint,
 	 */
 	mntpt = zfs_strdup(hdl, mountpoint);
 
-	/* make sure libshare initialized */
-	if ((err = zfs_init_libshare(hdl, SA_INIT_SHARE_API)) != SA_OK) {
+	/*
+	 * make sure libshare initialized, initialize everything because we
+	 * don't know what other unsharing may happen later. Functions up the
+	 * stack are allowed to initialize instead a subset of shares at the
+	 * time the set is known.
+	 */
+	if ((err = zfs_init_libshare_arg(hdl, SA_INIT_ONE_SHARE_FROM_NAME,
+	    (void *)name)) != SA_OK) {
 		free(mntpt);	/* don't need the copy anymore */
 		return (zfs_error_fmt(hdl, EZFS_UNSHARENFSFAILED,
 		    dgettext(TEXT_DOMAIN, "cannot unshare '%s': %s"),
@@ -1222,6 +1245,7 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	int i;
 	int ret = -1;
 	int flags = (force ? MS_FORCE : 0);
+	sa_init_selective_arg_t sharearg;
 
 	namelen = strlen(zhp->zpool_name);
 
@@ -1296,6 +1320,12 @@ zpool_disable_datasets(zpool_handle_t *zhp, boolean_t force)
 	 * At this point, we have the entire list of filesystems, so sort it by
 	 * mountpoint.
 	 */
+	sharearg.zhandle_arr = datasets;
+	sharearg.zhandle_len = used;
+	ret = zfs_init_libshare_arg(hdl, SA_INIT_SHARE_API_SELECTIVE,
+	    &sharearg);
+	if (ret != 0)
+		goto out;
 	qsort(mountpoints, used, sizeof (char *), mountpoint_compare);
 
 	/*

--- a/usr/src/lib/libzfs/common/mapfile-vers
+++ b/usr/src/lib/libzfs/common/mapfile-vers
@@ -88,6 +88,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zfs_handle_dup;
 	zfs_history_event_names;
 	zfs_hold;
+	zfs_init_libshare_arg;
 	zfs_is_mounted;
 	zfs_is_shared;
 	zfs_is_shared_nfs;
@@ -161,6 +162,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zfs_spa_version_map;
 	zfs_standard_error;
 	zfs_type_to_name;
+	zfs_uninit_libshare;
 	zfs_unmount;
 	zfs_unmountall;
 	zfs_unshare;

--- a/usr/src/test/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/inheritance/inherit_001_pos.ksh
@@ -331,7 +331,7 @@ function scan_state { #state-file
 				if [[ $op == "-" ]]; then
 					log_note "No operation specified"
 				else
-					export __ZFS_POOL_RESTRICT="$TESTPOOL"
+					export __ZFS_POOL_RESTRICT="TESTPOOL"
 					log_must zfs unmount -a
 					unset __ZFS_POOL_RESTRICT
 


### PR DESCRIPTION
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

Libshare currently initializes all available filesystems when doing any
libshare operation. This requires iterating through all the filesystem
multiple times, which is a huge performance problem for sharing and
unsharing operations.

This patch modifies the initialization of libshare in two more modes
beyond what had happened before. In one, a pathname is passed in, and
that one path is intiialized if possible. In another mode of operation,
an array of zfs dataset handles is passed into libshare to be
initialized. In any case, these initialization operations should speed
up most uses of libshare.

The following tests were run on a system with ~8300 ZFS filesystems on
it, using time(1) to measure the performance of each command without
this patch:

    $ sudo zfs create -o sharenfs=on rpool/test
    $ time sudo zfs destroy rpool/test
    real    0m28.957s
    user    0m7.494s
    sys     0m20.969s

    $ time sudo zfs create -o sharenfs=on rpool/test
    real    0m29.216s
    user    0m7.517s
    sys     0m20.579s

    $ time sudo zfs destroy rpool/test
    real    0m28.527s
    user    0m7.435s
    sys     0m20.688s

And then same commands were run on the same system, but using a version
of libshare with this patch applied:

    $ sudo zfs create -o sharenfs=on rpool/test
    $ time sudo zfs destroy rpool/test
    real    0m0.624s
    user    0m0.067s
    sys     0m0.255s

    $ time sudo zfs create -o sharenfs=on rpool/test
    real    0m0.797s
    user    0m0.020s
    sys     0m0.183s

    $ time sudo zfs destroy rpool/test
    real    0m0.627s
    user    0m0.072s
    sys     0m0.270s

That's about a 97% decrease in "wall clock" latency for these commands.

Upstream bugs: DLPX-47705, DLPX-47160, DLPX-48226, DLPX-50300