### PR TITLE
8149 deadlock between datalink deletion and kstat read

### DIFF
--- a/usr/src/pkg/manifests/system-test-ostest.mf
+++ b/usr/src/pkg/manifests/system-test-ostest.mf
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright (c) 2012 by Delphix. All rights reserved.
+# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
 # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2016, Joyent, Inc.
 #
@@ -29,6 +29,7 @@ dir path=opt/os-tests/tests/file-locking
 dir path=opt/os-tests/tests/sdevfs
 dir path=opt/os-tests/tests/secflags
 dir path=opt/os-tests/tests/sigqueue
+dir path=opt/os-tests/tests/stress
 file path=opt/os-tests/README mode=0444
 file path=opt/os-tests/bin/ostest mode=0555
 file path=opt/os-tests/runfiles/default.run mode=0444
@@ -56,6 +57,7 @@ file path=opt/os-tests/tests/secflags/secflags_zonecfg mode=0555
 file path=opt/os-tests/tests/secflags/stacky mode=0555
 file path=opt/os-tests/tests/sigqueue/sigqueue_queue_size mode=0555
 file path=opt/os-tests/tests/spoof-ras mode=0555
+file path=opt/os-tests/tests/stress/dladm-kstat mode=0555
 license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL
 depend fmri=system/test/testrunner type=require

--- a/usr/src/test/os-tests/runfiles/default.run
+++ b/usr/src/test/os-tests/runfiles/default.run
@@ -48,5 +48,9 @@ tests = ['sigqueue_queue_size']
 user = root
 tests = ['sdevfs_eisdir']
 
+[/opt/os-tests/tests/stress]
+user = root
+tests = ['dladm-kstat']
+
 [/opt/os-tests/tests/file-locking]
 tests = ['runtests.32', 'runtests.64']

--- a/usr/src/test/os-tests/tests/stress/Makefile
+++ b/usr/src/test/os-tests/tests/stress/Makefile
@@ -10,9 +10,33 @@
 #
 
 #
-# Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016 by Delphix. All rights reserved.
 #
 
-SUBDIRS = poll secflags sigqueue spoof-ras sdevfs stress file-locking
-
+include $(SRC)/cmd/Makefile.cmd
 include $(SRC)/test/Makefile.com
+
+PROG = dladm-kstat
+
+ROOTOPTPKG = $(ROOT)/opt/os-tests
+TESTDIR = $(ROOTOPTPKG)/tests/stress
+
+CMDS = $(PROG:%=$(TESTDIR)/%)
+$(CMDS) := FILEMODE = 0555
+
+all: $(PROG)
+
+install: all $(CMDS)
+
+clobber: clean
+
+clean:
+	-$(RM) $(PROG)
+
+$(CMDS): $(TESTDIR) $(PROG)
+
+$(TESTDIR):
+	$(INS.dir)
+
+$(TESTDIR)/%: %
+	$(INS.file)

--- a/usr/src/test/os-tests/tests/stress/dladm-kstat.sh
+++ b/usr/src/test/os-tests/tests/stress/dladm-kstat.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+#
+
+#
+# This test attempts to stress the interaction between threads adding
+# and deleting datalinks, and those reading kstats associated with
+# those datalinks.
+#
+
+RUNFILE=$(mktemp)
+linkname1=laverne0
+linkname2=shirley0
+duration=20 # seconds
+
+#
+# Delete any potential datalinks left behind by the etherstub function.
+#
+function cleanup
+{
+	rm -f $RUNFILE
+}
+
+function etherstub
+{
+	while [[ -e $RUNFILE ]]; do
+		dladm create-etherstub -t $linkname1
+		dladm rename-link $linkname1 $linkname2
+		dladm delete-etherstub -t $linkname2
+	done
+}
+
+function readkstat
+{
+	local linkname=$1
+	while [[ -e $RUNFILE ]]; do
+		kstat link:0:$linkname &>/dev/null
+	done
+}
+
+trap "cleanup; exit" SIGHUP SIGINT SIGTERM
+
+etherstub &
+readkstat $linkname1 &
+readkstat $linkname1 &
+readkstat $linkname2 &
+readkstat $linkname2 &
+
+sleep $duration
+cleanup
+
+wait
+
+exit 0


### PR DESCRIPTION
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

Problem
=======

Using the following stress test:

  - Thread 1: In a loop, create and delete etherstub datalinks using:

        dladm create-etherstub teststub0
        dladm delete-etherstub teststub0

  - Thread 2: In a loop, read the link kstat for teststub0.
  - Thread 3: Do the same thing as Thread 2

After a while of running the above (~30 seconds), a deadlock ensues,
where Thread 1 is stuck unkillably in `dladm delete-etherstub`, and the
other threads are stuck in the kernel, in `read_kstat_data()` (called
from the `KSTAT_IOC_READ` ioctl). The two kernel threads stuck are:

    ffffff03172f0b20 ffffff031d0bc028 ffffff036e341d00   1  59 ffffff038edd40c8
      PC: _resume_from_idle+0xf4    CMD: dladm delete-etherstub -t teststub0
      stack pointer for thread ffffff03172f0b20: ffffff000cd21810
      [ ffffff000cd21810 _resume_from_idle+0xf4() ]
        swtch+0x141()
        cv_wait+0x70()
        kstat_hold+0x4d()
        kstat_hold_bykid+0x37()
        kstat_delete+0x4e()
        dls_devnet_stat_destroy+0x59()
        dls_devnet_unset+0x1f3()
        dls_devnet_destroy+0x46()
        vnic_dev_delete+0x96()
        vnic_ioc_delete+0x28()
        drv_ioctl+0x1e4()
        cdev_ioctl+0x39()
        spec_ioctl+0x60()
        fop_ioctl+0x55()
        ioctl+0x9b()
        _sys_sysenter_post_swapgs+0x149()

    ffffff031733bb80 ffffff03188bb000 ffffff0315ad5380   1  59 ffffff0315b719d0
      PC: _resume_from_idle+0xf4    CMD: /opt/jdk1.8.0_60/bin/java ...
      stack pointer for thread ffffff031733bb80: ffffff000c3ea900
      [ ffffff000c3ea900 _resume_from_idle+0xf4() ]
        swtch+0x141()
        turnstile_block+0x21a()
        mutex_vector_enter+0x3a3()
        dls_devnet_stat_update+0x3c()
        read_kstat_data+0xd0()
        kstat_ioctl+0x83()
        cdev_ioctl+0x39()
        spec_ioctl+0x60()
        fop_ioctl+0x55()
        ioctl+0x9b()
        sys_syscall+0x17a()

Explanation
===========

This is a classic lock ordering problem. The sequence of events between
Thread 1 and Thread 2 that causes this deadlock is:

  1. Thread 1 calls dls_devnet_destroy() to delete the datalink. This
     in turn causes this sequence of calls:

         dls_devnet_unset()
           mutex_enter(ddp->dd_mutex)  <---- mutex aquired, function continues
           ...

    2. Thread 2 issues the `KSTAT_IOC_READ` ioctl, enters
       `read_kstat_data()`, which cause the following sequence of calls:

           kstat_hold_by_ktid()
           KSTAT_ENTER()
           KSTAT_UPDATE()
             dls_devnet_stat_update()
               mutex_enter(ddp->dd_mutex) <---- blocks due to Thread 1

    3. At this point, Thread 1 continues in `dls_devnet_unset()`:

           dls_devnet_stat_destroy()
             kstat_delete()
               kstat_hold_by_ktid()
                 cv_wait()                <----- waiting for Thread 2 to
                                                 signal that it has released
                                                 the kstat

At this point, Thread 1 and Thread 2 are deadlocked. Thread 1 is waiting
to be signaled by Thread 2, but Thread 2 is blocked waiting to acquire a
mutex that is held by Thread 1.

Solution
========

The fix is to always acquire a reference to a `dls_devnet_t` through the
same hash table lookup path so that lock ordering and destruction
semantics are always preserved. This means that instead of a back pointer
from `kstat_t` to `dls_devnet_t` (in the `ks_private` field), the
`ks_private` field will hold a `datalink_id_t` that will be used to call
`dls_devnet_hold_tmp()` to get at the `dls_devnet_t` in question.

This approach should have no performance impact, as the kstat update path
is not a datapath operation, the hash lookup is O(1), and the hash table
doesn't change frequently (only when datalinks are added or deleted).

tl;dr
=====

In summary, the statistic subsystem must use the `dls_devnet_hold_tmp()`
API to obtain a temporary reference to a `dls_devnet_t`. This API is
designed to enforce proper locking and locking order, and safe access to
these objects so that threads don't race with deletions or renames.

This means that instead of having a direct back-pointer from a `kstat_t`
to a `dls_devnet_t` (`ks_private`), the `ks_private` field contains a
datalink ID which is used to lookup the `dls_devnet_t` using
`dls_devnet_hold_tmp()`.

Doing this allowed me to remove one ugly hack: Use of the
`DD_KSTAT_CHANGING` flag. I can remove this and all uses of it since
`dls_devnet_hold_tmp()` is designed to safely access datalinks that are
being renamed (unlike the old back-door access).

While I was in `dls_mgmt.c`, I noticed two `rw_enter()` calls that were
erroneously entering as writer instead of reader. I fixed those while I
was there.

Upstream bugs: DLPX-46888