### PR TITLE
Let calloc() do the multiplication

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_fru.c
+++ b/usr/src/lib/libzfs/common/libzfs_fru.c
@@ -282,7 +282,7 @@ libzfs_fru_refresh(libzfs_handle_t *hdl)
 
 	if (hdl->libzfs_fru_hash == NULL &&
 	    (hdl->libzfs_fru_hash =
-	    calloc(ZFS_FRU_HASH_SIZE * sizeof (void *), 1)) == NULL)
+	    calloc(ZFS_FRU_HASH_SIZE, sizeof (void *))) == NULL)
 		return;
 
 	/*


### PR DESCRIPTION
On FreeBSD, and I think illumos as well, calloc() will also check for index overflows.