### PR TITLE
8018 Xen HVM VM with 32 VCPUs hangs on boot

### DIFF
--- a/usr/src/uts/i86pc/i86hvm/io/xpv/evtchn.c
+++ b/usr/src/uts/i86pc/i86hvm/io/xpv/evtchn.c
@@ -24,6 +24,10 @@
  * Use is subject to license terms.
  */
 
+/*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
 #include <sys/types.h>
 #include <sys/xpv_support.h>
 #include <sys/hypervisor.h>
@@ -268,7 +272,7 @@ again:
 		while (pending_word != 0) {
 			j = lowbit(pending_word) - 1;
 			port = (i << EVTCHN_SHIFT) + j;
-			pending_word = pending_word & ~(1 << j);
+			pending_word = pending_word & ~(1UL << j);
 
 			/*
 			 * If there is a handler registered for this event,


### PR DESCRIPTION
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>

The `pending_word` code is a bitmap which has a bit set for each event
channel that has pending data. The code processes one bit at a time, and
turns off bits as they are processed. The problem is on this line:

    pending_word = pending_word & ~(1 << j);

The integer constant `1` defaults to an `int` type so if `j > 31`, the
result of `1 << j` will be `0`. This means that we never turn off the
higher order bits and get stuck in an infinite loop. The fix is to
simply declare the integer constant as an `unsigned long`. I scanned
through the rest of the Xen code for any other bit shifts to see if
there might be other instances of this bug but did not find any. I was
a bit curious why this bug didn't show up when we used VMs with smaller
VCPU counts. With `kmdb` I was able to verify that the event channel
identifiers used for smaller VCPU configurations did not exceed 32:

    # (rdi is the event channel identifier)
    %rdi = 0x0000000000000019
    %rdi = 0x000000000000001b
    %rdi = 0x000000000000001c
    %rdi = 0x000000000000001d
    %rdi = 0x000000000000001e

Once we enabled 32 VCPUS we saw larger event channel identifiers:

    %rdi = 0x0000000000000021
    %rdi = 0x0000000000000023
    %rdi = 0x0000000000000024
    %rdi = 0x0000000000000025
    %rdi = 0x0000000000000026

Upstream bugs: 34224