### PR TITLE
8060 E_FUNC_SET_NOT_USED is not needed in zfs_ioc_send_space

### DIFF
--- a/usr/src/uts/common/fs/zfs/zfs_ioctl.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ioctl.c
@@ -5482,9 +5482,7 @@ zfs_ioc_send_space(const char *snapname, nvlist_t *innvl, nvlist_t *outnvl)
 	dsl_dataset_t *tosnap;
 	int error;
 	char *fromname;
-	/* LINTED E_FUNC_SET_NOT_USED */
 	boolean_t largeblockok;
-	/* LINTED E_FUNC_SET_NOT_USED */
 	boolean_t embedok;
 	boolean_t compressok;
 	uint64_t space;


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>

Upstream bugs: DLPX-49073