### PR TITLE
5380 a stream created with zfs send -p -I contains properties of all …

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_sendrecv.c
+++ b/usr/src/lib/libzfs/common/libzfs_sendrecv.c
@@ -2770,7 +2770,7 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 			goto out;
 		}
 
-		if (fromsnap != NULL) {
+		if (fromsnap != NULL && recursive) {
 			nvlist_t *renamed = NULL;
 			nvpair_t *pair = NULL;
 
@@ -2797,7 +2797,7 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 				*strchr(tofs, '@') = '\0';
 			}
 
-			if (recursive && !flags->dryrun && !flags->nomount) {
+			if (!flags->dryrun && !flags->nomount) {
 				VERIFY(0 == nvlist_alloc(&renamed,
 				    NV_UNIQUE_NAME, 0));
 			}
@@ -2866,7 +2866,7 @@ zfs_receive_package(libzfs_handle_t *hdl, int fd, const char *destname,
 		anyerr |= error;
 	} while (error == 0);
 
-	if (drr->drr_payloadlen != 0 && fromsnap != NULL) {
+	if (drr->drr_payloadlen != 0 && recursive && fromsnap != NULL) {
 		/*
 		 * Now that we have the fs's they sent us, try the
 		 * renames again.


### PR DESCRIPTION
…snapshots of a given dataset

recv_incremental_replication() takes care of things like removing
datasets that have been removed on the sending side, detecting
renamed datasets, ensuring that all datasets in the affected
hierarchy have the same properties as their counterparts on the
sending side.
All of the above are not necessary if we are receiving a stream
for a single dataset that has been generated with zfs send -p,
that is, a stream that includes properties.
zfs_receive_one() already takes care of applying the properties
to the received datasets.