### PR TITLE
Add "zpool_add_002_pos" to known zfstest failures

### DIFF
--- a/jenkins/sh/run-zfs-tests/zfstest-report.py
+++ b/jenkins/sh/run-zfs-tests/zfstest-report.py
@@ -55,6 +55,7 @@ known = {
     'cli_root/zfs_property/zfs_written_property_001_pos': 'FAIL',
     'cli_root/zfs_snapshot/zfs_snapshot_009_pos': 'FAIL',
     'cli_root/zpool_add/zpool_add_001_pos': 'FAIL',
+    'cli_root/zpool_add/zpool_add_002_pos': 'FAIL',
     'cli_root/zpool_clear/zpool_clear_001_pos': 'FAIL',
     'cli_root/zpool_expand/zpool_expand_001_pos': 'FAIL',
     'cli_root/zpool_get/zpool_get_002_pos': 'FAIL',


### PR DESCRIPTION
The "zpool_add_002_pos" has been seen to sporadically fail with the
following error messages when it does:

    Test: /opt/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add_002_pos (run as root) [00:19] [FAIL]
    00:51:54.70 ASSERTION: 'zpool add -f <pool> <vdev> ...' can successfully add devices to the pool in some cases.
    00:51:54.79 cannot create 'testpool': one or more devices is currently unavailable
    00:51:54.79 ERROR: zpool create -f testpool mirror c4t1d0s0 c4t1d0s1 exited 1

The failure generally isn't related to the patch under test, so this
change adds it to the list of known zfstest failures.