### PR TITLE
8020 Fix iostat on the EC2 instances

### DIFF
--- a/usr/src/uts/common/xen/io/xdf.c
+++ b/usr/src/uts/common/xen/io/xdf.c
@@ -638,10 +638,19 @@ xdf_kstat_exit(xdf_t *vdp, buf_t *bp)
 
 	if (vdp->xdf_xdev_iostat == NULL)
 		return;
+
 	if ((vreq != NULL) && vreq->v_runq) {
 		kstat_runq_exit(KSTAT_IO_PTR(vdp->xdf_xdev_iostat));
 	} else {
 		kstat_waitq_exit(KSTAT_IO_PTR(vdp->xdf_xdev_iostat));
+	}
+
+	if (bp->b_flags & B_READ) {
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->reads++;
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->nread += bp->b_bcount;
+	} else if (bp->b_flags & B_WRITE) {
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->writes++;
+		KSTAT_IO_PTR(vdp->xdf_xdev_iostat)->nwritten += bp->b_bcount;
 	}
 }
 
@@ -3364,7 +3373,7 @@ xdf_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	    HVMPV_XDF_VERS))
 		cmn_err(CE_WARN, "xdf: couldn't write version\n");
 
-#else /* !XPV_HVM_DRIVER */
+#endif /* XPV_HVM_DRIVER */
 
 	/* create kstat for iostat(1M) */
 	if (xdf_kstat_create(dip, "xdf", instance) != 0) {
@@ -3373,7 +3382,6 @@ xdf_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		goto errout1;
 	}
 
-#endif /* !XPV_HVM_DRIVER */
 
 	ddi_report_dev(dip);
 	DPRINTF(DDI_DBG, ("xdf@%s: attached\n", vdp->xdf_addr));


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>

This patch addresses two problems:

  1. We don't create kstats for devices if we're using the HVM driver.
     The reason is totally unclear; removing the `#else` doesn't break
     anything, and none of the code in `xdf_kstat_create` appears to
     depend on us being in a PV environment. That logic was added back
     in 2008 by commit 06bbe1e0, so the author (if we could ask them)
     probably doesn't remember why that particular thing was written
     that way.

  2. We don't increment the appropriate statistics to track reads and
     writes anywhere in the XDF driver. I added that to `xdf_kstat_exit`,
     which is called primarily from `xdf_io_fini`, which gets called in
     interrupt context when an IO finishes.

Upstream bugs: 35310