### PR TITLE
8204 Makefile changes in zfstest cannot cope with empty directories

### DIFF
--- a/usr/src/test/Makefile.com
+++ b/usr/src/test/Makefile.com
@@ -30,6 +30,10 @@ lint_SRCS:
 	$(LINT.c) $(SRCS) $(LDLIBS)
 
 $(SUBDIRS): FRC
-	@cd $@; pwd; $(MAKE) $(TARGET)
+	@if [ -f $@/Makefile  ]; then \
+		cd $@; pwd; $(MAKE) $(TARGET); \
+	else \
+		true; \
+	fi
 
 FRC:


### PR DESCRIPTION
Do a simple test for Makefile existence, same as done in usr/src/lib/Makefile.