### PR TITLE
8019 Some PV devices should not be configured in HVM mode

### DIFF
--- a/usr/src/uts/common/xen/os/xvdi.c
+++ b/usr/src/uts/common/xen/os/xvdi.c
@@ -25,6 +25,10 @@
  */
 
 /*
+ * Copyright (c) 2014 by Delphix. All rights reserved.
+ */
+
+/*
  * Xen virtual device driver interfaces
  */
 
@@ -146,8 +150,10 @@ typedef struct xd_cfg {
 #define	XD_DOM_ALL	(XD_DOM_ZERO | XD_DOM_GUEST)
 
 static i_xd_cfg_t xdci[] = {
+#ifndef XPV_HVM_DRIVER
 	{ XEN_CONSOLE, NULL, NULL, NULL, "xencons", NULL,
 	    "console", IPL_CONS, XD_DOM_ALL, },
+#endif
 
 	{ XEN_VNET, "vif", "device/vif", "backend/vif", "xnf", "xnb",
 	    "network", IPL_VIF, XD_DOM_ALL, },
@@ -158,6 +164,7 @@ static i_xd_cfg_t xdci[] = {
 	{ XEN_BLKTAP, "tap", NULL, "backend/tap", NULL, "xpvtap",
 	    "block", IPL_VBD, XD_DOM_ALL, },
 
+#ifndef XPV_HVM_DRIVER
 	{ XEN_XENBUS, NULL, NULL, NULL, "xenbus", NULL,
 	    NULL, 0, XD_DOM_ALL, },
 
@@ -166,6 +173,7 @@ static i_xd_cfg_t xdci[] = {
 
 	{ XEN_BALLOON, NULL, NULL, NULL, "balloon", NULL,
 	    NULL, 0, XD_DOM_ALL, },
+#endif
 
 	{ XEN_EVTCHN, NULL, NULL, NULL, "evtchn", NULL,
 	    NULL, 0, XD_DOM_ZERO, },


### PR DESCRIPTION
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Basil Crow <basil.crow@delphix.com>

When booting a Xen VM in HVM mode, we can see the `/var/adm/messages`
file is being spammed with the following messages:

    May 16 07:01:06 delphix genunix: [ID 408114 kern.info] /xpvd/xencons@0 (xencons0) offline
    May 16 07:01:06 delphix genunix: [ID 408114 kern.info] /xpvd/xenbus@0 (xenbus0) offline
    May 16 07:01:06 delphix genunix: [ID 408114 kern.info] /xpvd/domcaps@0 (domcaps0) offline
    May 16 07:01:06 delphix genunix: [ID 408114 kern.info] /xpvd/balloon@0 (balloon0) offline

This is happening because we are trying to configure Xen PV devices that
aren't available while in HVM mode. The configuration of these devices
fails, which causes us to to send a sysevent announcing that the event is
offline. This sysevent is being processed by devfsadm and causes it to
update it's device topology snapshot. Updating the device topology
causes xpvd to try and reconfigure its devices so we end up in an
infinite loop.

The devices that we are failing to configure are not available in HVM
mode and it does not make sense to try and create such devices.

Upstream bugs: 34424