### PR TITLE
WIP: Create the AMI prior to stopping the instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,15 +104,15 @@ node('master') {
         }
 
         stage('create image') {
-            shscript('aws-stop-instances', false, [
-                ['REGION', env.REGION],
-                ['INSTANCE_ID', env.BUILD_INSTANCE_ID]
-            ])
-
             env.BUILD_IMAGE_ID = shscript('aws-create-image', true, [
                 ['REGION', env.REGION],
                 ['INSTANCE_ID', env.BUILD_INSTANCE_ID]
             ]).trim()
+
+            shscript('aws-stop-instances', false, [
+                ['REGION', env.REGION],
+                ['INSTANCE_ID', env.BUILD_INSTANCE_ID]
+            ])
         }
 
         stage('run tests') {


### PR DESCRIPTION
This isn't intended to be landed, instead it's simply an experiement to
see if it's actually required to stop the build instance prior to
creating an AMI from it.