### PR TITLE
8075 Attempting to destroy ZFS filesystem and create ZFS volume with the same name caused system panic

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -2275,6 +2275,8 @@ file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_005_neg \
     mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_006_pos \
     mode=0555
+file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/setup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_swap/zvol_swap.cfg \

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -560,7 +560,8 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/libzfs]
 tests = ['many_fds']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -556,7 +556,8 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -556,7 +556,8 @@ tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
-    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']
+    'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos',
+    'zvol_misc_007_pos']
 
 [/opt/zfs-tests/tests/functional/zvol/zvol_swap]
 tests = ['zvol_swap_001_pos', 'zvol_swap_002_pos', 'zvol_swap_003_pos',

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_007_pos.ksh
@@ -1,0 +1,46 @@
+#! /usr/bin/ksh -p
+#
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2016 Nexenta Systems, Inc. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/zvol/zvol_common.shlib
+
+#
+# DESCRIPTION:
+# Check that name collision between just destroyed filesystem and newly created
+# volume with the same name doesn't cause panic.
+#
+# STRATEGY:
+# 1. Create ZFS filesystem.
+# 2. Create nested ZFS volume.
+# 3. Read and display information about the ZFS volume.
+# 4. Recursively destroy ZFS filesystem.
+# 5. Create ZFS volume with the same name as ZFS filesystem.
+# 6. Read and display information about the ZFS volume.
+#
+
+verify_runnable "global"
+log_assert "zfs can handle race volume create operation."
+log_onexit cleanup
+
+log_must zfs create $TESTPOOL/$TESTFS
+log_must zfs create -V 1M $TESTPOOL/$TESTFS/$TESTVOL
+log_must stat /dev/zvol/rdsk/$TESTPOOL/$TESTFS/$TESTVOL
+log_must zfs destroy -r $TESTPOOL/$TESTFS
+log_must zfs create -V 1M $TESTPOOL/$TESTFS
+log_must stat /dev/zvol/rdsk/$TESTPOOL/$TESTFS
+
+log_pass "zfs handle race volume create operation."

--- a/usr/src/uts/common/fs/dev/sdev_subr.c
+++ b/usr/src/uts/common/fs/dev/sdev_subr.c
@@ -2170,6 +2170,10 @@ found:
 				rw_exit(&ddv->sdev_contents);
 				rw_enter(&ddv->sdev_contents, RW_WRITER);
 			}
+
+			if (SDEVTOV(dv)->v_type == VDIR)
+				(void) sdev_cleandir(dv, NULL, SDEV_ENFORCE);
+
 			sdev_cache_update(ddv, &dv, nm, SDEV_CACHE_DELETE);
 			rw_downgrade(&ddv->sdev_contents);
 			SDEV_RELE(dv);


### PR DESCRIPTION
Work by @deiter (taking over the #191, please close that one).

Do a sdev_cleandir() call for sdev directory path invalidation. If SDEV_ENFORCE is specified in sdev_cleandir() flags, busy nodes are made stale, so they are excluded from future lookups.



