### PR TITLE
8380 Assertion failure panic in zio_buf_alloc()

### DIFF
--- a/usr/src/uts/common/fs/zfs/dnode.c
+++ b/usr/src/uts/common/fs/zfs/dnode.c
@@ -435,6 +435,7 @@ dnode_create(objset_t *os, dnode_phys_t *dnp, dmu_buf_impl_t *db,
 	dn->dn_maxblkid = dnp->dn_maxblkid;
 	dn->dn_have_spill = ((dnp->dn_flags & DNODE_FLAG_SPILL_BLKPTR) != 0);
 	dn->dn_id_flags = 0;
+	dn->dn_origin_obj_refd = 0;
 
 	dmu_zfetch_init(&dn->dn_zfetch, dn);
 


### PR DESCRIPTION
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

We need to initialize the dn_origin_obj_refd field of a dnode when it
is allocated from the kmem cache (or, alternatively, when it is free'd
to the cache), in order to prevent a newly allocated dnode from
inheriting the value of a previously free'd dnode.