### PR TITLE
8063 verify that we do not attempt to access inactive txg

### DIFF
--- a/usr/src/uts/common/avs/ns/sdbc/sd_bio.c
+++ b/usr/src/uts/common/avs/ns/sdbc/sd_bio.c
@@ -22,6 +22,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -180,9 +183,9 @@ _sdbc_iobuf_load(void)
 void
 _sdbc_iobuf_unload(void)
 {
-	/* Undo our VN_HOLD hack, by putting ref count back to normal state */
 	mutex_enter(&kvp.v_lock);
-	kvp.v_count = 0;
+	ASSERT(kvp.v_count == 1);
+	VN_RELE_LOCKED(&kvp);
 	mutex_exit(&kvp.v_lock);
 
 	mutex_destroy(&sdbc_bio_mutex);
@@ -706,7 +709,7 @@ _sd_pack_pages(struct buf *bp, struct buf *list, sd_addr_t *addr,
  */
 static void
 _sd_pack_pages_nopageio(struct buf *bp, struct buf *list, sd_addr_t *addr,
-	nsc_off_t offset, nsc_size_t size)
+    nsc_off_t offset, nsc_size_t size)
 {
 	uintptr_t start_addr;
 #ifdef _SD_BIO_STATS
@@ -924,7 +927,7 @@ sd_add_mem(struct buf *bp, char *buf, nsc_size_t len)
  */
 int
 sd_start_io(struct buf *bp, strategy_fn_t strategy, sdbc_ea_fn_t fn,
-		blind_t arg)
+    blind_t arg)
 {
 	int err;
 	iob_hook_t *hook = (iob_hook_t *)bp->b_private;

--- a/usr/src/uts/common/fs/autofs/auto_vfsops.c
+++ b/usr/src/uts/common/fs/autofs/auto_vfsops.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Bayard G. Bell. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -196,8 +197,10 @@ autofs_zone_destructor(zoneid_t zoneid, void *arg)
 	 * make this 0 to placate auto_freefnnode().
 	 */
 	vp = fntovn(fngp->fng_rootfnnodep);
+	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count == 1);
-	vp->v_count--;
+	VN_RELE_LOCKED(vp);
+	mutex_exit(&vp->v_lock);
 	auto_freefnnode(fngp->fng_rootfnnodep);
 	mutex_destroy(&fngp->fng_unmount_threads_lock);
 	kmem_free(fngp, sizeof (*fngp));

--- a/usr/src/uts/common/fs/autofs/auto_vnops.c
+++ b/usr/src/uts/common/fs/autofs/auto_vnops.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -1316,7 +1317,8 @@ auto_inactive(vnode_t *vp, cred_t *cred, caller_context_t *ct)
 	rw_enter(&dfnp->fn_rwlock, RW_WRITER);
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count > 0);
-	count = --vp->v_count;
+	VN_RELE_LOCKED(vp);
+	count = vp->v_count;
 	mutex_exit(&vp->v_lock);
 	if (count == 0) {
 		/*

--- a/usr/src/uts/common/fs/dcfs/dc_vnops.c
+++ b/usr/src/uts/common/fs/dcfs/dc_vnops.c
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -261,7 +262,7 @@ dc_close(struct vnode *vp, int flag, int count, offset_t off,
 /*ARGSUSED*/
 static int
 dc_read(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *cr,
-	struct caller_context *ct)
+    struct caller_context *ct)
 {
 	struct dcnode *dp = VTODC(vp);
 	size_t rdsize = MAX(MAXBSIZE, dp->dc_hdr->ch_blksize);
@@ -355,7 +356,8 @@ dc_inactive(struct vnode *vp, cred_t *cr, caller_context_t *ctp)
 	mutex_enter(&dctable_lock);
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		/*
 		 * Somebody accessed the dcnode before we got a chance to
 		 * remove it.  They will remove it when they do a vn_rele.

--- a/usr/src/uts/common/fs/dev/sdev_subr.c
+++ b/usr/src/uts/common/fs/dev/sdev_subr.c
@@ -21,6 +21,7 @@
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2016 Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -2810,8 +2811,8 @@ checkforroot:
 }
 
 int
-sdev_modctl_readdir(const char *dir, char ***dirlistp,
-	int *npathsp, int *npathsp_alloc, int checking_empty)
+sdev_modctl_readdir(const char *dir, char ***dirlistp, int *npathsp,
+    int *npathsp_alloc, int checking_empty)
 {
 	char	**pathlist = NULL;
 	char	**newlist = NULL;
@@ -3132,12 +3133,12 @@ devname_inactive_func(struct vnode *vp, struct cred *cred,
 		}
 		VERIFY(dv->sdev_nlink == 1);
 		decr_link(dv);
-		--vp->v_count;
+		VN_RELE_LOCKED(vp);
 		rw_exit(&dv->sdev_contents);
 		mutex_exit(&vp->v_lock);
 		sdev_nodedestroy(dv, 0);
 	} else {
-		--vp->v_count;
+		VN_RELE_LOCKED(vp);
 		rw_exit(&dv->sdev_contents);
 		mutex_exit(&vp->v_lock);
 	}

--- a/usr/src/uts/common/fs/devfs/devfs_vnops.c
+++ b/usr/src/uts/common/fs/devfs/devfs_vnops.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -105,7 +106,7 @@ devfs_close(struct vnode *vp, int flag, int count,
 /*ARGSUSED*/
 static int
 devfs_read(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *cred,
-	struct caller_context *ct)
+    struct caller_context *ct)
 {
 	dcmn_err2(("devfs_read %s\n", VTODV(vp)->dv_name));
 	ASSERT(vp->v_type == VDIR);
@@ -120,7 +121,7 @@ devfs_read(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *cred,
 /*ARGSUSED*/
 static int
 devfs_write(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *cred,
-	struct caller_context *ct)
+    struct caller_context *ct)
 {
 	dcmn_err2(("devfs_write %s\n", VTODV(vp)->dv_name));
 	ASSERT(vp->v_type == VDIR);
@@ -1053,7 +1054,7 @@ devfs_inactive(struct vnode *vp, struct cred *cred, caller_context_t *ct)
 	dcmn_err2(("devfs_inactive: %s\n", dv->dv_name));
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
-	--vp->v_count;
+	VN_RELE_LOCKED(vp);
 	destroy = (DV_STALE(dv) && vp->v_count == 0);
 	mutex_exit(&vp->v_lock);
 

--- a/usr/src/uts/common/fs/dnlc.c
+++ b/usr/src/uts/common/fs/dnlc.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -76,8 +77,9 @@
 #define	VN_HOLD_CALLER	VN_HOLD
 #define	VN_HOLD_DNLC(vp)	{	\
 	mutex_enter(&(vp)->v_lock);	\
-	if ((vp)->v_count_dnlc == 0)	\
-		(vp)->v_count++;	\
+	if ((vp)->v_count_dnlc == 0) {	\
+		VN_HOLD_LOCKED(vp);	\
+	}				\
 	(vp)->v_count_dnlc++;		\
 	mutex_exit(&(vp)->v_lock);	\
 }
@@ -404,11 +406,16 @@ dnlc_init()
 	dc_head.dch_prev = (dircache_t *)&dc_head;
 
 	/*
-	 * Initialise the reference count of the negative cache vnode to 1
-	 * so that it never goes away (VOP_INACTIVE isn't called on it).
+	 * Put a hold on the negative cache vnode so that it never goes away
+	 * (VOP_INACTIVE isn't called on it). The mutex_enter() isn't necessary
+	 * for correctness, but VN_HOLD_LOCKED() asserts that it's held, so
+	 * we oblige.
 	 */
-	negative_cache_vnode.v_count = 1;
+	mutex_enter(&negative_cache_vnode.v_lock);
+	negative_cache_vnode.v_count = 0;
+	VN_HOLD_LOCKED(&negative_cache_vnode);
 	negative_cache_vnode.v_count_dnlc = 0;
+	mutex_exit(&negative_cache_vnode.v_lock);
 
 	/*
 	 * Initialise kstats - both the old compatability raw kind and

--- a/usr/src/uts/common/fs/fd/fdops.c
+++ b/usr/src/uts/common/fs/fd/fdops.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -92,7 +93,7 @@ fdopen(vnode_t **vpp, int mode, cred_t *cr, caller_context_t *ct)
 /* ARGSUSED */
 static int
 fdclose(vnode_t *vp, int flag, int count, offset_t offset, cred_t *cr,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	return (0);
 }
@@ -162,7 +163,7 @@ fdread(vnode_t *vp, uio_t *uiop, int ioflag, cred_t *cr, caller_context_t *ct)
 /* ARGSUSED */
 static int
 fdgetattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *cr,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	vfs_t *vfsp = vp->v_vfsp;
 	timestruc_t now;
@@ -201,9 +202,9 @@ fdaccess(vnode_t *vp, int mode, int flags, cred_t *cr, caller_context_t *ct)
 
 /* ARGSUSED */
 static int
-fdlookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pnp,
-	int flags, vnode_t *rdir, cred_t *cr, caller_context_t *ct,
-	int *direntflags, pathname_t *realpnp)
+fdlookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pnp, int flags,
+    vnode_t *rdir, cred_t *cr, caller_context_t *ct, int *direntflags,
+    pathname_t *realpnp)
 {
 	if (comp[0] == 0 || strcmp(comp, ".") == 0 || strcmp(comp, "..") == 0) {
 		VN_HOLD(dp);
@@ -215,9 +216,9 @@ fdlookup(vnode_t *dp, char *comp, vnode_t **vpp, pathname_t *pnp,
 
 /* ARGSUSED */
 static int
-fdcreate(vnode_t *dvp, char *comp, vattr_t *vap, enum vcexcl excl,
-	int mode, vnode_t **vpp, cred_t *cr, int flag, caller_context_t *ct,
-	vsecattr_t *vsecp)
+fdcreate(vnode_t *dvp, char *comp, vattr_t *vap, enum vcexcl excl, int mode,
+    vnode_t **vpp, cred_t *cr, int flag, caller_context_t *ct,
+    vsecattr_t *vsecp)
 {
 	return (fdget(dvp, comp, vpp));
 }
@@ -225,7 +226,7 @@ fdcreate(vnode_t *dvp, char *comp, vattr_t *vap, enum vcexcl excl,
 /* ARGSUSED */
 static int
 fdreaddir(vnode_t *vp, uio_t *uiop, cred_t *cr, int *eofp, caller_context_t *ct,
-	int flags)
+    int flags)
 {
 	/* bp holds one dirent structure */
 	u_offset_t bp[DIRENT64_RECLEN(FDNSIZE) / sizeof (u_offset_t)];
@@ -306,7 +307,8 @@ fdinactive(vnode_t *vp, cred_t *cr, caller_context_t *ct)
 {
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		mutex_exit(&vp->v_lock);
 		return;
 	}

--- a/usr/src/uts/common/fs/fifofs/fifovnops.c
+++ b/usr/src/uts/common/fs/fifofs/fifovnops.c
@@ -29,6 +29,7 @@
 
 /*
  * Copyright 2015, Joyent, Inc.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -435,7 +436,7 @@ done:
 /*ARGSUSED*/
 int
 fifo_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	fifonode_t	*fnp		= VTOF(vp);
 	fifonode_t	*fn_dest	= fnp->fn_dest;
@@ -656,7 +657,7 @@ fifo_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *crp,
 
 static int
 fifo_read(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	fifonode_t	*fnp		= VTOF(vp);
 	fifonode_t	*fn_dest;
@@ -842,7 +843,7 @@ done:
 /*ARGSUSED*/
 static int
 fifo_write(vnode_t *vp, uio_t *uiop, int ioflag, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	struct fifonode	*fnp, *fn_dest;
 	fifolock_t	*fn_lock;
@@ -1112,8 +1113,8 @@ epipe:
 
 /*ARGSUSED6*/
 static int
-fifo_ioctl(vnode_t *vp, int cmd, intptr_t arg, int mode,
-	cred_t *cr, int *rvalp, caller_context_t *ct)
+fifo_ioctl(vnode_t *vp, int cmd, intptr_t arg, int mode, cred_t *cr,
+    int *rvalp, caller_context_t *ct)
 {
 	/*
 	 * Just a quick check
@@ -1127,8 +1128,8 @@ fifo_ioctl(vnode_t *vp, int cmd, intptr_t arg, int mode,
 }
 
 static int
-fifo_fastioctl(vnode_t *vp, int cmd, intptr_t arg, int mode,
-	cred_t *cr, int *rvalp)
+fifo_fastioctl(vnode_t *vp, int cmd, intptr_t arg, int mode, cred_t *cr,
+    int *rvalp)
 {
 	fifonode_t	*fnp		= VTOF(vp);
 	fifonode_t	*fn_dest;
@@ -1385,8 +1386,8 @@ stream_mode:
  * FIFO is in STREAMS mode; STREAMS framework does most of the work.
  */
 static int
-fifo_strioctl(vnode_t *vp, int cmd, intptr_t arg, int mode,
-	cred_t *cr, int *rvalp)
+fifo_strioctl(vnode_t *vp, int cmd, intptr_t arg, int mode, cred_t *cr,
+    int *rvalp)
 {
 	fifonode_t	*fnp = VTOF(vp);
 	int		error;
@@ -1441,7 +1442,7 @@ fifo_strioctl(vnode_t *vp, int cmd, intptr_t arg, int mode,
  */
 int
 fifo_getattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	int		error		= 0;
 	fifonode_t	*fnp		= VTOF(vp);
@@ -1517,12 +1518,8 @@ fifo_getattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *crp,
  * Otherwise, set the time and return 0.
  */
 int
-fifo_setattr(
-	vnode_t			*vp,
-	vattr_t			*vap,
-	int			flags,
-	cred_t			*crp,
-	caller_context_t	*ctp)
+fifo_setattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *crp,
+    caller_context_t *ctp)
 {
 	fifonode_t	*fnp	= VTOF(vp);
 	int		error	= 0;
@@ -1622,7 +1619,8 @@ fifo_inactive(vnode_t *vp, cred_t *crp, caller_context_t *ct)
 	mutex_enter(&ftable_lock);
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		/*
 		 * Somebody accessed the fifo before we got a chance to
 		 * remove it.  They will remove it when they do a vn_rele.
@@ -1760,7 +1758,7 @@ fifo_realvp(vnode_t *vp, vnode_t **vpp, caller_context_t *ct)
 /* ARGSUSED */
 int
 fifo_poll(vnode_t *vp, short events, int anyyet, short *reventsp,
-	pollhead_t **phpp, caller_context_t *ct)
+    pollhead_t **phpp, caller_context_t *ct)
 {
 	fifonode_t	*fnp, *fn_dest;
 	fifolock_t	*fn_lock;
@@ -1873,7 +1871,7 @@ stream_mode:
 /* ARGSUSED */
 int
 fifo_pathconf(vnode_t *vp, int cmd, ulong_t *valp, cred_t *cr,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	ulong_t val;
 	int error = 0;
@@ -1947,7 +1945,7 @@ fifo_pathconf(vnode_t *vp, int cmd, ulong_t *valp, cred_t *cr,
  */
 int
 fifo_setsecattr(struct vnode *vp, vsecattr_t *vsap, int flag, struct cred *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	int error;
 
@@ -1972,7 +1970,7 @@ fifo_setsecattr(struct vnode *vp, vsecattr_t *vsap, int flag, struct cred *crp,
  */
 int
 fifo_getsecattr(struct vnode *vp, vsecattr_t *vsap, int flag, struct cred *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	if (VTOF(vp)->fn_realvp)
 		return (VOP_GETSECATTR(VTOF(vp)->fn_realvp, vsap, flag,

--- a/usr/src/uts/common/fs/gfs.c
+++ b/usr/src/uts/common/fs/gfs.c
@@ -23,8 +23,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-
-#pragma ident	"%Z%%M%	%I%	%E% SMI"
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/types.h>
 #include <sys/cmn_err.h>
@@ -671,7 +672,7 @@ found:
 		}
 		vn_free(vp);
 	} else {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		data = NULL;
 		mutex_exit(&vp->v_lock);
 		if (vp->v_flag & V_XATTRDIR) {

--- a/usr/src/uts/common/fs/hsfs/hsfs_vnops.c
+++ b/usr/src/uts/common/fs/hsfs/hsfs_vnops.c
@@ -23,6 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -157,10 +158,7 @@ int hsched_invoke_strategy(struct hsfs *fsp);
 
 /* ARGSUSED */
 static int
-hsfs_fsync(vnode_t *cp,
-	int syncflag,
-	cred_t *cred,
-	caller_context_t *ct)
+hsfs_fsync(vnode_t *cp, int syncflag, cred_t *cred, caller_context_t *ct)
 {
 	return (0);
 }
@@ -168,11 +166,8 @@ hsfs_fsync(vnode_t *cp,
 
 /*ARGSUSED*/
 static int
-hsfs_read(struct vnode *vp,
-	struct uio *uiop,
-	int ioflag,
-	struct cred *cred,
-	struct caller_context *ct)
+hsfs_read(struct vnode *vp, struct uio *uiop, int ioflag, struct cred *cred,
+    struct caller_context *ct)
 {
 	caddr_t base;
 	offset_t diff;
@@ -301,12 +296,8 @@ hsfs_read(struct vnode *vp,
 
 /*ARGSUSED2*/
 static int
-hsfs_getattr(
-	struct vnode *vp,
-	struct vattr *vap,
-	int flags,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_getattr(struct vnode *vp, struct vattr *vap, int flags, struct cred *cred,
+    caller_context_t *ct)
 {
 	struct hsnode *hp;
 	struct vfs *vfsp;
@@ -349,10 +340,8 @@ hsfs_getattr(
 
 /*ARGSUSED*/
 static int
-hsfs_readlink(struct vnode *vp,
-	struct uio *uiop,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_readlink(struct vnode *vp, struct uio *uiop, struct cred *cred,
+    caller_context_t *ct)
 {
 	struct hsnode *hp;
 
@@ -371,9 +360,7 @@ hsfs_readlink(struct vnode *vp,
 
 /*ARGSUSED*/
 static void
-hsfs_inactive(struct vnode *vp,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_inactive(struct vnode *vp, struct cred *cred, caller_context_t *ct)
 {
 	struct hsnode *hp;
 	struct hsfs *fsp;
@@ -397,14 +384,13 @@ hsfs_inactive(struct vnode *vp,
 		/*NOTREACHED*/
 	}
 
-	if (vp->v_count > 1 || (hp->hs_flags & HREF) == 0) {
-		vp->v_count--;	/* release hold from vn_rele */
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count > 0 || (hp->hs_flags & HREF) == 0) {
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&hp->hs_contents_lock);
 		rw_exit(&fsp->hsfs_hash_lock);
 		return;
 	}
-	vp->v_count--;	/* release hold from vn_rele */
 	if (vp->v_count == 0) {
 		/*
 		 * Free the hsnode.
@@ -432,17 +418,9 @@ hsfs_inactive(struct vnode *vp,
 
 /*ARGSUSED*/
 static int
-hsfs_lookup(
-	struct vnode *dvp,
-	char *nm,
-	struct vnode **vpp,
-	struct pathname *pnp,
-	int flags,
-	struct vnode *rdir,
-	struct cred *cred,
-	caller_context_t *ct,
-	int *direntflags,
-	pathname_t *realpnp)
+hsfs_lookup(struct vnode *dvp, char *nm, struct vnode **vpp,
+    struct pathname *pnp, int flags, struct vnode *rdir, struct cred *cred,
+    caller_context_t *ct, int *direntflags, pathname_t *realpnp)
 {
 	int error;
 	int namelen = (int)strlen(nm);
@@ -470,13 +448,8 @@ hsfs_lookup(
 
 /*ARGSUSED*/
 static int
-hsfs_readdir(
-	struct vnode		*vp,
-	struct uio		*uiop,
-	struct cred		*cred,
-	int			*eofp,
-	caller_context_t	*ct,
-	int			flags)
+hsfs_readdir(struct vnode *vp, struct uio *uiop, struct cred *cred, int *eofp,
+    caller_context_t *ct, int flags)
 {
 	struct hsnode	*dhp;
 	struct hsfs	*fsp;
@@ -676,23 +649,15 @@ hsfs_fid(struct vnode *vp, struct fid *fidp, caller_context_t *ct)
 
 /*ARGSUSED*/
 static int
-hsfs_open(struct vnode **vpp,
-	int flag,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_open(struct vnode **vpp, int flag, struct cred *cred, caller_context_t *ct)
 {
 	return (0);
 }
 
 /*ARGSUSED*/
 static int
-hsfs_close(
-	struct vnode *vp,
-	int flag,
-	int count,
-	offset_t offset,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_close(struct vnode *vp, int flag, int count, offset_t offset,
+    struct cred *cred, caller_context_t *ct)
 {
 	(void) cleanlocks(vp, ttoproc(curthread)->p_pid, 0);
 	cleanshares(vp, ttoproc(curthread)->p_pid);
@@ -701,11 +666,8 @@ hsfs_close(
 
 /*ARGSUSED2*/
 static int
-hsfs_access(struct vnode *vp,
-	int mode,
-	int flags,
-	cred_t *cred,
-	caller_context_t *ct)
+hsfs_access(struct vnode *vp, int mode, int flags, cred_t *cred,
+    caller_context_t *ct)
 {
 	return (hs_access(vp, (mode_t)mode, cred));
 }
@@ -794,17 +756,9 @@ hsfs_ra_task(void *arg)
  */
 /*ARGSUSED*/
 static int
-hsfs_getpage_ra(
-	struct vnode *vp,
-	u_offset_t off,
-	struct seg *seg,
-	caddr_t addr,
-	struct hsnode *hp,
-	struct hsfs *fsp,
-	int	xarsiz,
-	offset_t	bof,
-	int	chunk_lbn_count,
-	int	chunk_data_bytes)
+hsfs_getpage_ra(struct vnode *vp, u_offset_t off, struct seg *seg,
+    caddr_t addr, struct hsnode *hp, struct hsfs *fsp, int xarsiz,
+    offset_t bof, int chunk_lbn_count, int chunk_data_bytes)
 {
 	struct buf *bufs;
 	caddr_t *vas;
@@ -1082,17 +1036,9 @@ hsfs_getpage_ra(
  */
 /*ARGSUSED*/
 static int
-hsfs_getapage(
-	struct vnode *vp,
-	u_offset_t off,
-	size_t len,
-	uint_t *protp,
-	struct page *pl[],
-	size_t plsz,
-	struct seg *seg,
-	caddr_t addr,
-	enum seg_rw rw,
-	struct cred *cred)
+hsfs_getapage(struct vnode *vp, u_offset_t off, size_t len, uint_t *protp,
+    struct page *pl[], size_t plsz, struct seg *seg, caddr_t addr,
+    enum seg_rw rw, struct cred *cred)
 {
 	struct hsnode *hp;
 	struct hsfs *fsp;
@@ -1563,18 +1509,9 @@ again:
 
 /*ARGSUSED*/
 static int
-hsfs_getpage(
-	struct vnode *vp,
-	offset_t off,
-	size_t len,
-	uint_t *protp,
-	struct page *pl[],
-	size_t plsz,
-	struct seg *seg,
-	caddr_t addr,
-	enum seg_rw rw,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_getpage(struct vnode *vp, offset_t off, size_t len, uint_t *protp,
+    struct page *pl[], size_t plsz, struct seg *seg, caddr_t addr,
+    enum seg_rw rw, struct cred *cred, caller_context_t *ct)
 {
 	uint_t filsiz;
 	struct hsfs *fsp;
@@ -1665,13 +1602,8 @@ hsfs_getpage(
  */
 /*ARGSUSED*/
 int
-hsfs_putapage(
-	vnode_t		*vp,
-	page_t		*pp,
-	u_offset_t	*offp,
-	size_t		*lenp,
-	int		flags,
-	cred_t		*cr)
+hsfs_putapage(vnode_t *vp, page_t *pp, u_offset_t *offp, size_t *lenp,
+    int flags, cred_t *cr)
 {
 	/* should never happen - just destroy it */
 	cmn_err(CE_NOTE, "hsfs_putapage: dirty HSFS page");
@@ -1694,13 +1626,8 @@ hsfs_putapage(
  */
 /*ARGSUSED*/
 static int
-hsfs_putpage(
-	struct vnode		*vp,
-	offset_t		off,
-	size_t			len,
-	int			flags,
-	struct cred		*cr,
-	caller_context_t	*ct)
+hsfs_putpage(struct vnode *vp, offset_t off, size_t len, int flags,
+    struct cred *cr, caller_context_t *ct)
 {
 	int error = 0;
 
@@ -1771,17 +1698,9 @@ hsfs_putpage(
 
 /*ARGSUSED*/
 static int
-hsfs_map(
-	struct vnode *vp,
-	offset_t off,
-	struct as *as,
-	caddr_t *addrp,
-	size_t len,
-	uchar_t prot,
-	uchar_t maxprot,
-	uint_t flags,
-	struct cred *cred,
-	caller_context_t *ct)
+hsfs_map(struct vnode *vp, offset_t off, struct as *as, caddr_t *addrp,
+    size_t len, uchar_t prot, uchar_t maxprot, uint_t flags, struct cred *cred,
+    caller_context_t *ct)
 {
 	struct segvn_crargs vn_a;
 	int error;
@@ -1833,17 +1752,9 @@ hsfs_map(
 
 /* ARGSUSED */
 static int
-hsfs_addmap(
-	struct vnode *vp,
-	offset_t off,
-	struct as *as,
-	caddr_t addr,
-	size_t len,
-	uchar_t prot,
-	uchar_t maxprot,
-	uint_t flags,
-	struct cred *cr,
-	caller_context_t *ct)
+hsfs_addmap(struct vnode *vp, offset_t off, struct as *as, caddr_t addr,
+    size_t len, uchar_t prot, uchar_t maxprot, uint_t flags, struct cred *cr,
+    caller_context_t *ct)
 {
 	struct hsnode *hp;
 
@@ -1859,17 +1770,9 @@ hsfs_addmap(
 
 /*ARGSUSED*/
 static int
-hsfs_delmap(
-	struct vnode *vp,
-	offset_t off,
-	struct as *as,
-	caddr_t addr,
-	size_t len,
-	uint_t prot,
-	uint_t maxprot,
-	uint_t flags,
-	struct cred *cr,
-	caller_context_t *ct)
+hsfs_delmap(struct vnode *vp, offset_t off, struct as *as, caddr_t addr,
+    size_t len, uint_t prot, uint_t maxprot, uint_t flags, struct cred *cr,
+    caller_context_t *ct)
 {
 	struct hsnode *hp;
 
@@ -1886,26 +1789,17 @@ hsfs_delmap(
 
 /* ARGSUSED */
 static int
-hsfs_seek(
-	struct vnode *vp,
-	offset_t ooff,
-	offset_t *noffp,
-	caller_context_t *ct)
+hsfs_seek(struct vnode *vp, offset_t ooff, offset_t *noffp,
+    caller_context_t *ct)
 {
 	return ((*noffp < 0 || *noffp > MAXOFFSET_T) ? EINVAL : 0);
 }
 
 /* ARGSUSED */
 static int
-hsfs_frlock(
-	struct vnode *vp,
-	int cmd,
-	struct flock64 *bfp,
-	int flag,
-	offset_t offset,
-	struct flk_callback *flk_cbp,
-	cred_t *cr,
-	caller_context_t *ct)
+hsfs_frlock(struct vnode *vp, int cmd, struct flock64 *bfp, int flag,
+    offset_t offset, struct flk_callback *flk_cbp, cred_t *cr,
+    caller_context_t *ct)
 {
 	struct hsnode *hp = VTOH(vp);
 
@@ -2391,11 +2285,8 @@ hsched_enqueue_io(struct hsfs *fsp, struct hio *hsio, int ra)
 
 /* ARGSUSED */
 static int
-hsfs_pathconf(struct vnode *vp,
-	int cmd,
-	ulong_t *valp,
-	struct cred *cr,
-	caller_context_t *ct)
+hsfs_pathconf(struct vnode *vp, int cmd, ulong_t *valp, struct cred *cr,
+    caller_context_t *ct)
 {
 	struct hsfs	*fsp;
 

--- a/usr/src/uts/common/fs/lofs/lofs_subr.c
+++ b/usr/src/uts/common/fs/lofs/lofs_subr.c
@@ -22,6 +22,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 /*
  * The idea behind composition-based stacked filesystems is to add a
@@ -656,7 +659,7 @@ freelonode(lnode_t *lp)
 
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count > 1) {
-		vp->v_count--;	/* release our hold from vn_rele */
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		TABLE_LOCK_EXIT(lp->lo_vp, li);
 		return;
@@ -759,10 +762,8 @@ static int lofsdebug;
 
 #ifdef LODEBUG
 /*VARARGS2*/
-lo_dprint(level, str, a1, a2, a3, a4, a5, a6, a7, a8, a9)
-	int level;
-	char *str;
-	int a1, a2, a3, a4, a5, a6, a7, a8, a9;
+lo_dprint(int level, char *str, int a1, int a2, int a3, int a4, int a5, int a6,
+    int a7, int a8, int a9)
 {
 
 	if (lofsdebug == level || (lofsdebug > 10 && (lofsdebug - 10) >= level))

--- a/usr/src/uts/common/fs/namefs/namevfs.c
+++ b/usr/src/uts/common/fs/namefs/namevfs.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -581,7 +582,8 @@ nm_unmount(vfs_t *vfsp, int flag, cred_t *crp)
 	nameremove(nodep);
 	thisvp = NMTOV(nodep);
 	mutex_enter(&thisvp->v_lock);
-	if (thisvp->v_count-- == 1) {
+	VN_RELE_LOCKED(thisvp);
+	if (thisvp->v_count == 0) {
 		fp = nodep->nm_filep;
 		mutex_exit(&thisvp->v_lock);
 		vn_invalid(thisvp);

--- a/usr/src/uts/common/fs/namefs/namevno.c
+++ b/usr/src/uts/common/fs/namefs/namevno.c
@@ -24,7 +24,7 @@
 
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -162,7 +162,7 @@ gotit:
  */
 static int
 nm_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	struct namenode *nodep = VTONM(vp);
 	int error = 0;
@@ -191,21 +191,21 @@ nm_close(vnode_t *vp, int flag, int count, offset_t offset, cred_t *crp,
 
 static int
 nm_read(vnode_t *vp, struct uio *uiop, int ioflag, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	return (VOP_READ(VTONM(vp)->nm_filevp, uiop, ioflag, crp, ct));
 }
 
 static int
 nm_write(vnode_t *vp, struct uio *uiop, int ioflag, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	return (VOP_WRITE(VTONM(vp)->nm_filevp, uiop, ioflag, crp, ct));
 }
 
 static int
 nm_ioctl(vnode_t *vp, int cmd, intptr_t arg, int mode, cred_t *cr, int *rvalp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	return (VOP_IOCTL(VTONM(vp)->nm_filevp, cmd, arg, mode, cr, rvalp, ct));
 }
@@ -217,7 +217,7 @@ nm_ioctl(vnode_t *vp, int cmd, intptr_t arg, int mode, cred_t *cr, int *rvalp,
 /* ARGSUSED */
 static int
 nm_getattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *crp,
-	caller_context_t *ct)
+    caller_context_t *ct)
 {
 	struct namenode *nodep = VTONM(vp);
 	struct vattr va;
@@ -261,12 +261,8 @@ nm_access_unlocked(void *vnp, int mode, cred_t *crp)
  */
 /* ARGSUSED */
 static int
-nm_setattr(
-	vnode_t *vp,
-	vattr_t *vap,
-	int flags,
-	cred_t *crp,
-	caller_context_t *ctp)
+nm_setattr(vnode_t *vp, vattr_t *vap, int flags, cred_t *crp,
+    caller_context_t *ctp)
 {
 	struct namenode *nodep = VTONM(vp);
 	struct vattr *nmvap = &nodep->nm_vattr;
@@ -334,8 +330,7 @@ out:
  */
 /* ARGSUSED */
 static int
-nm_access(vnode_t *vp, int mode, int flags, cred_t *crp,
-	caller_context_t *ct)
+nm_access(vnode_t *vp, int mode, int flags, cred_t *crp, caller_context_t *ct)
 {
 	struct namenode *nodep = VTONM(vp);
 	int error;
@@ -356,9 +351,9 @@ nm_access(vnode_t *vp, int mode, int flags, cred_t *crp,
  */
 /*ARGSUSED*/
 static int
-nm_create(vnode_t *dvp, char *name, vattr_t *vap, enum vcexcl excl,
-	int mode, vnode_t **vpp, cred_t *cr, int flag,
-	caller_context_t *ct, vsecattr_t *vsecp)
+nm_create(vnode_t *dvp, char *name, vattr_t *vap, enum vcexcl excl, int mode,
+    vnode_t **vpp, cred_t *cr, int flag, caller_context_t *ct,
+    vsecattr_t *vsecp)
 {
 	int error;
 
@@ -378,7 +373,7 @@ nm_create(vnode_t *dvp, char *name, vattr_t *vap, enum vcexcl excl,
 /*ARGSUSED*/
 static int
 nm_link(vnode_t *tdvp, vnode_t *vp, char *tnm, cred_t *crp,
-	caller_context_t *ct, int flags)
+    caller_context_t *ct, int flags)
 {
 	return (EXDEV);
 }
@@ -399,7 +394,8 @@ nm_inactive(vnode_t *vp, cred_t *crp, caller_context_t *ct)
 
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		mutex_exit(&vp->v_lock);
 		return;
 	}
@@ -457,7 +453,7 @@ nm_realvp(vnode_t *vp, vnode_t **vpp, caller_context_t *ct)
 
 static int
 nm_poll(vnode_t *vp, short events, int anyyet, short *reventsp,
-	pollhead_t **phpp, caller_context_t *ct)
+    pollhead_t **phpp, caller_context_t *ct)
 {
 	return (VOP_POLL(VTONM(vp)->nm_filevp, events, anyyet, reventsp,
 	    phpp, ct));

--- a/usr/src/uts/common/fs/nfs/nfs4_client.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_client.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1986, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -3198,10 +3199,15 @@ nfs4_clnt_init(void)
 	    nfs4_mi_destroy);
 
 	/*
-	 * Initialise the reference count of the notsupp xattr cache vnode to 1
-	 * so that it never goes away (VOP_INACTIVE isn't called on it).
+	 * Initialize the reference count of the notsupp xattr cache vnode to 1
+	 * so that it never goes away (VOP_INACTIVE isn't called on it). The
+	 * mutex_enter() isn't necessary for correctness, but VN_HOLD_LOCK()
+	 * asserts that it's held, so we oblige.
 	 */
-	nfs4_xattr_notsupp_vnode.v_count = 1;
+	mutex_enter(&nfs4_xattr_notsupp_vnode.v_lock);
+	nfs4_xattr_notsupp_vnode.v_count = 0;
+	VN_HOLD_LOCKED(&nfs4_xattr_notsupp_vnode);
+	mutex_exit(&nfs4_xattr_notsupp_vnode.v_lock);
 }
 
 void

--- a/usr/src/uts/common/fs/nfs/nfs4_rnode.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_rnode.c
@@ -30,6 +30,7 @@
 
 /*
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -603,7 +604,7 @@ start:
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				rw_enter(&rhtp->r_lock, RW_READER);
@@ -618,7 +619,7 @@ start:
 
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			rw_enter(&rhtp->r_lock, RW_READER);
 			goto start;
@@ -785,7 +786,7 @@ rp4_addfree(rnode4_t *rp, cred_t *cr)
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				return;
@@ -827,7 +828,7 @@ rp4_addfree(rnode4_t *rp, cred_t *cr)
 		 */
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			return;
 		}
@@ -850,7 +851,7 @@ again:
 
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		rw_exit(&rp->r_hashq->r_lock);
 		return;
@@ -1552,7 +1553,7 @@ nfs4_rnode_reclaim(void)
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				mutex_enter(&rp4freelist_lock);

--- a/usr/src/uts/common/fs/nfs/nfs4_shadow.c
+++ b/usr/src/uts/common/fs/nfs/nfs4_shadow.c
@@ -22,6 +22,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 
 #include <sys/systm.h>
@@ -303,7 +306,7 @@ sv_inactive(vnode_t *vp)
 	mutex_enter(&vp->v_lock);
 	/* check if someone slipped in while locks were dropped */
 	if (vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&rp->r_svlock);
 		return;

--- a/usr/src/uts/common/fs/nfs/nfs_subr.c
+++ b/usr/src/uts/common/fs/nfs/nfs_subr.c
@@ -25,7 +25,7 @@
 
 /*
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -2490,7 +2490,7 @@ start:
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				rw_enter(&rhtp->r_lock, RW_READER);
@@ -2505,7 +2505,7 @@ start:
 
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			rw_enter(&rhtp->r_lock, RW_READER);
 			goto start;
@@ -2698,7 +2698,7 @@ rp_addfree(rnode_t *rp, cred_t *cr)
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				return;
@@ -2731,7 +2731,7 @@ rp_addfree(rnode_t *rp, cred_t *cr)
 		 */
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			return;
 		}
@@ -2753,7 +2753,7 @@ rp_addfree(rnode_t *rp, cred_t *cr)
 
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		rw_exit(&rp->r_hashq->r_lock);
 		return;
@@ -4081,7 +4081,7 @@ nfs_rnode_reclaim(void)
 			rw_enter(&rp->r_hashq->r_lock, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&rp->r_hashq->r_lock);
 				mutex_enter(&rpfreelist_lock);

--- a/usr/src/uts/common/fs/pcfs/pc_node.c
+++ b/usr/src/uts/common/fs/pcfs/pc_node.c
@@ -22,6 +22,9 @@
  * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/param.h>
 #include <sys/t_lock.h>
@@ -259,7 +262,7 @@ retry:
 	}
 	ASSERT(!vn_has_cached_data(vp));
 
-	vp->v_count--;  /* release our hold from vn_rele */
+	VN_RELE_LOCKED(vp);
 	if (vp->v_count > 0) { /* Is this check still needed? */
 		PC_DPRINTF1(3, "pc_rele: pcp=0x%p HELD AGAIN!\n", (void *)pcp);
 		mutex_exit(&vp->v_lock);

--- a/usr/src/uts/common/fs/pcfs/pc_vnops.c
+++ b/usr/src/uts/common/fs/pcfs/pc_vnops.c
@@ -27,6 +27,7 @@
 /*
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/param.h>
@@ -945,7 +946,7 @@ pcfs_inactive(
 	mutex_enter(&vp->v_lock);
 	ASSERT(vp->v_count >= 1);
 	if (vp->v_count > 1) {
-		vp->v_count--;  /* release our hold from vn_rele */
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		pc_unlockfs(fsp);
 		return;

--- a/usr/src/uts/common/fs/proc/prvnops.c
+++ b/usr/src/uts/common/fs/proc/prvnops.c
@@ -22,6 +22,7 @@
 /*
  * Copyright (c) 1989, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984,	 1986, 1987, 1988, 1989 AT&T	*/
@@ -5630,7 +5631,7 @@ prinactive(vnode_t *vp, cred_t *cr, caller_context_t *ct)
 	mutex_enter(&vp->v_lock);
 
 	if (type == PR_PROCDIR || vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		if (p != NULL)
 			mutex_exit(&p->p_lock);

--- a/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_subr2.c
+++ b/usr/src/uts/common/fs/smbclnt/smbfs/smbfs_subr2.c
@@ -25,6 +25,9 @@
  *	Copyright (c) 1983,1984,1985,1986,1987,1988,1989  AT&T.
  *	All rights reserved.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 /*
  * Node hash implementation initially borrowed from NFS (nfs_subr.c)
@@ -354,7 +357,7 @@ start:
 			rw_enter(&tmp_mi->smi_hash_lk, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&tmp_mi->smi_hash_lk);
 				/* start over */
@@ -370,7 +373,7 @@ start:
 
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			rw_enter(&mi->smi_hash_lk, RW_READER);
 			goto start;
@@ -533,7 +536,7 @@ smbfs_addfree(smbnode_t *np)
 			rw_enter(&mi->smi_hash_lk, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&mi->smi_hash_lk);
 				return;
@@ -570,7 +573,7 @@ smbfs_addfree(smbnode_t *np)
 		 */
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			return;
 		}
@@ -592,7 +595,7 @@ smbfs_addfree(smbnode_t *np)
 
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		rw_exit(&mi->smi_hash_lk);
 		return;
@@ -1137,7 +1140,7 @@ smbfs_node_reclaim(void)
 			rw_enter(&mi->smi_hash_lk, RW_WRITER);
 			mutex_enter(&vp->v_lock);
 			if (vp->v_count > 1) {
-				vp->v_count--;
+				VN_RELE_LOCKED(vp);
 				mutex_exit(&vp->v_lock);
 				rw_exit(&mi->smi_hash_lk);
 				mutex_enter(&smbfreelist_lock);

--- a/usr/src/uts/common/fs/sockfs/sockcommon_vnops.c
+++ b/usr/src/uts/common/fs/sockfs/sockcommon_vnops.c
@@ -23,6 +23,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/types.h>
 #include <sys/t_lock.h>
@@ -434,10 +437,8 @@ socket_vop_inactive(struct vnode *vp, struct cred *cr, caller_context_t *ct)
 	if (vp->v_count < 1)
 		cmn_err(CE_PANIC, "socket_inactive: Bad v_count");
 
-	/*
-	 * Drop the temporary hold by vn_rele now
-	 */
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		mutex_exit(&vp->v_lock);
 		return;
 	}

--- a/usr/src/uts/common/fs/specfs/specvnops.c
+++ b/usr/src/uts/common/fs/specfs/specvnops.c
@@ -22,6 +22,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -1581,10 +1582,8 @@ spec_inactive(struct vnode *vp, struct cred *cr, caller_context_t *ct)
 	mutex_enter(&stable_lock);
 
 	mutex_enter(&vp->v_lock);
-	/*
-	 * Drop the temporary hold by vn_rele now
-	 */
-	if (--vp->v_count != 0) {
+	VN_RELE_LOCKED(vp);
+	if (vp->v_count != 0) {
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&stable_lock);
 		return;

--- a/usr/src/uts/common/fs/tmpfs/tmp_vnops.c
+++ b/usr/src/uts/common/fs/tmpfs/tmp_vnops.c
@@ -28,6 +28,7 @@
  * Copyright (c) 2015, Joyent, Inc. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2016 RackTop Systems.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -1676,7 +1677,7 @@ top:
 	 * there's little to do -- just drop our hold.
 	 */
 	if (vp->v_count > 1 || tp->tn_nlink != 0) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&tp->tn_tlock);
 		rw_exit(&tp->tn_rwlock);

--- a/usr/src/uts/common/fs/ufs/ufs_inode.c
+++ b/usr/src/uts/common/fs/ufs/ufs_inode.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1983, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -702,7 +702,7 @@ ufs_iinactive(struct inode *ip)
 	mutex_enter(&vp->v_lock);
 
 	if (vp->v_count > 1) {
-		vp->v_count--;  /* release our hold from vn_rele */
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		rw_exit(&ip->i_contents);
 		return;
@@ -745,7 +745,7 @@ ufs_iinactive(struct inode *ip)
 		 */
 		if (ULOCKFS_IS_NOIDEL(ITOUL(ip))) {
 			mutex_enter(&vp->v_lock);
-			vp->v_count--;
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			rw_exit(&ip->i_contents);
 			return;
@@ -786,7 +786,7 @@ ufs_iinactive(struct inode *ip)
 		 */
 		mutex_enter(&vp->v_lock);
 		if (vp->v_count > 1) {
-			vp->v_count--;  /* release our hold from vn_rele */
+			VN_RELE_LOCKED(vp);
 			mutex_exit(&vp->v_lock);
 			rw_exit(&ip->i_contents);
 			return;
@@ -1616,7 +1616,7 @@ ufs_rmidle(struct inode *ip)
  */
 int
 ufs_scan_inodes(int rwtry, int (*func)(struct inode *, void *), void *arg,
-		struct ufsvfs *ufsvfsp)
+    struct ufsvfs *ufsvfsp)
 {
 	struct inode		*ip;		/* current inode */
 	struct inode		*lip = NULL;	/* last/previous inode */

--- a/usr/src/uts/common/fs/vnode.c
+++ b/usr/src/uts/common/fs/vnode.c
@@ -23,6 +23,7 @@
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -837,7 +838,7 @@ vn_rele(vnode_t *vp)
 		VOP_INACTIVE(vp, CRED(), NULL);
 		return;
 	}
-	vp->v_count--;
+	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }
 
@@ -858,15 +859,15 @@ vn_rele_dnlc(vnode_t *vp)
 			VOP_INACTIVE(vp, CRED(), NULL);
 			return;
 		}
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 	}
 	mutex_exit(&vp->v_lock);
 }
 
 /*
  * Like vn_rele() except that it clears v_stream under v_lock.
- * This is used by sockfs when it dismantels the association between
- * the sockfs node and the vnode in the underlaying file system.
+ * This is used by sockfs when it dismantles the association between
+ * the sockfs node and the vnode in the underlying file system.
  * v_lock has to be held to prevent a thread coming through the lookupname
  * path from accessing a stream head that is going away.
  */
@@ -881,7 +882,7 @@ vn_rele_stream(vnode_t *vp)
 		VOP_INACTIVE(vp, CRED(), NULL);
 		return;
 	}
-	vp->v_count--;
+	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }
 
@@ -912,7 +913,7 @@ vn_rele_async(vnode_t *vp, taskq_t *taskq)
 		    vp, TQ_SLEEP) != NULL);
 		return;
 	}
-	vp->v_count--;
+	VN_RELE_LOCKED(vp);
 	mutex_exit(&vp->v_lock);
 }
 

--- a/usr/src/uts/common/fs/zfs/zfs_ctldir.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ctldir.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright 2015, OmniTI Computer Consulting, Inc. All rights reserved.
  */
 
@@ -1210,7 +1210,7 @@ zfsctl_snapshot_inactive(vnode_t *vp, cred_t *cr, caller_context_t *ct)
 
 	mutex_enter(&vp->v_lock);
 	if (vp->v_count > 1) {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&sdp->sd_lock);
 		VN_RELE(dvp);

--- a/usr/src/uts/common/fs/zfs/zfs_vnops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vnops.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2015 Joyent, Inc.
  * Copyright 2017 Nexenta Systems, Inc.
@@ -1819,7 +1819,7 @@ top:
 			ASSERT0(error);
 		}
 		mutex_enter(&vp->v_lock);
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		ASSERT0(vp->v_count);
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&zp->z_lock);
@@ -4411,7 +4411,7 @@ zfs_inactive(vnode_t *vp, cred_t *cr, caller_context_t *ct)
 		mutex_enter(&zp->z_lock);
 		mutex_enter(&vp->v_lock);
 		ASSERT(vp->v_count == 1);
-		vp->v_count = 0;
+		VN_RELE_LOCKED(vp);
 		mutex_exit(&vp->v_lock);
 		mutex_exit(&zp->z_lock);
 		rw_exit(&zfsvfs->z_teardown_inactive_lock);

--- a/usr/src/uts/common/fs/zfs/zfs_znode.c
+++ b/usr/src/uts/common/fs/zfs/zfs_znode.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  */
 
@@ -1293,7 +1293,7 @@ zfs_zinactive(znode_t *zp)
 
 	mutex_enter(&zp->z_lock);
 	mutex_enter(&vp->v_lock);
-	vp->v_count--;
+	VN_RELE_LOCKED(vp);
 	if (vp->v_count > 0 || vn_has_cached_data(vp)) {
 		/*
 		 * If the hold count is greater than zero, somebody has

--- a/usr/src/uts/common/os/contract.c
+++ b/usr/src/uts/common/os/contract.c
@@ -22,6 +22,9 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 /*
  * Contracts
@@ -891,7 +894,7 @@ contract_vnode_clear(contract_t *ct, contract_vnode_t *ctv)
 		list_remove(&ct->ct_vnodes, ctv);
 		result = 1;
 	} else {
-		vp->v_count--;
+		VN_RELE_LOCKED(vp);
 		result = 0;
 	}
 	mutex_exit(&vp->v_lock);

--- a/usr/src/uts/common/os/driver.c
+++ b/usr/src/uts/common/os/driver.c
@@ -22,6 +22,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/types.h>
 #include <sys/t_lock.h>
@@ -363,7 +366,7 @@ dev_lclose(dev_t dev, int flag, int otype, struct cred *cred)
 	mutex_enter(&cvp->v_lock);
 	switch (cvp->v_count) {
 	default:
-		cvp->v_count--;
+		VN_RELE_LOCKED(cvp);
 		break;
 
 	case 0:
@@ -570,7 +573,7 @@ cdev_ioctl(dev_t dev, int cmd, intptr_t arg, int mode, struct cred *cred,
 
 int
 cdev_devmap(dev_t dev, devmap_cookie_t dhp, offset_t off, size_t len,
-	size_t *maplen, uint_t mode)
+    size_t *maplen, uint_t mode)
 {
 	struct cb_ops	*cb;
 
@@ -586,7 +589,7 @@ cdev_mmap(int (*mapfunc)(dev_t, off_t, int), dev_t dev, off_t off, int prot)
 
 int
 cdev_segmap(dev_t dev, off_t off, struct as *as, caddr_t *addrp, off_t len,
-	    uint_t prot, uint_t maxprot, uint_t flags, cred_t *credp)
+    uint_t prot, uint_t maxprot, uint_t flags, cred_t *credp)
 {
 	struct cb_ops	*cb;
 
@@ -597,7 +600,7 @@ cdev_segmap(dev_t dev, off_t off, struct as *as, caddr_t *addrp, off_t len,
 
 int
 cdev_poll(dev_t dev, short events, int anyyet, short *reventsp,
-	struct pollhead **pollhdrp)
+    struct pollhead **pollhdrp)
 {
 	struct cb_ops	*cb;
 

--- a/usr/src/uts/common/sys/fs/sdev_impl.h
+++ b/usr/src/uts/common/sys/fs/sdev_impl.h
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015, 2016 Joyent, Inc.  All rights reserved.
- * Copyright (c) 2014 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2017 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_SDEV_IMPL_H
@@ -239,9 +239,10 @@ typedef enum {
 #define	SDEV_HOLD(dv)	VN_HOLD(SDEVTOV(dv))
 #define	SDEV_RELE(dv)	VN_RELE(SDEVTOV(dv))
 #define	SDEV_SIMPLE_RELE(dv)	{	\
-	mutex_enter(&SDEVTOV(dv)->v_lock);	\
-	SDEVTOV(dv)->v_count--;	\
-	mutex_exit(&SDEVTOV(dv)->v_lock);	\
+	struct vnode *vp = SDEVTOV(dv);	\
+	mutex_enter(&vp->v_lock);	\
+	VN_RELE_LOCKED(vp);		\
+	mutex_exit(&vp->v_lock);	\
 }
 
 #define	SDEV_ACL_FLAVOR(vp)	(VFSTOSDEVFS(vp->v_vfsp)->sdev_acl_flavor)


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

A standard practice in ZFS is to keep track of "per-txg" state. Any of
the 3 active TXG's (open, quiescing, syncing) can have different values
for this state. We should assert that we do not attempt to modify other
(inactive) TXG's.

Upstream bugs: DLPX-49462