### PR TITLE
8125 kmem_move tunables must not be declared static

### DIFF
--- a/usr/src/uts/common/os/kmem.c
+++ b/usr/src/uts/common/os/kmem.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1994, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  */
 
@@ -1113,10 +1113,10 @@ static struct {
 #endif	/* KMEM_STATS */
 
 /* consolidator knobs */
-static boolean_t kmem_move_noreap;
-static boolean_t kmem_move_blocked;
-static boolean_t kmem_move_fulltilt;
-static boolean_t kmem_move_any_partial;
+boolean_t kmem_move_noreap;
+boolean_t kmem_move_blocked;
+boolean_t kmem_move_fulltilt;
+boolean_t kmem_move_any_partial;
 
 #ifdef	DEBUG
 /*


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

The kmem_move_* tunables (e.g. kmem_move_noreap) are declared "static".
Because they are never set in the code, the compiler can consider them
constants and optimize them away - removing the code that checks them.

They must not be declared "static" to be used as tunables.

Upstream bugs: DLPX-50335