### PR TITLE
8086 Add Stride parameter to dd

### DIFF
--- a/usr/src/cmd/dd/dd.c
+++ b/usr/src/cmd/dd/dd.c
@@ -25,6 +25,7 @@
  * Use is subject to license terms.
  * Copyright 2012, Josef 'Jeff' Sipek <jeffpc@31bits.net>. All rights reserved.
  * Copyright (c) 2014, Joyent, Inc.  All rights reserved.
+ * Copyright (c) 2014 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T	*/
@@ -103,10 +104,10 @@
 #define	USAGE\
 	"usage: dd [if=file] [of=file] [ibs=n|nk|nb|nxm] [obs=n|nk|nb|nxm]\n"\
 	"	   [bs=n|nk|nb|nxm] [cbs=n|nk|nb|nxm] [files=n] [skip=n]\n"\
-	"	   [iseek=n] [oseek=n] [seek=n] [count=n] [conv=[ascii]\n"\
-	"	   [,ebcdic][,ibm][,asciib][,ebcdicb][,ibmb]\n"\
-	"	   [,block|unblock][,lcase|ucase][,swab]\n"\
-	"	   [,noerror][,notrunc][,sync]]\n"\
+	"	   [iseek=n] [oseek=n] [seek=n] [stride=n] [istride=n]\n"\
+	"	   [ostride=n] [count=n] [conv=[ascii] [,ebcdic][,ibm]\n"\
+	"	   [,asciib][,ebcdicb][,ibmb][,block|unblock][,lcase|ucase]\n"\
+	"	   [,swab][,noerror][,notrunc][,sync]]\n"\
 	"	   [oflag=[dsync][sync]]\n"
 
 /* Global references */
@@ -148,6 +149,11 @@ static off_t	oseekn;	/* number of output records to seek past */
 static unsigned long long	count;	/* number of input records to copy */
 			/* (0 = all) */
 static boolean_t ecount;	/* explicit count given */
+static off_t	ostriden;	/* number of output blocks to skip between */
+				/* records */
+static off_t	istriden;	/* number of input blocks to skip between */
+				/* records */
+
 static int	trantype; /* BSD or SVr4 compatible EBCDIC */
 
 static char		*string;	/* command arg pointer */
@@ -569,6 +575,21 @@ main(int argc, char **argv)
 			oseekn = number(BIG);
 			continue;
 		}
+		if (match("ostride="))
+		{
+			ostriden = ((off_t)number(BIG)) - 1;
+			continue;
+		}
+		if (match("istride="))
+		{
+			istriden = ((off_t)number(BIG)) - 1;
+			continue;
+		}
+		if (match("stride="))
+		{
+			istriden = ostriden = ((off_t)number(BIG)) - 1;
+			continue;
+		}
 		if (match("count="))
 		{
 			count = number(BIG);
@@ -718,6 +739,16 @@ main(int argc, char **argv)
 	{
 		(void) fprintf(stderr, "dd: %s\n",
 			gettext("buffer sizes cannot be zero"));
+		exit(2);
+	}
+	if (ostriden == (off_t)-1) {
+		(void) fprintf(stderr, "dd: %s\n",
+			gettext("stride must be greater than zero"));
+		exit(2);
+	}
+	if (istriden == (off_t)-1) {
+		(void) fprintf(stderr, "dd: %s\n",
+			gettext("stride must be greater than zero"));
 		exit(2);
 	}
 	if (conv == COPY)
@@ -1034,6 +1065,12 @@ main(int argc, char **argv)
 			/* Read the next input block */
 
 			ibc = read(ibf, (char *)ibuf, ibs);
+
+			if (istriden > 0 && lseek(ibf, istriden * ((off_t)ibs),
+			    SEEK_CUR) == -1) {
+				perror("lseek");
+				exit(2);
+			}
 
 			/* Process input errors */
 
@@ -1804,7 +1841,7 @@ long long big;
 /* Flush the output buffer, move any excess bytes down to the beginning	*/
 /*									*/
 /* Arg:		none							*/
-/* Global args:	obuf, obc, obs, nofr, nopr				*/
+/* Global args:	obuf, obc, obs, nofr, nopr, ostriden			*/
 /*									*/
 /* Return:	Pointer to the first free byte in the output buffer.	*/
 /*		Also reset `obc' to account for moved bytes.		*/
@@ -1839,6 +1876,13 @@ static unsigned char
 				"wrote %d bytes, expected %d\n"), bc, oc);
 			term(2);
 		}
+
+		if (ostriden && lseek(obf, (((off_t)ostriden) * ((off_t)obs)),
+		    SEEK_CUR) == -1) {
+			perror("lseek");
+			exit(2);
+		}
+
 		obc -= oc;
 		op = obuf;
 		obytes += bc;

--- a/usr/src/man/man1m/dd.1m
+++ b/usr/src/man/man1m/dd.1m
@@ -1,5 +1,6 @@
 '\" te
 .\" Copyright (c) 2014, Joyent, Inc.  All rights Reserved.
+.\" Copyright (c) 2014 by Delphix. All rights reserved.
 .\" Copyright (c) 1992, X/Open Company Limited  All Rights Reserved
 .\" Copyright 1989 AT&T
 .\" Portions Copyright (c) 1995, Sun Microsystems, Inc.  All Rights Reserved
@@ -195,6 +196,41 @@ output file before copying. On non-seekable files, existing blocks are read and
 space from the current end-of-file to the specified offset, if any, is filled
 with null bytes. On seekable files, the implementation seeks to the specified
 offset or reads the blocks as described for non-seekable files.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBostride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Writes every \fIn\fRth block (using the specified output block size) when
+writing output.  Skips \fIn\fR - 1 blocks after writing each record.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBistride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Reads every \fIn\fRth block (using the specified input block size) when
+reading input.  Skips \fIn\fR - 1 blocks after reading each record.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBstride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Reads every \fIn\fRth block (using the specified input block size) when
+reading input.  Skips \fIn\fR - 1 blocks after reading each record.  Also
+writes every \fIn\fRth block (using the specified output block size) when
+writing output.  Skips \fIn\fR - 1 blocks after writing each record.
 .RE
 
 .sp


### PR DESCRIPTION
Reviewed by: Alex Reece <alex@delphix.com>
Reviewed by: Basil Crow <basil.crow@delphix.com>

Sometimes, we want to update blocks of a file, but not every block. In these
cases, in the existing world, the best answer is either to run dd many, many,
many times (seeking and reading/writing one block each time), or to write a
program to do it yourself. This patch adds this functionality to dd itself,
by adding the following new options:

  - ostride; for writing, similar to of
  - istride; for reading, similar to if
  - stride; for both, reading and writing

Performance was tested three ways:

  1. Using the new dd, we wrote out a gigabyte of data to the start of a
     32 GB sparse file.

  2. Then, we did the same, but updated only every 32nd block using the
     new feature.

  3. Finally, we emulated the second case using a bash for loop and dd,
     where we wrote one block at a time and did a seek to the correct offset
     each time.

Note that the second and third cases actually involve writing significantly
more (2.08 GB vs 1.16 GB, 77% more) data to disk, due to the increase in zfs
overhead from storing the data sparsely.

1GB Contiguous:

    $ dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=2048k
    2097152+0 records in
    2097152+0 records out
    1073741824 bytes transferred in 73.005140 secs (14707757 bytes/sec)

1GB Sparse:

    $ dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=2048k ostride=32
    2097152+0 records in
    2097152+0 records out
    1073741824 bytes transferred in 105.598897 secs (10168116 bytes/sec)

1GB Sparse with bash for loop:

    #
    # This run was actually cancelled due to its extraordinary slowness.
    # After 15 minutes and 50 seconds, the run had gotten to block offset
    # 1115584, which is only 1.66% of the way through the 1GB of output.
    #
    $ date; for i in `seq 1 2097152`; do
    > offset=$(( $i * 32 ))
    > dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=1 seek=$offset 2>/dev/null
    > done; date
    August  6, 2014 05:44:08 PM UT
    ^C

Additionally, correctness of the new feature was verified using od:

  - Create the file:

    $ for i in seq 0 2048; do
    > dd if=<(echo $i) of=/tmp/ddfile bs=512 count=1 oseek=$i 2>/dev/null
    > done
    $ od -Ax -tx /tmp/ddfile
    000000 00000a30 00000000 00000000 00000000
    000010 00000000 00000000 00000000 00000000
    *
    000200 00000a31 00000000 00000000 00000000
    000210 00000000 00000000 00000000 00000000
    *
    000400 00000a32 00000000 00000000 00000000
    000410 00000000 00000000 00000000 00000000
    *
    000600 00000a33 00000000 00000000 00000000
    000610 00000000 00000000 00000000 00000000
    *
    ... <snip> ...

 - Test new "istride" feature:

    $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 istride=4 count=512 2>/dev/null
    $ od -Ax -tx /tmp/ddfile2
    000000 00000a30 00000000 00000000 00000000
    000010 00000000 00000000 00000000 00000000
    *
    000200 00000a34 00000000 00000000 00000000
    000210 00000000 00000000 00000000 00000000
    *
    000400 00000a38 00000000 00000000 00000000
    000410 00000000 00000000 00000000 00000000
    *
    ... <snip> ...

 - Test new "ostride" feature:

    $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 ostride=4 count=512 2>/dev/null
    $ od -Ax -tx /tmp/ddfile2
    000000 00000a30 00000000 00000000 00000000
    000010 00000000 00000000 00000000 00000000
    *
    000800 00000a31 00000000 00000000 00000000
    000810 00000000 00000000 00000000 00000000
    *
    001000 00000a32 00000000 00000000 00000000
    001010 00000000 00000000 00000000 00000000
    *
    ... <snip> ...

 - Test new "stride" feature:

    $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 stride=4 count=512 2>/dev/null
    $ od -Ax -tx /tmp/ddfile2
    000000 00000a30 00000000 00000000 00000000
    000010 00000000 00000000 00000000 00000000
    *
    000800 00000a34 00000000 00000000 00000000
    000810 00000000 00000000 00000000 00000000
    *
    001000 00000a38 00000000 00000000 00000000
    001010 00000000 00000000 00000000 00000000
    *
    ... <snip> ...

Upstream bugs: 37007, DLPX-34103