### PR TITLE
7956 "minimum" is misspelled in zpool manpage

### DIFF
--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -569,7 +569,7 @@ Threshold for the number of block ditto copies. If the reference count for a
 deduplicated block increases above this number, a new ditto copy of this block
 is automatically stored. The default setting is
 .Sy 0
-which causes no ditto copies to be created for deduplicated blocks. The miniumum
+which causes no ditto copies to be created for deduplicated blocks. The minimum
 legal nonzero setting is
 .Sy 100 .
 .It Sy delegation Ns = Ns Sy on Ns | Ns Sy off


### PR DESCRIPTION
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>

Upstream bugs: DLPX-46474