### PR TITLE
8100 8021 seems to cause random BAD TRAP: type=d (#gp General protection)

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -143,6 +143,7 @@ dir path=opt/zfs-tests/tests/functional/xattr
 dir path=opt/zfs-tests/tests/functional/zvol
 dir path=opt/zfs-tests/tests/functional/zvol/zvol_ENOSPC
 dir path=opt/zfs-tests/tests/functional/zvol/zvol_cli
+dir path=opt/zfs-tests/tests/functional/zvol/zvol_dump
 dir path=opt/zfs-tests/tests/functional/zvol/zvol_misc
 dir path=opt/zfs-tests/tests/functional/zvol/zvol_swap
 dir path=opt/zfs-tests/tests/perf
@@ -2262,6 +2263,8 @@ file path=opt/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli_002_pos \
 file path=opt/zfs-tests/tests/functional/zvol/zvol_cli/zvol_cli_003_neg \
     mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_common.shlib mode=0444
+file path=opt/zfs-tests/tests/functional/zvol/zvol_dump/zvol_dump_raidz \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/setup mode=0555
 file path=opt/zfs-tests/tests/functional/zvol/zvol_misc/zvol_misc_001_neg \

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -558,6 +558,11 @@ tests = ['zvol_ENOSPC_001_pos']
 [/opt/zfs-tests/tests/functional/zvol/zvol_cli]
 tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
+[/opt/zfs-tests/tests/functional/zvol/zvol_dump]
+tests = ['zvol_dump_raidz']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -554,6 +554,11 @@ tests = ['zvol_ENOSPC_001_pos']
 [/opt/zfs-tests/tests/functional/zvol/zvol_cli]
 tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
+[/opt/zfs-tests/tests/functional/zvol/zvol_dump]
+tests = ['zvol_dump_raidz']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -554,6 +554,11 @@ tests = ['zvol_ENOSPC_001_pos']
 [/opt/zfs-tests/tests/functional/zvol/zvol_cli]
 tests = ['zvol_cli_001_pos', 'zvol_cli_002_pos', 'zvol_cli_003_neg']
 
+[/opt/zfs-tests/tests/functional/zvol/zvol_dump]
+tests = ['zvol_dump_raidz']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/zvol/zvol_misc]
 tests = ['zvol_misc_001_neg', 'zvol_misc_002_pos', 'zvol_misc_003_neg',
     'zvol_misc_004_pos', 'zvol_misc_005_neg', 'zvol_misc_006_pos']

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_dump/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_dump/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/zvol/zvol_dump
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/zvol/zvol_dump/zvol_dump_raidz.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/zvol/zvol_dump/zvol_dump_raidz.ksh
@@ -1,0 +1,54 @@
+#!/usr/bin/ksh -p
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+# Attempt to access a dump device on a RAID-Z pool.
+#
+# STRATEGY:
+# 1. Create a RAID-Z pool.
+# 2. Create a zvol on that pool called "dump".
+# 3. Configure it with "dumpadm".
+# 4. Attempt to issue reads and writes to it.
+#
+
+# Save the current dump device so we can restore it after the test.
+orig_dump_device=$(dumpadm | awk '/Dump device/ { print $3 }')
+
+function cleanup
+{
+	log_must dumpadm -u -d $orig_dump_device
+	log_must zpool destroy -f $TESTPOOL
+}
+
+log_onexit cleanup
+
+DISK1="$(echo $DISKS | cut -d' ' -f1)"
+DISK2="$(echo $DISKS | cut -d' ' -f2)"
+DISK3="$(echo $DISKS | cut -d' ' -f3)"
+
+log_must zpool create -f $TESTPOOL raidz $DISK1 $DISK2 $DISK3
+log_must zfs create -V 8G $TESTPOOL/dump
+
+log_must dumpadm -u -d /dev/zvol/dsk/$TESTPOOL/dump
+
+log_must dd if=/dev/zvol/dsk/$TESTPOOL/dump of=/dev/null bs=1M count=1
+log_must dd if=/dev/urandom of=/dev/zvol/dsk/$TESTPOOL/dump bs=1M count=1
+
+log_pass "Reads and writes to the dump device on a RAID-Z pool were successful"


### PR DESCRIPTION
I made a mistake in [this line](https://github.com/openzfs/openzfs/commit/2c9df17e7833028517263307ab877871c829e9a2#diff-826708a55165ad963711ccae15edaad6R1850) from the original ABD integration, where for I/O to RAID-Z dump devices I passed an `abd_t` where I meant to pass the data buffer associated with it.

I also audited the rest of the ABD / RAID-Z interactions (so the full diff includes a couple of small cleanups elsewhere in that code, but only the one correctness fix above), and added a test case for reading and writing RAID-Z dump devices.