### PR TITLE
8108 zdb -l fails to read labels 2 and 3

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -2301,24 +2301,29 @@ dump_label(const char *dev)
 
 		(void) snprintf(path, sizeof (path), "%s%s", ZFS_RDISK_ROOTD,
 		    dev);
-		if ((s = strrchr(dev, 's')) == NULL || !isdigit(*(s + 1)))
+		if (((s = strrchr(dev, 's')) == NULL &&
+		    (s = strchr(dev, 'p')) == NULL) ||
+		    !isdigit(*(s + 1)))
 			(void) strlcat(path, "s0", sizeof (path));
 	}
 
-	if (stat64(path, &statbuf) != 0) {
-		(void) printf("failed to stat '%s': %s\n", path,
+	if ((fd = open64(path, O_RDONLY)) < 0) {
+		(void) fprintf(stderr, "cannot open '%s': %s\n", path,
 		    strerror(errno));
 		exit(1);
 	}
 
-	if (S_ISBLK(statbuf.st_mode)) {
-		(void) printf("cannot use '%s': character device required\n",
-		    path);
+	if (fstat64(fd, &statbuf) != 0) {
+		(void) fprintf(stderr, "failed to stat '%s': %s\n", path,
+		    strerror(errno));
+		(void) close(fd);
 		exit(1);
 	}
 
-	if ((fd = open64(path, O_RDONLY)) < 0) {
-		(void) printf("cannot open '%s': %s\n", path, strerror(errno));
+	if (S_ISBLK(statbuf.st_mode)) {
+		(void) fprintf(stderr,
+		    "cannot use '%s': character device required\n", path);
+		(void) close(fd);
 		exit(1);
 	}
 


### PR DESCRIPTION
I've introduced a regression in ```zdb -l``` while implementing #6866 - st_size is not defined for character special files, so we always had psize being 0 - fix the logic a bit to do a fstat64() after opening the device.

While here, make slice "autocompletion" a bit smarter, checking for p* as well, so if we specified ```zdb -l c0t0d0p0```, we'll use ```/dev/rdsk/c0t0d0p0``` and not ```/dev/rdsk/c0t0d0p0s0```.

Both reported by Toomas Soome.