### PR TITLE
6392 zdb: Introduce -V for verbatim import

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -120,20 +120,21 @@ static void
 usage(void)
 {
 	(void) fprintf(stderr,
-	    "Usage:\t%s [-AbcdDFGhiLMPsvX] [-e [-p <path> ...]] "
+	    "Usage:\t%s [-AbcdDFGhiLMPsvX] [-e [-V] [-p <path> ...]] "
 	    "[-I <inflight I/Os>]\n"
 	    "\t\t[-o <var>=<value>]... [-t <txg>] [-U <cache>] [-x <dumpdir>]\n"
 	    "\t\t[<poolname> [<object> ...]]\n"
-	    "\t%s [-AdiPv] [-e [-p <path> ...]] [-U <cache>] <dataset> "
+	    "\t%s [-AdiPv] [-e [-V] [-p <path> ...]] [-U <cache>] <dataset> "
 	    "[<object> ...]\n"
 	    "\t%s -C [-A] [-U <cache>]\n"
 	    "\t%s -l [-Aqu] <device>\n"
-	    "\t%s -m [-AFLPX] [-e [-p <path> ...]] [-t <txg>] [-U <cache>]\n"
-	    "\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
+	    "\t%s -m [-AFLPX] [-e [-V] [-p <path> ...]] [-t <txg>] "
+	    "[-U <cache>]\n\t\t<poolname> [<vdev> [<metaslab> ...]]\n"
 	    "\t%s -O <dataset> <path>\n"
-	    "\t%s -R [-A] [-e [-p <path> ...]] [-U <cache>]\n"
+	    "\t%s -R [-A] [-e [-V] [-p <path> ...]] [-U <cache>]\n"
 	    "\t\t<poolname> <vdev>:<offset>:<size>[:<flags>]\n"
-	    "\t%s -S [-AP] [-e [-p <path> ...]] [-U <cache>] <poolname>\n\n",
+	    "\t%s -S [-AP] [-e [-V] [-p <path> ...]] [-U <cache>] "
+	    "<poolname>\n\n",
 	    cmdname, cmdname, cmdname, cmdname, cmdname, cmdname, cmdname,
 	    cmdname);
 
@@ -188,6 +189,7 @@ usage(void)
 	(void) fprintf(stderr, "        -u uberblock\n");
 	(void) fprintf(stderr, "        -U <cachefile_path> -- use alternate "
 	    "cachefile\n");
+	(void) fprintf(stderr, "        -V do verbatim import\n");
 	(void) fprintf(stderr, "        -x <dumpdir> -- "
 	    "dump all read blocks into specified directory\n");
 	(void) fprintf(stderr, "        -X attempt extreme rewind (does not "
@@ -3713,6 +3715,7 @@ main(int argc, char **argv)
 	char *target;
 	nvlist_t *policy = NULL;
 	uint64_t max_txg = UINT64_MAX;
+	int flags = ZFS_IMPORT_MISSING_LOG;
 	int rewind = ZPOOL_NEVER_REWIND;
 	char *spa_config_path_env;
 	boolean_t target_is_spa = B_TRUE;
@@ -3732,7 +3735,7 @@ main(int argc, char **argv)
 		spa_config_path = spa_config_path_env;
 
 	while ((c = getopt(argc, argv,
-	    "AbcCdDeFGhiI:lLmMo:Op:PqRsSt:uU:vx:X")) != -1) {
+	    "AbcCdDeFGhiI:lLmMo:Op:PqRsSt:uU:vVx:X")) != -1) {
 		switch (c) {
 		case 'b':
 		case 'c':
@@ -3805,6 +3808,9 @@ main(int argc, char **argv)
 			break;
 		case 'v':
 			verbose++;
+			break;
+		case 'V':
+			flags = ZFS_IMPORT_VERBATIM;
 			break;
 		case 'x':
 			vn_dumpdir = optarg;
@@ -3905,11 +3911,7 @@ main(int argc, char **argv)
 				fatal("can't open '%s': %s",
 				    target, strerror(ENOMEM));
 			}
-			if ((error = spa_import(name, cfg, NULL,
-			    ZFS_IMPORT_MISSING_LOG)) != 0) {
-				error = spa_import(name, cfg, NULL,
-				    ZFS_IMPORT_VERBATIM);
-			}
+			error = spa_import(name, cfg, NULL, flags);
 		}
 	}
 

--- a/usr/src/man/man1m/zdb.1m
+++ b/usr/src/man/man1m/zdb.1m
@@ -22,7 +22,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl AbcdDFGhiLMPsvX
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl I Ar inflight I/Os
 .Oo Fl o Ar var Ns = Ns Ar value Oc Ns ...
 .Op Fl t Ar txg
@@ -31,7 +31,7 @@
 .Op Ar poolname Op Ar object ...
 .Nm
 .Op Fl AdiPv
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar dataset Op Ar object ...
 .Nm
@@ -45,8 +45,8 @@
 .Nm
 .Fl m
 .Op Fl AFLPX
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl t Ar txg
-.Op Fl e Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname Op Ar vdev Op Ar metaslab ...
 .Nm
@@ -55,13 +55,13 @@
 .Nm
 .Fl R
 .Op Fl A
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname vdev Ns : Ns Ar offset Ns : Ns Ar size Ns Op : Ns Ar flags
 .Nm
 .Fl S
 .Op Fl AP
-.Op Fl e Op Fl p Ar path ...
+.Op Fl e Oo Fl V Oc Op Fl p Ar path ...
 .Op Fl U Ar cache
 .Ar poolname
 .Sh DESCRIPTION
@@ -316,6 +316,11 @@ Use a cache file other than
 .It Fl v
 Enable verbosity.
 Specify multiple times for increased verbosity.
+.It Fl V
+Attempt verbatim import.
+This mimics the behavior of the kernel when loading a pool from a cachefile.
+Only usable with
+.Fl e .
 .It Fl X
 Attempt
 .Qq extreme

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zdb/zdb_001_neg.ksh
@@ -59,7 +59,7 @@ set -A args "create" "add" "destroy" "import fakepool" \
     "-a" "-f" "-g" "-h" "-j" "-k" "-m" "-n" "-o" "-p" \
     "-p /tmp" "-r" "-t" "-w" "-x" "-y" "-z" \
     "-D" "-E" "-G" "-H" "-I" "-J" "-K" "-M" \
-    "-N" "-Q" "-R" "-S" "-T" "-V" "-W" "-Y" "-Z"
+    "-N" "-Q" "-R" "-S" "-T" "-W" "-Y" "-Z"
 
 log_assert "Execute zdb using invalid parameters."
 


### PR DESCRIPTION
Supersedes #22 (its description below).

Reviewed by: Brian Behlendorf behlendorf1@llnl.gov
Reviewed by: Matthew Ahrens mahrens@delphix.com

When given a pool name via -e, zdb would attempt an import. If it
failed, then it would attempt a verbatim import. This behavior is
not always desirable so a -V switch is added to zdb to control the
behavior. When specified, a verbatim import is done. Otherwise,
the behavior is as it was previously, except no verbatim import
is done on failure.