### PR TITLE
8071 zfs-tests: 7290 missed some cases

### DIFF
--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -61,6 +61,7 @@ export USR_BIN_FILES='awk
     isainfo
     kill
     ksh
+    ln
     logname
     ls
     md5sum
@@ -123,6 +124,7 @@ export USR_SBIN_FILES='arp
     dumpadm
     ff
     format
+    fsck
     fsdb
     fsirand
     fstyp

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_destroy/zpool_destroy_002_pos.ksh
@@ -52,9 +52,7 @@ function cleanup
 	[[ -n $cwd ]] && log_must cd $cwd
 
 	if [[ -d $TESTDIR ]]; then
-		ismounted $TESTDIR
-		((  $? == 0 )) && \
-			log_must $UNMOUNT $TESTDIR
+		ismounted $TESTDIR && log_must umount $TESTDIR
 		log_must rm -rf $TESTDIR
 	fi
 

--- a/usr/src/test/zfs-tests/tests/functional/xattr/xattr_009_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/xattr/xattr_009_neg.ksh
@@ -54,9 +54,9 @@ log_must touch $TESTDIR/myfile.$$
 create_xattr $TESTDIR/myfile.$$ passwd /etc/passwd
 
 # Try to create a soft link from the xattr namespace to the default namespace
-log_mustnot runat $TESTDIR/myfile.$$ $LN -s /etc/passwd foo
+log_mustnot runat $TESTDIR/myfile.$$ ln -s /etc/passwd foo
 
 # Try to create a hard link from the xattr namespace to the default namespace
-log_mustnot runat $TESTDIR/myfile.$$ $LN /etc/passwd foo
+log_mustnot runat $TESTDIR/myfile.$$ ln /etc/passwd foo
 
 log_pass "links between xattr and normal file namespace fail"

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_002_pos.ksh
@@ -77,21 +77,20 @@ typeset -i fn=0
 typeset -i retval=0
 
 while (( 1 )); do
-        file_write -o create -f $TESTDIR/testfile$$.$fn \
-            -b $BLOCKSZ -c $NUM_WRITES
-        retval=$?
-        if (( $retval != 0 )); then
-                break
-        fi
-
-        (( fn = fn + 1 ))
+	file_write -o create -f $TESTDIR/testfile$$.$fn \
+	    -b $BLOCKSZ -c $NUM_WRITES
+	retval=$?
+	if (( $retval != 0 )); then
+		break
+	fi
+	(( fn = fn + 1 ))
 done
 
 log_must lockfs -f $TESTDIR
 log_must zfs snapshot $TESTPOOL/$TESTVOL@snap
 
-$FSCK -n /dev/zvol/rdsk/$TESTPOOL/$TESTVOL@snap >/dev/null 2>&1
+fsck -n /dev/zvol/rdsk/$TESTPOOL/$TESTVOL@snap >/dev/null 2>&1
 retval=$?
-(( $retval == 39 )) || log_fail "$FSCK exited with wrong value $retval "
+(( $retval == 39 )) || log_fail "fsck exited with wrong value $retval "
 
 log_pass "Verify that ZFS volume snapshot could be fscked"

--- a/usr/src/test/zfs-tests/tests/perf/perf.shlib
+++ b/usr/src/test/zfs-tests/tests/perf/perf.shlib
@@ -90,7 +90,7 @@ function do_fio_run
 				typeset suffix="$sync_str.$iosize-ios.$threads-threads"
 
 				# Define output file
-				typeset logbase="$(get_perf_output_dir)/$($BASENAME \
+				typeset logbase="$(get_perf_output_dir)/$(basename \
 				    $SUDO_COMMAND)"
 				typeset outfile="$logbase.fio.$suffix"
 


### PR DESCRIPTION
Fix some commands missed in 7290.

Note that I'm not sure what to do with SUDO_COMMAND, it doesn't seem to be defined anywhere, but I'm probably missing something here.