### PR TITLE
8081 Compiler warnings in zdb

### DIFF
--- a/usr/src/cmd/zdb/Makefile.com
+++ b/usr/src/cmd/zdb/Makefile.com
@@ -46,7 +46,11 @@ CFLAGS += $(CCVERBOSE)
 CFLAGS64 += $(CCVERBOSE)
 CPPFLAGS += -D_LARGEFILE64_SOURCE=1 -D_REENTRANT $(INCS) -DDEBUG
 
-CERRWARN += -_gcc=-Wno-uninitialized
+# re-enable warnings that we can tolerate, which are disabled by default
+# in Makefile.master
+CERRWARN += -_gcc=-Wmissing-braces
+CERRWARN += -_gcc=-Wsign-compare
+CERRWARN += -_gcc=-Wmissing-field-initializers
 
 # lint complains about unused _umem_* functions
 LINTFLAGS += -xerroff=E_NAME_DEF_NOT_USED2

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -1018,8 +1018,8 @@ dump_all_ddts(spa_t *spa)
 	ddt_histogram_t ddh_total;
 	ddt_stat_t dds_total;
 
-	bzero(&ddh_total, sizeof(ddh_total));
-	bzero(&dds_total, sizeof(dds_total));
+	bzero(&ddh_total, sizeof (ddh_total));
+	bzero(&dds_total, sizeof (dds_total));
 
 	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
@@ -2738,7 +2738,7 @@ zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 	ddt_entry_t dde;
 	int error;
 
-	bzero(&ddb, sizeof(ddb));
+	bzero(&ddb, sizeof (ddb));
 	while ((error = ddt_walk(spa, &ddb, &dde)) == 0) {
 		blkptr_t blk;
 		ddt_phys_t *ddp = dde.dde_phys;
@@ -2901,7 +2901,7 @@ dump_block_stats(spa_t *spa)
 	int flags = TRAVERSE_PRE | TRAVERSE_PREFETCH_METADATA | TRAVERSE_HARD;
 	boolean_t leaks = B_FALSE;
 
-	bzero(&zcb, sizeof(zcb));
+	bzero(&zcb, sizeof (zcb));
 	(void) printf("\nTraversing all blocks %s%s%s%s%s...\n\n",
 	    (dump_opt['c'] || !dump_opt['L']) ? "to verify " : "",
 	    (dump_opt['c'] == 1) ? "metadata " : "",
@@ -3206,8 +3206,8 @@ dump_simulated_ddt(spa_t *spa)
 	ddt_histogram_t ddh_total;
 	ddt_stat_t dds_total;
 
-	bzero(&ddh_total, sizeof(ddh_total));
-	bzero(&dds_total, sizeof(dds_total));
+	bzero(&ddh_total, sizeof (ddh_total));
+	bzero(&dds_total, sizeof (dds_total));
 	avl_create(&t, ddt_entry_compare,
 	    sizeof (zdb_ddt_entry_t), offsetof(zdb_ddt_entry_t, zdde_node));
 
@@ -3718,7 +3718,7 @@ zdb_embedded_block(char *thing)
 	char buf[SPA_MAXBLOCKSIZE];
 	int err;
 
-	bzero(&bp, sizeof(bp));
+	bzero(&bp, sizeof (bp));
 	err = sscanf(thing, "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx:"
 	    "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx",
 	    words + 0, words + 1, words + 2, words + 3,
@@ -3765,7 +3765,7 @@ find_zpool(char **target, nvlist_t **configp, int dirc, char **dirv)
 	int count = 0;
 	importargs_t args;
 
-	bzero(&args, sizeof(args));
+	bzero(&args, sizeof (args));
 	args.paths = dirc;
 	args.path = dirv;
 	args.can_be_active = B_TRUE;

--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -67,6 +67,8 @@
 #undef verify
 #include <libzfs.h>
 
+#include "zdb.h"
+
 #define	ZDB_COMPRESS_NAME(idx) ((idx) < ZIO_COMPRESS_FUNCTIONS ?	\
 	zio_compress_table[(idx)].ci_name : "UNKNOWN")
 #define	ZDB_CHECKSUM_NAME(idx) ((idx) < ZIO_CHECKSUM_FUNCTIONS ?	\
@@ -90,14 +92,13 @@ uint64_t zfs_arc_max, zfs_arc_meta_limit;
 int zfs_vdev_async_read_max_active;
 #endif
 
-const char cmdname[] = "zdb";
+static const char cmdname[] = "zdb";
 uint8_t dump_opt[256];
 
 typedef void object_viewer_t(objset_t *, uint64_t, void *data, size_t size);
 
-extern void dump_intent_log(zilog_t *);
 uint64_t *zopt_object = NULL;
-int zopt_objects = 0;
+static unsigned zopt_objects = 0;
 libzfs_handle_t *g_zfs;
 uint64_t max_inflight = 1000;
 
@@ -285,8 +286,8 @@ zdb_nicenum(uint64_t num, char *buf, size_t buflen)
 		nicenum(num, buf, sizeof (buf));
 }
 
-const char histo_stars[] = "****************************************";
-const int histo_width = sizeof (histo_stars) - 1;
+static const char histo_stars[] = "****************************************";
+static const uint64_t histo_width = sizeof (histo_stars) - 1;
 
 static void
 dump_histogram(const uint64_t *histo, int size, int offset)
@@ -392,7 +393,7 @@ dump_unknown(objset_t *os, uint64_t object, void *data, size_t size)
 }
 
 /*ARGSUSED*/
-void
+static void
 dump_uint8(objset_t *os, uint64_t object, void *data, size_t size)
 {
 }
@@ -410,7 +411,7 @@ dump_zap(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 	void *prop;
-	int i;
+	unsigned i;
 
 	dump_zap_stats(os, object);
 	(void) printf("\n");
@@ -573,7 +574,7 @@ dump_sa_layouts(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_cursor_t zc;
 	zap_attribute_t attr;
 	uint16_t *layout_attrs;
-	int i;
+	unsigned i;
 
 	dump_zap_stats(os, object);
 	(void) printf("\n");
@@ -642,7 +643,7 @@ dump_zpldir(objset_t *os, uint64_t object, void *data, size_t size)
 	zap_cursor_fini(&zc);
 }
 
-int
+static int
 get_dtl_refcount(vdev_t *vd)
 {
 	int refcount = 0;
@@ -656,18 +657,18 @@ get_dtl_refcount(vdev_t *vd)
 		return (0);
 	}
 
-	for (int c = 0; c < vd->vdev_children; c++)
+	for (unsigned c = 0; c < vd->vdev_children; c++)
 		refcount += get_dtl_refcount(vd->vdev_child[c]);
 	return (refcount);
 }
 
-int
+static int
 get_metaslab_refcount(vdev_t *vd)
 {
 	int refcount = 0;
 
 	if (vd->vdev_top == vd && !vd->vdev_removing) {
-		for (int m = 0; m < vd->vdev_ms_count; m++) {
+		for (unsigned m = 0; m < vd->vdev_ms_count; m++) {
 			space_map_t *sm = vd->vdev_ms[m]->ms_sm;
 
 			if (sm != NULL &&
@@ -675,7 +676,7 @@ get_metaslab_refcount(vdev_t *vd)
 				refcount++;
 		}
 	}
-	for (int c = 0; c < vd->vdev_children; c++)
+	for (unsigned c = 0; c < vd->vdev_children; c++)
 		refcount += get_metaslab_refcount(vd->vdev_child[c]);
 
 	return (refcount);
@@ -707,7 +708,7 @@ static void
 dump_spacemap(objset_t *os, space_map_t *sm)
 {
 	uint64_t alloc, offset, entry;
-	char *ddata[] = { "ALLOC", "FREE", "CONDENSE", "INVALID",
+	const char *ddata[] = { "ALLOC", "FREE", "CONDENSE", "INVALID",
 			    "INVALID", "INVALID", "INVALID", "INVALID" };
 
 	if (sm == NULL)
@@ -844,7 +845,7 @@ dump_metaslab_groups(spa_t *spa)
 
 	metaslab_class_histogram_verify(mc);
 
-	for (int c = 0; c < rvd->vdev_children; c++) {
+	for (unsigned c = 0; c < rvd->vdev_children; c++) {
 		vdev_t *tvd = rvd->vdev_child[c];
 		metaslab_group_t *mg = tvd->vdev_mg;
 
@@ -923,7 +924,7 @@ dump_dde(const ddt_t *ddt, const ddt_entry_t *dde, uint64_t index)
 {
 	const ddt_phys_t *ddp = dde->dde_phys;
 	const ddt_key_t *ddk = &dde->dde_key;
-	char *types[4] = { "ditto", "single", "double", "triple" };
+	const char *types[4] = { "ditto", "single", "double", "triple" };
 	char blkbuf[BP_SPRINTF_LEN];
 	blkptr_t blk;
 
@@ -1014,8 +1015,11 @@ dump_ddt(ddt_t *ddt, enum ddt_type type, enum ddt_class class)
 static void
 dump_all_ddts(spa_t *spa)
 {
-	ddt_histogram_t ddh_total = { 0 };
-	ddt_stat_t dds_total = { 0 };
+	ddt_histogram_t ddh_total;
+	ddt_stat_t dds_total;
+
+	bzero(&ddh_total, sizeof(ddh_total));
+	bzero(&dds_total, sizeof(dds_total));
 
 	for (enum zio_checksum c = 0; c < ZIO_CHECKSUM_FUNCTIONS; c++) {
 		ddt_t *ddt = spa->spa_ddt[c];
@@ -1062,7 +1066,8 @@ dump_dtl(vdev_t *vd, int indent)
 {
 	spa_t *spa = vd->vdev_spa;
 	boolean_t required;
-	char *name[DTL_TYPES] = { "missing", "partial", "scrub", "outage" };
+	const char *name[DTL_TYPES] = { "missing", "partial", "scrub",
+		"outage" };
 	char prefix[256];
 
 	spa_vdev_state_enter(spa, SCL_NONE);
@@ -1090,7 +1095,7 @@ dump_dtl(vdev_t *vd, int indent)
 			dump_spacemap(spa->spa_meta_objset, vd->vdev_dtl_sm);
 	}
 
-	for (int c = 0; c < vd->vdev_children; c++)
+	for (unsigned c = 0; c < vd->vdev_children; c++)
 		dump_dtl(vd->vdev_child[c], indent + 4);
 }
 
@@ -1125,7 +1130,7 @@ dump_history(spa_t *spa)
 	umem_free(buf, SPA_MAXBLOCKSIZE);
 
 	(void) printf("\nHistory:\n");
-	for (int i = 0; i < num; i++) {
+	for (unsigned i = 0; i < num; i++) {
 		uint64_t time, txg, ievent;
 		char *cmd, *intstr;
 		boolean_t printed = B_FALSE;
@@ -1147,8 +1152,8 @@ dump_history(spa_t *spa)
 
 			(void) snprintf(internalstr,
 			    sizeof (internalstr),
-			    "[internal %s txg:%lld] %s",
-			    zfs_history_event_names[ievent], txg,
+			    "[internal %s txg:%ju] %s",
+			    zfs_history_event_names[ievent], (uintmax_t)txg,
 			    intstr);
 			cmd = internalstr;
 		}
@@ -1465,7 +1470,7 @@ dump_bptree_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 }
 
 static void
-dump_bptree(objset_t *os, uint64_t obj, char *name)
+dump_bptree(objset_t *os, uint64_t obj, const char *name)
 {
 	char bytes[32];
 	bptree_phys_t *bt;
@@ -1505,7 +1510,7 @@ dump_bpobj_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 }
 
 static void
-dump_full_bpobj(bpobj_t *bpo, char *name, int indent)
+dump_full_bpobj(bpobj_t *bpo, const char *name, int indent)
 {
 	char bytes[32];
 	char comp[32];
@@ -2011,7 +2016,7 @@ dump_object(objset_t *os, uint64_t object, int verbosity, int *print_header)
 		dmu_buf_rele(db, FTAG);
 }
 
-static char *objset_types[DMU_OST_NUMTYPES] = {
+static const char *objset_types[DMU_OST_NUMTYPES] = {
 	"NONE", "META", "ZPL", "ZVOL", "OTHER", "ANY" };
 
 static void
@@ -2023,10 +2028,11 @@ dump_dir(objset_t *os)
 	char numbuf[32];
 	char blkbuf[BP_SPRINTF_LEN + 20];
 	char osname[ZFS_MAX_DATASET_NAME_LEN];
-	char *type = "UNKNOWN";
+	const char *type = "UNKNOWN";
 	int verbosity = dump_opt['d'];
 	int print_header = 1;
-	int i, error;
+	unsigned i;
+	int error;
 
 	/* make sure nicenum has enough space */
 	CTASSERT(sizeof (numbuf) >= NN_NUMBUF_SZ);
@@ -2116,7 +2122,7 @@ dump_uberblock(uberblock_t *ub, const char *header, const char *footer)
 {
 	time_t timestamp = ub->ub_timestamp;
 
-	(void) printf(header ? header : "");
+	(void) printf("%s", header ? header : "");
 	(void) printf("\tmagic = %016llx\n", (u_longlong_t)ub->ub_magic);
 	(void) printf("\tversion = %llu\n", (u_longlong_t)ub->ub_version);
 	(void) printf("\ttxg = %llu\n", (u_longlong_t)ub->ub_txg);
@@ -2128,7 +2134,7 @@ dump_uberblock(uberblock_t *ub, const char *header, const char *footer)
 		snprintf_blkptr(blkbuf, sizeof (blkbuf), &ub->ub_rootbp);
 		(void) printf("\trootbp = %s\n", blkbuf);
 	}
-	(void) printf(footer ? footer : "");
+	(void) printf("%s", footer ? footer : "");
 }
 
 static void
@@ -2471,7 +2477,7 @@ typedef struct zdb_blkstats {
 #define	ZDB_OT_OTHER	(DMU_OT_NUMTYPES + 2)
 #define	ZDB_OT_TOTAL	(DMU_OT_NUMTYPES + 3)
 
-static char *zdb_ot_extname[] = {
+static const char *zdb_ot_extname[] = {
 	"deferred free",
 	"dedup ditto",
 	"other",
@@ -2488,7 +2494,7 @@ typedef struct zdb_cb {
 	uint64_t	zcb_embedded_histogram[NUM_BP_EMBEDDED_TYPES]
 	    [BPE_PAYLOAD_SIZE];
 	uint64_t	zcb_start;
-	uint64_t	zcb_lastprint;
+	hrtime_t	zcb_lastprint;
 	uint64_t	zcb_totalasize;
 	uint64_t	zcb_errors[256];
 	int		zcb_readfails;
@@ -2523,7 +2529,7 @@ zdb_count_block(zdb_cb_t *zcb, zilog_t *zilog, const blkptr_t *bp,
 		 * SPA_OLD_MAXBLOCKSIZE; larger blocks go into the last,
 		 * "other", bucket.
 		 */
-		int idx = BP_GET_PSIZE(bp) >> SPA_MINBLOCKSHIFT;
+		unsigned idx = BP_GET_PSIZE(bp) >> SPA_MINBLOCKSHIFT;
 		idx = MIN(idx, SPA_OLD_MAXBLOCKSIZE / SPA_MINBLOCKSIZE + 1);
 		zb->zb_psize_histogram[idx]++;
 
@@ -2728,10 +2734,11 @@ static metaslab_ops_t zdb_metaslab_ops = {
 static void
 zdb_ddt_leak_init(spa_t *spa, zdb_cb_t *zcb)
 {
-	ddt_bookmark_t ddb = { 0 };
+	ddt_bookmark_t ddb;
 	ddt_entry_t dde;
 	int error;
 
+	bzero(&ddb, sizeof(ddb));
 	while ((error = ddt_walk(spa, &ddb, &dde)) == 0) {
 		blkptr_t blk;
 		ddt_phys_t *ddp = dde.dde_phys;
@@ -2839,10 +2846,10 @@ zdb_leak_fini(spa_t *spa)
 {
 	if (!dump_opt['L']) {
 		vdev_t *rvd = spa->spa_root_vdev;
-		for (int c = 0; c < rvd->vdev_children; c++) {
+		for (unsigned c = 0; c < rvd->vdev_children; c++) {
 			vdev_t *vd = rvd->vdev_child[c];
 			metaslab_group_t *mg = vd->vdev_mg;
-			for (int m = 0; m < vd->vdev_ms_count; m++) {
+			for (unsigned m = 0; m < vd->vdev_ms_count; m++) {
 				metaslab_t *msp = vd->vdev_ms[m];
 				ASSERT3P(mg, ==, msp->ms_group);
 				mutex_enter(&msp->ms_lock);
@@ -2888,12 +2895,13 @@ count_block_cb(void *arg, const blkptr_t *bp, dmu_tx_t *tx)
 static int
 dump_block_stats(spa_t *spa)
 {
-	zdb_cb_t zcb = { 0 };
+	zdb_cb_t zcb;
 	zdb_blkstats_t *zb, *tzb;
 	uint64_t norm_alloc, norm_space, total_alloc, total_found;
 	int flags = TRAVERSE_PRE | TRAVERSE_PREFETCH_METADATA | TRAVERSE_HARD;
 	boolean_t leaks = B_FALSE;
 
+	bzero(&zcb, sizeof(zcb));
 	(void) printf("\nTraversing all blocks %s%s%s%s%s...\n\n",
 	    (dump_opt['c'] || !dump_opt['L']) ? "to verify " : "",
 	    (dump_opt['c'] == 1) ? "metadata " : "",
@@ -3044,7 +3052,7 @@ dump_block_stats(spa_t *spa)
 		for (t = 0; t <= ZDB_OT_TOTAL; t++) {
 			char csize[32], lsize[32], psize[32], asize[32];
 			char avg[32], gang[32];
-			char *typename;
+			const char *typename;
 
 			/* make sure nicenum has enough space */
 			CTASSERT(sizeof (csize) >= NN_NUMBUF_SZ);
@@ -3195,9 +3203,11 @@ dump_simulated_ddt(spa_t *spa)
 	avl_tree_t t;
 	void *cookie = NULL;
 	zdb_ddt_entry_t *zdde;
-	ddt_histogram_t ddh_total = { 0 };
-	ddt_stat_t dds_total = { 0 };
+	ddt_histogram_t ddh_total;
+	ddt_stat_t dds_total;
 
+	bzero(&ddh_total, sizeof(ddh_total));
+	bzero(&dds_total, sizeof(dds_total));
 	avl_create(&t, ddt_entry_compare,
 	    sizeof (zdb_ddt_entry_t), offsetof(zdb_ddt_entry_t, zdde_node));
 
@@ -3345,7 +3355,7 @@ dump_zpool(spa_t *spa)
 #define	ZDB_FLAG_RAW		0x0040
 #define	ZDB_FLAG_PRINT_BLKPTR	0x0080
 
-int flagbits[256];
+static int flagbits[256];
 
 static void
 zdb_print_blkptr(blkptr_t *bp, int flags)
@@ -3386,10 +3396,11 @@ static void
 zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
 {
 	uint64_t *d = (uint64_t *)buf;
-	int nwords = size / sizeof (uint64_t);
+	unsigned nwords = size / sizeof (uint64_t);
 	int do_bswap = !!(flags & ZDB_FLAG_BSWAP);
-	int i, j;
-	char *hdr, *c;
+	unsigned i, j;
+	const char *hdr;
+	char *c;
 
 
 	if (do_bswap)
@@ -3422,19 +3433,19 @@ zdb_dump_block(char *label, void *buf, uint64_t size, int flags)
  * RAID-Zs, you can specify either RAID-Z vdev with 0.0 or 0.1 .
  */
 static vdev_t *
-zdb_vdev_lookup(vdev_t *vdev, char *path)
+zdb_vdev_lookup(vdev_t *vdev, const char *path)
 {
 	char *s, *p, *q;
-	int i;
+	unsigned i;
 
 	if (vdev == NULL)
 		return (NULL);
 
 	/* First, assume the x.x.x.x format */
-	i = (int)strtoul(path, &s, 10);
+	i = strtoul(path, &s, 10);
 	if (s == path || (s && *s != '.' && *s != '\0'))
 		goto name;
-	if (i < 0 || i >= vdev->vdev_children)
+	if (i >= vdev->vdev_children)
 		return (NULL);
 
 	vdev = vdev->vdev_child[i];
@@ -3509,7 +3520,8 @@ zdb_read_block(char *thing, spa_t *spa)
 	vdev_t *vd;
 	abd_t *pabd;
 	void *lbuf, *buf;
-	char *s, *p, *dup, *vdev, *flagstr;
+	const char *s, *vdev;
+	char *p, *dup, *flagstr;
 	int i, error;
 
 	dup = strdup(thing);
@@ -3520,7 +3532,10 @@ zdb_read_block(char *thing, spa_t *spa)
 	s = strtok(NULL, ":");
 	size = strtoull(s ? s : "", NULL, 16);
 	s = strtok(NULL, ":");
-	flagstr = s ? s : "";
+	if (s)
+		flagstr = strdup(s);
+	else
+		flagstr = strdup("");
 
 	s = NULL;
 	if (size == 0)
@@ -3561,6 +3576,7 @@ zdb_read_block(char *thing, spa_t *spa)
 			}
 		}
 	}
+	free(flagstr);
 
 	vd = zdb_vdev_lookup(spa->spa_root_vdev, vdev);
 	if (vd == NULL) {
@@ -3697,11 +3713,12 @@ out:
 static void
 zdb_embedded_block(char *thing)
 {
-	blkptr_t bp = { 0 };
+	blkptr_t bp;
 	unsigned long long *words = (void *)&bp;
 	char buf[SPA_MAXBLOCKSIZE];
 	int err;
 
+	bzero(&bp, sizeof(bp));
 	err = sscanf(thing, "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx:"
 	    "%llx:%llx:%llx:%llx:%llx:%llx:%llx:%llx",
 	    words + 0, words + 1, words + 2, words + 3,
@@ -3746,8 +3763,9 @@ find_zpool(char **target, nvlist_t **configp, int dirc, char **dirv)
 	char *sepp = NULL;
 	char sep = '\0';
 	int count = 0;
-	importargs_t args = { 0 };
+	importargs_t args;
 
+	bzero(&args, sizeof(args));
 	args.paths = dirc;
 	args.path = dirv;
 	args.can_be_active = B_TRUE;
@@ -3807,7 +3825,7 @@ find_zpool(char **target, nvlist_t **configp, int dirc, char **dirv)
 int
 main(int argc, char **argv)
 {
-	int i, c;
+	int c;
 	struct rlimit rl = { 1024, 1024 };
 	spa_t *spa = NULL;
 	objset_t *os = NULL;
@@ -4087,7 +4105,7 @@ main(int argc, char **argv)
 		if (argc > 0) {
 			zopt_objects = argc;
 			zopt_object = calloc(zopt_objects, sizeof (uint64_t));
-			for (i = 0; i < zopt_objects; i++) {
+			for (unsigned i = 0; i < zopt_objects; i++) {
 				errno = 0;
 				zopt_object[i] = strtoull(argv[i], NULL, 0);
 				if (zopt_object[i] == 0 && errno != 0)
@@ -4112,7 +4130,7 @@ main(int argc, char **argv)
 		flagbits['p'] = ZDB_FLAG_PHYS;
 		flagbits['r'] = ZDB_FLAG_RAW;
 
-		for (i = 0; i < argc; i++)
+		for (int i = 0; i < argc; i++)
 			zdb_read_block(argv[i], spa);
 	}
 

--- a/usr/src/cmd/zdb/zdb.h
+++ b/usr/src/cmd/zdb/zdb.h
@@ -24,10 +24,10 @@
  */
 
 
-#ifndef __ZDB_H
-#define __ZDB_H
+#ifndef	_ZDB_H
+#define	_ZDB_H
 
 void dump_intent_log(zilog_t *);
 extern uint8_t dump_opt[256];
 
-#endif //__ZDB_H
+#endif	/* _ZDB_H */

--- a/usr/src/cmd/zdb/zdb.h
+++ b/usr/src/cmd/zdb/zdb.h
@@ -1,0 +1,33 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Spectra Logic Corp Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+
+#ifndef __ZDB_H
+#define __ZDB_H
+
+void dump_intent_log(zilog_t *);
+extern uint8_t dump_opt[256];
+
+#endif //__ZDB_H

--- a/usr/src/cmd/zdb/zdb_il.c
+++ b/usr/src/cmd/zdb/zdb_il.c
@@ -271,7 +271,7 @@ zil_prt_rec_acl(zilog_t *zilog, int txtype, void *arg)
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_aclcnt);
 }
 
-typedef void (*zil_prt_rec_func_t)(zilog_t*, int, void*);
+typedef void (*zil_prt_rec_func_t)(zilog_t *, int, void *);
 typedef struct zil_rec_info {
 	zil_prt_rec_func_t	zri_print;
 	const char		*zri_name;
@@ -279,27 +279,27 @@ typedef struct zil_rec_info {
 } zil_rec_info_t;
 
 static zil_rec_info_t zil_rec_info[TX_MAX_TYPE] = {
-	{.zri_print=NULL,		.zri_name="Total              "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE          "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR           "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKXATTR         "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_SYMLINK         "},
-	{.zri_print=zil_prt_rec_remove,	.zri_name="TX_REMOVE          "},
-	{.zri_print=zil_prt_rec_remove,	.zri_name="TX_RMDIR           "},
-	{.zri_print=zil_prt_rec_link,	.zri_name="TX_LINK            "},
-	{.zri_print=zil_prt_rec_rename,	.zri_name="TX_RENAME          "},
-	{.zri_print=zil_prt_rec_write,	.zri_name="TX_WRITE           "},
-	{.zri_print=zil_prt_rec_truncate, .zri_name="TX_TRUNCATE        "},
-	{.zri_print=zil_prt_rec_setattr,  .zri_name="TX_SETATTR         "},
-	{.zri_print=zil_prt_rec_acl,	.zri_name="TX_ACL_V0          "},
-	{.zri_print=zil_prt_rec_acl,	.zri_name="TX_ACL_ACL         "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ACL      "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ATTR     "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ACL_ATTR "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ACL       "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ATTR      "},
-	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ACL_ATTR  "},
-	{.zri_print=zil_prt_rec_write,	.zri_name="TX_WRITE2          "},
+	{.zri_print = NULL,		    .zri_name = "Total              "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE          "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR           "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKXATTR         "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_SYMLINK         "},
+	{.zri_print = zil_prt_rec_remove,   .zri_name = "TX_REMOVE          "},
+	{.zri_print = zil_prt_rec_remove,   .zri_name = "TX_RMDIR           "},
+	{.zri_print = zil_prt_rec_link,	    .zri_name = "TX_LINK            "},
+	{.zri_print = zil_prt_rec_rename,   .zri_name = "TX_RENAME          "},
+	{.zri_print = zil_prt_rec_write,    .zri_name = "TX_WRITE           "},
+	{.zri_print = zil_prt_rec_truncate, .zri_name = "TX_TRUNCATE        "},
+	{.zri_print = zil_prt_rec_setattr,  .zri_name = "TX_SETATTR         "},
+	{.zri_print = zil_prt_rec_acl,	    .zri_name = "TX_ACL_V0          "},
+	{.zri_print = zil_prt_rec_acl,	    .zri_name = "TX_ACL_ACL         "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ACL      "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ATTR     "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_CREATE_ACL_ATTR "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ACL       "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ATTR      "},
+	{.zri_print = zil_prt_rec_create,   .zri_name = "TX_MKDIR_ACL_ATTR  "},
+	{.zri_print = zil_prt_rec_write,    .zri_name = "TX_WRITE2          "},
 };
 
 /* ARGSUSED */

--- a/usr/src/cmd/zdb/zdb_il.c
+++ b/usr/src/cmd/zdb/zdb_il.c
@@ -43,9 +43,11 @@
 #include <sys/zil_impl.h>
 #include <sys/abd.h>
 
+#include "zdb.h"
+
 extern uint8_t dump_opt[256];
 
-static char prefix[4] = "\t\t\t";
+static char tab_prefix[4] = "\t\t\t";
 
 static void
 print_log_bp(const blkptr_t *bp, const char *prefix)
@@ -58,8 +60,9 @@ print_log_bp(const blkptr_t *bp, const char *prefix)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_create(zilog_t *zilog, int txtype, lr_create_t *lr)
+zil_prt_rec_create(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_create_t *lr = arg;
 	time_t crtime = lr->lr_crtime[0];
 	char *name, *link;
 	lr_attr_t *lrattr;
@@ -74,47 +77,53 @@ zil_prt_rec_create(zilog_t *zilog, int txtype, lr_create_t *lr)
 
 	if (txtype == TX_SYMLINK) {
 		link = name + strlen(name) + 1;
-		(void) printf("%s%s -> %s\n", prefix, name, link);
+		(void) printf("%s%s -> %s\n", tab_prefix, name, link);
 	} else if (txtype != TX_MKXATTR) {
-		(void) printf("%s%s\n", prefix, name);
+		(void) printf("%s%s\n", tab_prefix, name);
 	}
 
-	(void) printf("%s%s", prefix, ctime(&crtime));
-	(void) printf("%sdoid %llu, foid %llu, mode %llo\n", prefix,
+	(void) printf("%s%s", tab_prefix, ctime(&crtime));
+	(void) printf("%sdoid %llu, foid %llu, mode %llo\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (u_longlong_t)lr->lr_foid,
 	    (longlong_t)lr->lr_mode);
-	(void) printf("%suid %llu, gid %llu, gen %llu, rdev 0x%llx\n", prefix,
+	(void) printf("%suid %llu, gid %llu, gen %llu, rdev 0x%llx\n",
+	    tab_prefix,
 	    (u_longlong_t)lr->lr_uid, (u_longlong_t)lr->lr_gid,
 	    (u_longlong_t)lr->lr_gen, (u_longlong_t)lr->lr_rdev);
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_remove(zilog_t *zilog, int txtype, lr_remove_t *lr)
+zil_prt_rec_remove(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sdoid %llu, name %s\n", prefix,
+	lr_remove_t *lr = arg;
+
+	(void) printf("%sdoid %llu, name %s\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (char *)(lr + 1));
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_link(zilog_t *zilog, int txtype, lr_link_t *lr)
+zil_prt_rec_link(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sdoid %llu, link_obj %llu, name %s\n", prefix,
+	lr_link_t *lr = arg;
+
+	(void) printf("%sdoid %llu, link_obj %llu, name %s\n", tab_prefix,
 	    (u_longlong_t)lr->lr_doid, (u_longlong_t)lr->lr_link_obj,
 	    (char *)(lr + 1));
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_rename(zilog_t *zilog, int txtype, lr_rename_t *lr)
+zil_prt_rec_rename(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_rename_t *lr = arg;
 	char *snm = (char *)(lr + 1);
 	char *tnm = snm + strlen(snm) + 1;
 
-	(void) printf("%ssdoid %llu, tdoid %llu\n", prefix,
+	(void) printf("%ssdoid %llu, tdoid %llu\n", tab_prefix,
 	    (u_longlong_t)lr->lr_sdoid, (u_longlong_t)lr->lr_tdoid);
-	(void) printf("%ssrc %s tgt %s\n", prefix, snm, tnm);
+	(void) printf("%ssrc %s tgt %s\n", tab_prefix, snm, tnm);
 }
 
 /* ARGSUSED */
@@ -122,7 +131,7 @@ static int
 zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 {
 	char *cdata = data;
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		if (isprint(*cdata))
 			(void) printf("%c ", *cdata);
 		else
@@ -134,15 +143,16 @@ zil_prt_rec_write_cb(void *data, size_t len, void *unused)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
+zil_prt_rec_write(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_write_t *lr = arg;
 	abd_t *data;
 	blkptr_t *bp = &lr->lr_blkptr;
 	zbookmark_phys_t zb;
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
 	int error;
 
-	(void) printf("%sfoid %llu, offset %llx, length %llx\n", prefix,
+	(void) printf("%sfoid %llu, offset %llx, length %llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_offset,
 	    (u_longlong_t)lr->lr_length);
 
@@ -150,20 +160,21 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		return;
 
 	if (lr->lr_common.lrc_reclen == sizeof (lr_write_t)) {
-		(void) printf("%shas blkptr, %s\n", prefix,
+		(void) printf("%shas blkptr, %s\n", tab_prefix,
 		    !BP_IS_HOLE(bp) &&
 		    bp->blk_birth >= spa_first_txg(zilog->zl_spa) ?
 		    "will claim" : "won't claim");
-		print_log_bp(bp, prefix);
+		print_log_bp(bp, tab_prefix);
 
 		if (BP_IS_HOLE(bp)) {
 			(void) printf("\t\t\tLSIZE 0x%llx\n",
 			    (u_longlong_t)BP_GET_LSIZE(bp));
-			(void) printf("%s<hole>\n", prefix);
+			(void) printf("%s<hole>\n", tab_prefix);
 			return;
 		}
 		if (bp->blk_birth < zilog->zl_header->zh_claim_txg) {
-			(void) printf("%s<block already committed>\n", prefix);
+			(void) printf("%s<block already committed>\n",
+			    tab_prefix);
 			return;
 		}
 
@@ -183,7 +194,7 @@ zil_prt_rec_write(zilog_t *zilog, int txtype, lr_write_t *lr)
 		abd_copy_from_buf(data, lr + 1, lr->lr_length);
 	}
 
-	(void) printf("%s", prefix);
+	(void) printf("%s", tab_prefix);
 	(void) abd_iterate_func(data,
 	    0, MIN(lr->lr_length, (verbose < 6 ? 20 : SPA_MAXBLOCKSIZE)),
 	    zil_prt_rec_write_cb, NULL);
@@ -195,52 +206,55 @@ out:
 
 /* ARGSUSED */
 static void
-zil_prt_rec_truncate(zilog_t *zilog, int txtype, lr_truncate_t *lr)
+zil_prt_rec_truncate(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sfoid %llu, offset 0x%llx, length 0x%llx\n", prefix,
+	lr_truncate_t *lr = arg;
+
+	(void) printf("%sfoid %llu, offset 0x%llx, length 0x%llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (longlong_t)lr->lr_offset,
 	    (u_longlong_t)lr->lr_length);
 }
 
 /* ARGSUSED */
 static void
-zil_prt_rec_setattr(zilog_t *zilog, int txtype, lr_setattr_t *lr)
+zil_prt_rec_setattr(zilog_t *zilog, int txtype, void *arg)
 {
+	lr_setattr_t *lr = arg;
 	time_t atime = (time_t)lr->lr_atime[0];
 	time_t mtime = (time_t)lr->lr_mtime[0];
 
-	(void) printf("%sfoid %llu, mask 0x%llx\n", prefix,
+	(void) printf("%sfoid %llu, mask 0x%llx\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_mask);
 
 	if (lr->lr_mask & AT_MODE) {
-		(void) printf("%sAT_MODE  %llo\n", prefix,
+		(void) printf("%sAT_MODE  %llo\n", tab_prefix,
 		    (longlong_t)lr->lr_mode);
 	}
 
 	if (lr->lr_mask & AT_UID) {
-		(void) printf("%sAT_UID   %llu\n", prefix,
+		(void) printf("%sAT_UID   %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_uid);
 	}
 
 	if (lr->lr_mask & AT_GID) {
-		(void) printf("%sAT_GID   %llu\n", prefix,
+		(void) printf("%sAT_GID   %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_gid);
 	}
 
 	if (lr->lr_mask & AT_SIZE) {
-		(void) printf("%sAT_SIZE  %llu\n", prefix,
+		(void) printf("%sAT_SIZE  %llu\n", tab_prefix,
 		    (u_longlong_t)lr->lr_size);
 	}
 
 	if (lr->lr_mask & AT_ATIME) {
-		(void) printf("%sAT_ATIME %llu.%09llu %s", prefix,
+		(void) printf("%sAT_ATIME %llu.%09llu %s", tab_prefix,
 		    (u_longlong_t)lr->lr_atime[0],
 		    (u_longlong_t)lr->lr_atime[1],
 		    ctime(&atime));
 	}
 
 	if (lr->lr_mask & AT_MTIME) {
-		(void) printf("%sAT_MTIME %llu.%09llu %s", prefix,
+		(void) printf("%sAT_MTIME %llu.%09llu %s", tab_prefix,
 		    (u_longlong_t)lr->lr_mtime[0],
 		    (u_longlong_t)lr->lr_mtime[1],
 		    ctime(&mtime));
@@ -249,41 +263,43 @@ zil_prt_rec_setattr(zilog_t *zilog, int txtype, lr_setattr_t *lr)
 
 /* ARGSUSED */
 static void
-zil_prt_rec_acl(zilog_t *zilog, int txtype, lr_acl_t *lr)
+zil_prt_rec_acl(zilog_t *zilog, int txtype, void *arg)
 {
-	(void) printf("%sfoid %llu, aclcnt %llu\n", prefix,
+	lr_acl_t *lr = arg;
+
+	(void) printf("%sfoid %llu, aclcnt %llu\n", tab_prefix,
 	    (u_longlong_t)lr->lr_foid, (u_longlong_t)lr->lr_aclcnt);
 }
 
-typedef void (*zil_prt_rec_func_t)();
+typedef void (*zil_prt_rec_func_t)(zilog_t*, int, void*);
 typedef struct zil_rec_info {
 	zil_prt_rec_func_t	zri_print;
-	char			*zri_name;
+	const char		*zri_name;
 	uint64_t		zri_count;
 } zil_rec_info_t;
 
 static zil_rec_info_t zil_rec_info[TX_MAX_TYPE] = {
-	{	NULL,			"Total              " },
-	{	zil_prt_rec_create,	"TX_CREATE          " },
-	{	zil_prt_rec_create,	"TX_MKDIR           " },
-	{	zil_prt_rec_create,	"TX_MKXATTR         " },
-	{	zil_prt_rec_create,	"TX_SYMLINK         " },
-	{	zil_prt_rec_remove,	"TX_REMOVE          " },
-	{	zil_prt_rec_remove,	"TX_RMDIR           " },
-	{	zil_prt_rec_link,	"TX_LINK            " },
-	{	zil_prt_rec_rename,	"TX_RENAME          " },
-	{	zil_prt_rec_write,	"TX_WRITE           " },
-	{	zil_prt_rec_truncate,	"TX_TRUNCATE        " },
-	{	zil_prt_rec_setattr,	"TX_SETATTR         " },
-	{	zil_prt_rec_acl,	"TX_ACL_V0          " },
-	{	zil_prt_rec_acl,	"TX_ACL_ACL         " },
-	{	zil_prt_rec_create,	"TX_CREATE_ACL      " },
-	{	zil_prt_rec_create,	"TX_CREATE_ATTR     " },
-	{	zil_prt_rec_create,	"TX_CREATE_ACL_ATTR " },
-	{	zil_prt_rec_create,	"TX_MKDIR_ACL       " },
-	{	zil_prt_rec_create,	"TX_MKDIR_ATTR      " },
-	{	zil_prt_rec_create,	"TX_MKDIR_ACL_ATTR  " },
-	{	zil_prt_rec_write,	"TX_WRITE2          " },
+	{.zri_print=NULL,		.zri_name="Total              "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE          "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR           "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKXATTR         "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_SYMLINK         "},
+	{.zri_print=zil_prt_rec_remove,	.zri_name="TX_REMOVE          "},
+	{.zri_print=zil_prt_rec_remove,	.zri_name="TX_RMDIR           "},
+	{.zri_print=zil_prt_rec_link,	.zri_name="TX_LINK            "},
+	{.zri_print=zil_prt_rec_rename,	.zri_name="TX_RENAME          "},
+	{.zri_print=zil_prt_rec_write,	.zri_name="TX_WRITE           "},
+	{.zri_print=zil_prt_rec_truncate, .zri_name="TX_TRUNCATE        "},
+	{.zri_print=zil_prt_rec_setattr,  .zri_name="TX_SETATTR         "},
+	{.zri_print=zil_prt_rec_acl,	.zri_name="TX_ACL_V0          "},
+	{.zri_print=zil_prt_rec_acl,	.zri_name="TX_ACL_ACL         "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ACL      "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ATTR     "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_CREATE_ACL_ATTR "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ACL       "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ATTR      "},
+	{.zri_print=zil_prt_rec_create,	.zri_name="TX_MKDIR_ACL_ATTR  "},
+	{.zri_print=zil_prt_rec_write,	.zri_name="TX_WRITE2          "},
 };
 
 /* ARGSUSED */
@@ -321,7 +337,7 @@ print_log_block(zilog_t *zilog, blkptr_t *bp, void *arg, uint64_t claim_txg)
 {
 	char blkbuf[BP_SPRINTF_LEN + 10];
 	int verbose = MAX(dump_opt['d'], dump_opt['i']);
-	char *claim;
+	const char *claim;
 
 	if (verbose <= 3)
 		return (0);
@@ -350,7 +366,7 @@ print_log_block(zilog_t *zilog, blkptr_t *bp, void *arg, uint64_t claim_txg)
 static void
 print_log_stats(int verbose)
 {
-	int i, w, p10;
+	unsigned i, w, p10;
 
 	if (verbose > 3)
 		(void) printf("\n");

--- a/usr/src/cmd/ztest/ztest.c
+++ b/usr/src/cmd/ztest/ztest.c
@@ -1423,8 +1423,10 @@ ztest_log_setattr(ztest_ds_t *zd, dmu_tx_t *tx, lr_setattr_t *lr)
  * ZIL replay ops
  */
 static int
-ztest_replay_create(ztest_ds_t *zd, lr_create_t *lr, boolean_t byteswap)
+ztest_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_create_t *lr = arg2;
 	char *name = (void *)(lr + 1);		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	ztest_block_tag_t *bbt;
@@ -1507,8 +1509,10 @@ ztest_replay_create(ztest_ds_t *zd, lr_create_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_remove(ztest_ds_t *zd, lr_remove_t *lr, boolean_t byteswap)
+ztest_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_remove_t *lr = arg2;
 	char *name = (void *)(lr + 1);		/* name follows lr */
 	objset_t *os = zd->zd_os;
 	dmu_object_info_t doi;
@@ -1558,8 +1562,10 @@ ztest_replay_remove(ztest_ds_t *zd, lr_remove_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
+ztest_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_write_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	void *data = lr + 1;			/* data follows lr */
 	uint64_t offset, length;
@@ -1683,8 +1689,10 @@ ztest_replay_write(ztest_ds_t *zd, lr_write_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
+ztest_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_truncate_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	uint64_t txg;
@@ -1722,8 +1730,10 @@ ztest_replay_truncate(ztest_ds_t *zd, lr_truncate_t *lr, boolean_t byteswap)
 }
 
 static int
-ztest_replay_setattr(ztest_ds_t *zd, lr_setattr_t *lr, boolean_t byteswap)
+ztest_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 {
+	ztest_ds_t *zd = arg1;
+	lr_setattr_t *lr = arg2;
 	objset_t *os = zd->zd_os;
 	dmu_tx_t *tx;
 	dmu_buf_t *db;

--- a/usr/src/lib/libzpool/common/sys/zfs_context.h
+++ b/usr/src/lib/libzpool/common/sys/zfs_context.h
@@ -197,7 +197,7 @@ extern struct proc p0;
 
 #define	PS_NONE		-1
 
-extern kthread_t *zk_thread_create(void (*func)(), void *arg, uint64_t len);
+extern kthread_t *zk_thread_create(void (*func)(void*), void *arg, uint64_t len);
 
 #define	issig(why)	(FALSE)
 #define	ISSIG(thr, why)	(FALSE)

--- a/usr/src/lib/libzpool/common/sys/zfs_context.h
+++ b/usr/src/lib/libzpool/common/sys/zfs_context.h
@@ -197,7 +197,8 @@ extern struct proc p0;
 
 #define	PS_NONE		-1
 
-extern kthread_t *zk_thread_create(void (*func)(void*), void *arg, uint64_t len);
+extern kthread_t *zk_thread_create(void (*func)(void*), void *arg,
+    uint64_t len);
 
 #define	issig(why)	(FALSE)
 #define	ISSIG(thr, why)	(FALSE)

--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -4087,8 +4087,9 @@ arc_kmem_reap_now(void)
  * This possible deadlock is avoided by always acquiring a hash lock
  * using mutex_tryenter() from arc_reclaim_thread().
  */
+/* ARGSUSED */
 static void
-arc_reclaim_thread(void)
+arc_reclaim_thread(void *unused)
 {
 	hrtime_t		growtime = 0;
 	callb_cpr_t		cpr;
@@ -7022,8 +7023,9 @@ l2arc_write_buffers(spa_t *spa, l2arc_dev_t *dev, uint64_t target_sz)
  * This thread feeds the L2ARC at regular intervals.  This is the beating
  * heart of the L2ARC.
  */
+/* ARGSUSED */
 static void
-l2arc_feed_thread(void)
+l2arc_feed_thread(void *unused)
 {
 	callb_cpr_t cpr;
 	l2arc_dev_t *dev;

--- a/usr/src/uts/common/fs/zfs/dbuf.c
+++ b/usr/src/uts/common/fs/zfs/dbuf.c
@@ -495,8 +495,9 @@ dbuf_evict_one(void)
  * of the dbuf cache is at or below the maximum size. Once the dbuf is aged
  * out of the cache it is destroyed and becomes eligible for arc eviction.
  */
+/* ARGSUSED */
 static void
-dbuf_evict_thread(void)
+dbuf_evict_thread(void *unused)
 {
 	callb_cpr_t cpr;
 

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -5867,7 +5867,7 @@ spa_async_autoexpand(spa_t *spa, vdev_t *vd)
 static void
 spa_async_thread(void *arg)
 {
-	spa_t *spa = (spa_t*) arg;
+	spa_t *spa = (spa_t *)arg;
 	int tasks;
 
 	ASSERT(spa->spa_sync_on);

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -5865,8 +5865,9 @@ spa_async_autoexpand(spa_t *spa, vdev_t *vd)
 }
 
 static void
-spa_async_thread(spa_t *spa)
+spa_async_thread(void *arg)
 {
+	spa_t *spa = (spa_t*) arg;
 	int tasks;
 
 	ASSERT(spa->spa_sync_on);

--- a/usr/src/uts/common/fs/zfs/sys/refcount.h
+++ b/usr/src/uts/common/fs/zfs/sys/refcount.h
@@ -39,7 +39,7 @@ extern "C" {
  * particular object, use FTAG (which is a string) for the holder_tag.
  * Otherwise, use the object that holds the reference.
  */
-#define	FTAG ((char *)__func__)
+#define	FTAG ((char *)(uintptr_t)__func__)
 
 #ifdef	ZFS_DEBUG
 typedef struct reference {

--- a/usr/src/uts/common/fs/zfs/sys/sa.h
+++ b/usr/src/uts/common/fs/zfs/sys/sa.h
@@ -146,8 +146,8 @@ int sa_replace_all_by_template(sa_handle_t *, sa_bulk_attr_t *,
 int sa_replace_all_by_template_locked(sa_handle_t *, sa_bulk_attr_t *,
     int, dmu_tx_t *);
 boolean_t sa_enabled(objset_t *);
-void sa_cache_init();
-void sa_cache_fini();
+void sa_cache_init(void);
+void sa_cache_fini(void);
 int sa_set_sa_object(objset_t *, uint64_t);
 int sa_hdrsize(void *);
 void sa_handle_lock(sa_handle_t *);

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -870,7 +870,7 @@ extern void vdev_cache_stat_fini(void);
 /* Initialization and termination */
 extern void spa_init(int flags);
 extern void spa_fini(void);
-extern void spa_boot_init();
+extern void spa_boot_init(void);
 
 /* properties */
 extern int spa_prop_set(spa_t *spa, nvlist_t *nvp);

--- a/usr/src/uts/common/fs/zfs/sys/zil.h
+++ b/usr/src/uts/common/fs/zfs/sys/zil.h
@@ -389,7 +389,7 @@ typedef int zil_parse_blk_func_t(zilog_t *zilog, blkptr_t *bp, void *arg,
     uint64_t txg);
 typedef int zil_parse_lr_func_t(zilog_t *zilog, lr_t *lr, void *arg,
     uint64_t txg);
-typedef int zil_replay_func_t();
+typedef int zil_replay_func_t(void *arg1, void *arg2, boolean_t byteswap);
 typedef int zil_get_data_t(void *arg, lr_write_t *lr, char *dbuf,
     struct lwb *lwb, zio_t *zio);
 

--- a/usr/src/uts/common/fs/zfs/txg.c
+++ b/usr/src/uts/common/fs/zfs/txg.c
@@ -106,8 +106,8 @@
  * now transition to the syncing state.
  */
 
-static void txg_sync_thread(dsl_pool_t *dp);
-static void txg_quiesce_thread(dsl_pool_t *dp);
+static void txg_sync_thread(void *arg);
+static void txg_quiesce_thread(void *arg);
 
 int zfs_txg_timeout = 5;	/* max seconds worth of delta per txg */
 
@@ -445,8 +445,9 @@ txg_dispatch_callbacks(dsl_pool_t *dp, uint64_t txg)
 }
 
 static void
-txg_sync_thread(dsl_pool_t *dp)
+txg_sync_thread(void *arg)
 {
+	dsl_pool_t *dp = arg;
 	spa_t *spa = dp->dp_spa;
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
@@ -525,8 +526,9 @@ txg_sync_thread(dsl_pool_t *dp)
 }
 
 static void
-txg_quiesce_thread(dsl_pool_t *dp)
+txg_quiesce_thread(void *arg)
 {
+	dsl_pool_t *dp = arg;
 	tx_state_t *tx = &dp->dp_tx;
 	callb_cpr_t cpr;
 

--- a/usr/src/uts/common/fs/zfs/zfs_replay.c
+++ b/usr/src/uts/common/fs/zfs/zfs_replay.c
@@ -69,7 +69,7 @@ zfs_init_vattr(vattr_t *vap, uint64_t mask, uint64_t mode,
 
 /* ARGSUSED */
 static int
-zfs_replay_error(zfsvfs_t *zfsvfs, lr_t *lr, boolean_t byteswap)
+zfs_replay_error(void *arg1, void *arg2, boolean_t byteswap)
 {
 	return (SET_ERROR(ENOTSUP));
 }
@@ -262,9 +262,10 @@ zfs_replay_swap_attrs(lr_attr_t *lrattr)
  * as option FUID information.
  */
 static int
-zfs_replay_create_acl(zfsvfs_t *zfsvfs,
-    lr_acl_create_t *lracl, boolean_t byteswap)
+zfs_replay_create_acl(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_create_t *lracl = arg2;
 	char *name = NULL;		/* location determined later */
 	lr_create_t *lr = (lr_create_t *)lracl;
 	znode_t *dzp;
@@ -403,8 +404,10 @@ bail:
 }
 
 static int
-zfs_replay_create(zfsvfs_t *zfsvfs, lr_create_t *lr, boolean_t byteswap)
+zfs_replay_create(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_create_t *lr = arg2;
 	char *name = NULL;		/* location determined later */
 	char *link;			/* symlink content follows name */
 	znode_t *dzp;
@@ -528,8 +531,10 @@ out:
 }
 
 static int
-zfs_replay_remove(zfsvfs_t *zfsvfs, lr_remove_t *lr, boolean_t byteswap)
+zfs_replay_remove(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_remove_t *lr = arg2;
 	char *name = (char *)(lr + 1);	/* name follows lr_remove_t */
 	znode_t *dzp;
 	int error;
@@ -561,8 +566,10 @@ zfs_replay_remove(zfsvfs_t *zfsvfs, lr_remove_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_link(zfsvfs_t *zfsvfs, lr_link_t *lr, boolean_t byteswap)
+zfs_replay_link(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_link_t *lr = arg2;
 	char *name = (char *)(lr + 1);	/* name follows lr_link_t */
 	znode_t *dzp, *zp;
 	int error;
@@ -591,8 +598,10 @@ zfs_replay_link(zfsvfs_t *zfsvfs, lr_link_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_rename(zfsvfs_t *zfsvfs, lr_rename_t *lr, boolean_t byteswap)
+zfs_replay_rename(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_rename_t *lr = arg2;
 	char *sname = (char *)(lr + 1);	/* sname and tname follow lr_rename_t */
 	char *tname = sname + strlen(sname) + 1;
 	znode_t *sdzp, *tdzp;
@@ -623,8 +632,10 @@ zfs_replay_rename(zfsvfs_t *zfsvfs, lr_rename_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_write(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
+zfs_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_write_t *lr = arg2;
 	char *data = (char *)(lr + 1);	/* data follows lr_write_t */
 	znode_t	*zp;
 	int error;
@@ -689,8 +700,10 @@ zfs_replay_write(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
  * the file is grown.
  */
 static int
-zfs_replay_write2(zfsvfs_t *zfsvfs, lr_write_t *lr, boolean_t byteswap)
+zfs_replay_write2(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_write_t *lr = arg2;
 	znode_t	*zp;
 	int error;
 	uint64_t end;
@@ -734,8 +747,10 @@ top:
 }
 
 static int
-zfs_replay_truncate(zfsvfs_t *zfsvfs, lr_truncate_t *lr, boolean_t byteswap)
+zfs_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_truncate_t *lr = arg2;
 	znode_t *zp;
 	flock64_t fl;
 	int error;
@@ -761,8 +776,10 @@ zfs_replay_truncate(zfsvfs_t *zfsvfs, lr_truncate_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_setattr(zfsvfs_t *zfsvfs, lr_setattr_t *lr, boolean_t byteswap)
+zfs_replay_setattr(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_setattr_t *lr = arg2;
 	znode_t *zp;
 	xvattr_t xva;
 	vattr_t *vap = &xva.xva_vattr;
@@ -813,8 +830,10 @@ zfs_replay_setattr(zfsvfs_t *zfsvfs, lr_setattr_t *lr, boolean_t byteswap)
 }
 
 static int
-zfs_replay_acl_v0(zfsvfs_t *zfsvfs, lr_acl_v0_t *lr, boolean_t byteswap)
+zfs_replay_acl_v0(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_v0_t* lr = arg2;
 	ace_t *ace = (ace_t *)(lr + 1);	/* ace array follows lr_acl_t */
 	vsecattr_t vsa;
 	znode_t *zp;
@@ -857,8 +876,10 @@ zfs_replay_acl_v0(zfsvfs_t *zfsvfs, lr_acl_v0_t *lr, boolean_t byteswap)
  *
  */
 static int
-zfs_replay_acl(zfsvfs_t *zfsvfs, lr_acl_t *lr, boolean_t byteswap)
+zfs_replay_acl(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zfsvfs_t *zfsvfs = arg1;
+	lr_acl_t *lr = arg2;
 	ace_t *ace = (ace_t *)(lr + 1);
 	vsecattr_t vsa;
 	znode_t *zp;

--- a/usr/src/uts/common/fs/zfs/zfs_replay.c
+++ b/usr/src/uts/common/fs/zfs/zfs_replay.c
@@ -833,7 +833,7 @@ static int
 zfs_replay_acl_v0(void *arg1, void *arg2, boolean_t byteswap)
 {
 	zfsvfs_t *zfsvfs = arg1;
-	lr_acl_v0_t* lr = arg2;
+	lr_acl_v0_t *lr = arg2;
 	ace_t *ace = (ace_t *)(lr + 1);	/* ace array follows lr_acl_t */
 	vsecattr_t vsa;
 	znode_t *zp;

--- a/usr/src/uts/common/fs/zfs/zvol.c
+++ b/usr/src/uts/common/fs/zfs/zvol.c
@@ -374,8 +374,10 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
  * implement DKIOCFREE/free-long-range.
  */
 static int
-zvol_replay_truncate(zvol_state_t *zv, lr_truncate_t *lr, boolean_t byteswap)
+zvol_replay_truncate(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zvol_state_t *zv = arg1;
+	lr_truncate_t *lr = arg2;
 	uint64_t offset, length;
 
 	if (byteswap)
@@ -392,8 +394,10 @@ zvol_replay_truncate(zvol_state_t *zv, lr_truncate_t *lr, boolean_t byteswap)
  * after a system failure
  */
 static int
-zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
+zvol_replay_write(void *arg1, void *arg2, boolean_t byteswap)
 {
+	zvol_state_t *zv = arg1;
+	lr_write_t *lr = arg2;
 	objset_t *os = zv->zv_objset;
 	char *data = (char *)(lr + 1);	/* data follows lr_write_t */
 	uint64_t offset, length;
@@ -430,7 +434,7 @@ zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
 
 /* ARGSUSED */
 static int
-zvol_replay_err(zvol_state_t *zv, lr_t *lr, boolean_t byteswap)
+zvol_replay_err(void *arg1, void *arg2, boolean_t byteswap)
 {
 	return (SET_ERROR(ENOTSUP));
 }


### PR DESCRIPTION
Fix compiler warnings in zdb.  With these changes, FreeBSD can compile
zdb with all compiler warnings enabled save -Wunused-parameter.

usr/src/cmd/zdb/zdb.c
usr/src/cmd/zdb/zdb_il.c
usr/src/uts/common/fs/zfs/sys/sa.h
usr/src/uts/common/fs/zfs/sys/spa.h
	Fix numerous warnings, including:
	* const-correctness
	* shadowing global definitions
	* signed vs unsigned comparisons
	* missing prototypes, or missing static declarations
	* unused variables and functions
	* Unreadable array initializations
	* Missing struct initializers

usr/src/cmd/zdb/zdb.h
	Add a header file to declare common symbols

usr/src/lib/libzpool/common/sys/zfs_context.h
usr/src/uts/common/fs/zfs/arc.c
usr/src/uts/common/fs/zfs/dbuf.c
usr/src/uts/common/fs/zfs/spa.c
usr/src/uts/common/fs/zfs/txg.c
	Add a function prototype for zk_thread_create, and ensure that every
	callback supplied to this function actually matches the prototype.

usr/src/cmd/ztest/ztest.c
usr/src/uts/common/fs/zfs/sys/zil.h
usr/src/uts/common/fs/zfs/zfs_replay.c
usr/src/uts/common/fs/zfs/zvol.c
	Add a function prototype for zil_replay_func_t, and ensure that
	every function of this type actually matches the prototype.

usr/src/uts/common/fs/zfs/sys/refcount.h
	Change FTAG so it discards any constness of __func__, necessary
	since existing APIs expect it passed as void *.