### PR TITLE
7668 zfs get only outputs 3 columns if "clones" property is empty

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_util.c
+++ b/usr/src/lib/libzfs/common/libzfs_util.c
@@ -991,7 +991,7 @@ zprop_print_one_property(const char *name, zprop_get_cbdata_t *cbp,
 			break;
 
 		case GET_COL_VALUE:
-			str = value;
+			str = (*value == '\0') ? "-" : value;
 			break;
 
 		case GET_COL_SOURCE:


### PR DESCRIPTION
Check the numclones property and return early if it's 0, setting "-" for clones string.