### PR TITLE
Add "zpool_create_016_pos" to known zfstest failures

### DIFF
--- a/jenkins/sh/run-zfs-tests/zfstest-report.py
+++ b/jenkins/sh/run-zfs-tests/zfstest-report.py
@@ -57,6 +57,7 @@ known = {
     'cli_root/zpool_add/zpool_add_001_pos': 'FAIL',
     'cli_root/zpool_add/zpool_add_002_pos': 'FAIL',
     'cli_root/zpool_clear/zpool_clear_001_pos': 'FAIL',
+    'cli_root/zpool_create/zpool_create_016_pos': 'FAIL',
     'cli_root/zpool_expand/zpool_expand_001_pos': 'FAIL',
     'cli_root/zpool_get/zpool_get_002_pos': 'FAIL',
     'delegate/zfs_allow_007_pos': 'FAIL',


### PR DESCRIPTION
The "zpool_create_016_pos" test will sporadically fail with the message:

    Test: /opt/zfs-tests/tests/functional/cli_root/zpool_create/zpool_create_016_pos (run as root) [00:00] [FAIL]
    01:53:51.76 ASSERTION: 'zpool create' should success with no device in swap.
    01:53:51.76 NOTE: Executing: swap -d /dev/zvol/dsk/rpool/swap
    01:53:51.78 NOTE: Performing local cleanup via log_onexit (cleanup)
    01:53:51.88 SUCCESS: swapadd /tmp/fstab_342474
    01:53:51.89 SUCCESS: dumpadm -u -d /dev/zvol/dsk/rpool/dump
    01:53:51.89 Unable to delete swap device /dev/zvol/dsk/rpool/swap because of insufficient RAM

This failure generally isn't due to the code being tested, so this
change adds it to the list of known zfstest failures.