### PR TITLE
8086 Add Stride parameter to dd

### DIFF
--- a/usr/src/man/man1m/dd.1m
+++ b/usr/src/man/man1m/dd.1m
@@ -1,5 +1,6 @@
 '\" te
 .\" Copyright (c) 2014, Joyent, Inc.  All rights Reserved.
+.\" Copyright (c) 2014 by Delphix. All rights reserved.
 .\" Copyright (c) 1992, X/Open Company Limited  All Rights Reserved
 .\" Copyright 1989 AT&T
 .\" Portions Copyright (c) 1995, Sun Microsystems, Inc.  All Rights Reserved
@@ -10,7 +11,7 @@
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
-.TH DD 1M "Jan 04, 2014"
+.TH DD 1M "Dec 12, 2014"
 .SH NAME
 dd \- convert and copy a file
 .SH SYNOPSIS
@@ -195,6 +196,41 @@ output file before copying. On non-seekable files, existing blocks are read and
 space from the current end-of-file to the specified offset, if any, is filled
 with null bytes. On seekable files, the implementation seeks to the specified
 offset or reads the blocks as described for non-seekable files.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBostride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Writes every \fIn\fRth block (using the specified output block size) when
+writing output.  Skips \fIn\fR - 1 blocks after writing each record.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBistride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Reads every \fIn\fRth block (using the specified input block size) when
+reading input.  Skips \fIn\fR - 1 blocks after reading each record.
+.RE
+
+.sp
+.ne 2
+.na
+\fB\fBstride=\fR\fIn\fR\fR
+.ad
+.sp .6
+.RS 4n
+Reads every \fIn\fRth block (using the specified input block size) when
+reading input.  Skips \fIn\fR - 1 blocks after reading each record.  Also
+writes every \fIn\fRth block (using the specified output block size) when
+writing output.  Skips \fIn\fR - 1 blocks after writing each record.
 .RE
 
 .sp


### PR DESCRIPTION
Reviewed by: Alex Reece <alex@delphix.com>
Reviewed by: Basil Crow <basil.crow@delphix.com>

Sometimes, we want to update blocks of a file, but not every block. In these
cases, in the existing world, the best answer is either to run dd many, many,
many times (seeking and reading/writing one block each time), or to write a
program to do it yourself. This patch adds this functionality to dd itself,
by adding the following new options:

  - ostride; for writing, similar to of
  - istride; for reading, similar to if
  - stride; for both, reading and writing

Performance was tested three ways:

  1. Using the new dd, we wrote out a gigabyte of data to the start of a
     32 GB sparse file.

  2. Then, we did the same, but updated only every 32nd block using the
     new feature.

  3. Finally, we emulated the second case using a bash for loop and dd,
     where we wrote one block at a time and did a seek to the correct offset
     each time.

Note that the second and third cases actually involve writing significantly
more (2.08 GB vs 1.16 GB, 77% more) data to disk, due to the increase in zfs
overhead from storing the data sparsely.

1GB Contiguous:

    $ dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=2048k
    2097152+0 records in
    2097152+0 records out
    1073741824 bytes transferred in 73.005140 secs (14707757 bytes/sec)

1GB Sparse:

    $ dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=2048k ostride=32
    2097152+0 records in
    2097152+0 records out
    1073741824 bytes transferred in 105.598897 secs (10168116 bytes/sec)

1GB Sparse with bash for loop:

    #
    # This run was actually cancelled due to its extraordinary slowness.
    # After 15 minutes and 50 seconds, the run had gotten to block offset
    # 1115584, which is only 1.66% of the way through the 1GB of output.
    #
    $ date; for i in `seq 1 2097152`; do
    > offset=$(( $i * 32 ))
    > dd if=/dev/urandom of=/ddtest/fs/f1 bs=512 count=1 seek=$offset 2>/dev/null
    > done; date
    August  6, 2014 05:44:08 PM UT
    ^C

Additionally, correctness of the new feature was verified using od:

  - Create the file:
```
      $ for i in seq 0 2048; do
      > dd if=<(echo $i) of=/tmp/ddfile bs=512 count=1 oseek=$i 2>/dev/null
      > done
      $ od -Ax -tx /tmp/ddfile
      000000 00000a30 00000000 00000000 00000000
      000010 00000000 00000000 00000000 00000000
      *
      000200 00000a31 00000000 00000000 00000000
      000210 00000000 00000000 00000000 00000000
      *
      000400 00000a32 00000000 00000000 00000000
      000410 00000000 00000000 00000000 00000000
      *
      000600 00000a33 00000000 00000000 00000000
      000610 00000000 00000000 00000000 00000000
      *
      ... <snip> ...
```
 - Test new "istride" feature:
```
      $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 istride=4 count=512 2>/dev/null
      $ od -Ax -tx /tmp/ddfile2
      000000 00000a30 00000000 00000000 00000000
      000010 00000000 00000000 00000000 00000000
      *
      000200 00000a34 00000000 00000000 00000000
      000210 00000000 00000000 00000000 00000000
      *
      000400 00000a38 00000000 00000000 00000000
      000410 00000000 00000000 00000000 00000000
      *
      ... <snip> ...
```
 - Test new "ostride" feature:
```
      $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 ostride=4 count=512 2>/dev/null
      $ od -Ax -tx /tmp/ddfile2
      000000 00000a30 00000000 00000000 00000000
      000010 00000000 00000000 00000000 00000000
      *
      000800 00000a31 00000000 00000000 00000000
      000810 00000000 00000000 00000000 00000000
      *
      001000 00000a32 00000000 00000000 00000000
      001010 00000000 00000000 00000000 00000000
      *
      ... <snip> ...
```
 - Test new "stride" feature:
```
      $ dd if=/tmp/ddfile of=/tmp/ddfile2 bs=512 stride=4 count=512 2>/dev/null
      $ od -Ax -tx /tmp/ddfile2
      000000 00000a30 00000000 00000000 00000000
      000010 00000000 00000000 00000000 00000000
      *
      000800 00000a34 00000000 00000000 00000000
      000810 00000000 00000000 00000000 00000000
      *
      001000 00000a38 00000000 00000000 00000000
      001010 00000000 00000000 00000000 00000000
      *
      ... <snip> ...
```
Upstream bugs: 37007, DLPX-34103