### PR TITLE
8062 memory leak in smb_unicode_init()

### DIFF
--- a/usr/src/common/smbsrv/smb_string.c
+++ b/usr/src/common/smbsrv/smb_string.c
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2014 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #if defined(_KERNEL) || defined(_FAKE_KERNEL)
@@ -49,6 +50,8 @@
  */
 static const smb_codepage_t *current_codepage = usascii_codepage;
 static boolean_t is_unicode = B_FALSE;
+
+static smb_codepage_t *unicode_codepage = NULL;
 
 static smb_codepage_t *smb_unicode_init(void);
 
@@ -115,17 +118,28 @@ strcanon(char *buf, const char *class)
 void
 smb_codepage_init(void)
 {
-	const smb_codepage_t *cp;
+	smb_codepage_t *cp;
 
 	if (is_unicode)
 		return;
 
 	if ((cp = smb_unicode_init()) != NULL) {
 		current_codepage = cp;
+		unicode_codepage = cp;
 		is_unicode = B_TRUE;
 	} else {
 		current_codepage = usascii_codepage;
 		is_unicode = B_FALSE;
+	}
+}
+
+void
+smb_codepage_fini(void)
+{
+	if (unicode_codepage != NULL) {
+		MEM_FREE("unicode", unicode_codepage);
+		unicode_codepage = NULL;
+		current_codepage = NULL;
 	}
 }
 

--- a/usr/src/uts/common/fs/smbsrv/smb_server.c
+++ b/usr/src/uts/common/fs/smbsrv/smb_server.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -362,6 +363,7 @@ smb_server_g_fini(void)
 
 	smb_node_fini();
 	smb_mbc_fini();
+	smb_codepage_fini();
 	smb_kshare_g_fini();
 
 	smb_fem_fini();

--- a/usr/src/uts/common/smbsrv/string.h
+++ b/usr/src/uts/common/smbsrv/string.h
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #ifndef	_SMBSRV_STRING_H
@@ -113,6 +114,7 @@ typedef struct smb_codepage {
 } smb_codepage_t;
 
 void smb_codepage_init(void);
+void smb_codepage_fini(void);
 
 int smb_isupper(int);
 int smb_islower(int);


### PR DESCRIPTION
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Brad Lewis <brad.lewis@delphix.com>

There's a memory leak in `smbsrv`:

    kmem_oversize leak: 80 vmem_segs, 393256 bytes each, 31460480 bytes total
                ADDR TYPE            START              END             SIZE
                                    THREAD        TIMESTAMP
    ffffff034ae874d8 ALLC ffffff0448219000 ffffff0448279028           393256
                          ffffff000c462c40       7a51c1bd4a
                     vmem_hash_insert+0xae
                     vmem_seg_alloc+0x23e
                     vmem_xalloc+0x749
                     vmem_alloc+0x145
                     kmem_alloc+0x11a
                     kmem_zalloc+0xed
                     smbsrv`smb_alloc+0x35
                     smb_mem_zalloc+0x1b
                     smb_unicode_init+0xe
                     smb_codepage_init+0x15
                     smb_server_g_init+0x42
                     _init+0xd
                     modinstall+0x113
                     mod_hold_installed_mod+0x77
                     modrload+0xdd
                     modload+0x17
                     mod_hold_dev_by_major+0xbf
                     ndi_hold_driver+0x30
                     probe_node+0x52
                     i_ndi_config_node+0x110

The problem is that there's `smb_codepage_init()` but not `smb_codepage_fini()`,
so a `smb_codepage_t *` table is created in `smb_unicode_init()`, but never
destroyed.

Upstream bugs: DLPX-49475