### PR TITLE
8265 Reserve send stream flag for large dnode feature

### DIFF
--- a/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
@@ -93,6 +93,7 @@ typedef enum drr_headertype {
 #define	DMU_BACKUP_FEATURE_RESUMING		(1 << 20)
 /* flag #21 is reserved for a Delphix feature */
 #define	DMU_BACKUP_FEATURE_COMPRESSED		(1 << 22)
+/* flag #23 is reserved for the large dnode feature */
 
 /*
  * Mask of all supported backup features


### PR DESCRIPTION
Reserve bit 23 in the zfs send stream flags for the large
dnode feature which has been implemented for Linux.

https://github.com/zfsonlinux/zfs/pull/3542