### PR TITLE
8408 dsl_props_set_sync_impl() does not handle nested nvlists correctly

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -722,6 +722,9 @@ file \
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_013_pos \
     mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_014_pos \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_rename/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_rename/setup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.cfg \

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -153,7 +153,7 @@ tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_005_neg', 'zfs_receive_006_pos',
     'zfs_receive_007_neg', 'zfs_receive_008_pos', 'zfs_receive_009_neg',
     'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
-    'zfs_receive_013_pos']
+    'zfs_receive_013_pos', 'zfs_receive_014_pos']
 
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rename]
 tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -151,7 +151,8 @@ tests = ['zfs_written_property_001_pos']
 tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_005_neg', 'zfs_receive_006_pos',
     'zfs_receive_007_neg', 'zfs_receive_008_pos', 'zfs_receive_009_neg',
-    'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos']
+    'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
+    'zfs_receive_014_pos']
 
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rename]
 tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -151,7 +151,8 @@ tests = ['zfs_written_property_001_pos']
 tests = ['zfs_receive_001_pos', 'zfs_receive_002_pos', 'zfs_receive_003_pos',
     'zfs_receive_005_neg', 'zfs_receive_006_pos',
     'zfs_receive_007_neg', 'zfs_receive_008_pos', 'zfs_receive_009_neg',
-    'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos']
+    'zfs_receive_010_pos', 'zfs_receive_011_pos', 'zfs_receive_012_pos',
+    'zfs_receive_014_pos']
 
 [/opt/zfs-tests/tests/functional/cli_root/zfs_rename]
 tests = ['zfs_rename_001_pos', 'zfs_rename_002_pos', 'zfs_rename_003_pos',

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_014_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_receive/zfs_receive_014_pos.ksh
@@ -1,0 +1,122 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_set/zfs_set_common.kshlib
+
+#
+# DESCRIPTION:
+# Verify ZFS successfully receive and restore properties.
+#
+# STRATEGY:
+# 1. Create a filesystem.
+# 2. Create a full stream with properties and receive it.
+# 3. Create also an incremental stream without some properties and a truncated
+#    stream.
+# 4. Fail to receive the truncated incremental stream and verify previously
+#    received properties are still present.
+# 5. Receive the complete incremental send stream and verify that sent
+#    properties are successfully received.
+#
+
+verify_runnable "both"
+
+orig=$TESTPOOL/$TESTFS1
+dest=$TESTPOOL/$TESTFS2
+typeset userprop=$(valid_user_property 8)
+typeset userval=$(user_property_value 8)
+typeset streamfile_full=$TESTDIR/streamfile_full.$$
+typeset streamfile_incr=$TESTDIR/streamfile_incr.$$
+typeset streamfile_trun=$TESTDIR/streamfile_trun.$$
+
+function cleanup
+{
+	log_must rm $streamfile_full
+	log_must rm $streamfile_incr
+	log_must rm $streamfile_trun
+	log_must zfs destroy -rf $orig
+	log_must zfs destroy -rf $dest
+}
+
+#
+# Verify property $2 is set from source $4 on dataset $1 and has value $3.
+#
+# $1 checked dataset
+# $2 user property
+# $3 property value
+# $4 source
+#
+function check_prop_source
+{
+	typeset dataset=$1
+	typeset prop=$2
+	typeset value=$3
+	typeset source=$4
+	typeset chk_value=$(get_prop "$prop" "$dataset")
+	typeset chk_source=$(get_source "$prop" "$dataset")
+	if [[ "$chk_value" != "$value" || \
+	    "$chk_source" != "$4" ]]
+	then
+		return 1
+	else
+		return 0
+	fi
+}
+
+log_assert "ZFS successfully receive and restore properties."
+log_onexit cleanup
+
+# 1. Create a filesystem.
+log_must eval "zfs create $orig"
+mntpnt=$(get_prop mountpoint $orig)
+
+# 2. Create a full stream with properties and receive it.
+log_must eval "zfs set compression='gzip-1' $orig"
+log_must eval "zfs set '$userprop'='$userval' $orig"
+log_must eval "zfs snapshot $orig@snap1"
+log_must eval "zfs send -p $orig@snap1 > $streamfile_full"
+log_must eval "zfs recv $dest < $streamfile_full"
+log_must eval "check_prop_source $dest compression 'gzip-1' received"
+log_must eval "check_prop_source $dest '$userprop' '$userval' received"
+
+# 3. Create also an incremental stream without some properties and a truncated
+#    stream.
+log_must eval "zfs set compression='gzip-2' $orig"
+log_must eval "zfs inherit '$userprop' $orig"
+log_must eval "dd if=/dev/urandom of=$mntpnt/file bs=1024k count=10"
+log_must eval "zfs snapshot $orig@snap2"
+log_must eval "zfs send -p -i $orig@snap1 $orig@snap2 > $streamfile_incr"
+log_must eval "dd if=$streamfile_incr of=$streamfile_trun bs=1024k count=9"
+log_must eval "zfs snapshot $orig@snap3"
+log_must eval "zfs send -p -i $orig@snap1 $orig@snap3 > $streamfile_incr"
+
+# 4. Fail to receive the truncated incremental stream and verify previously
+#    received properties are still present.
+log_mustnot eval "zfs recv -F $dest < $streamfile_trun"
+log_must eval "check_prop_source $dest compression 'gzip-1' received"
+log_must eval "check_prop_source $dest '$userprop' '$userval' received"
+
+# 5. Receive the complete incremental send stream and verify that sent
+#    properties are successfully received.
+log_must eval "zfs recv -F $dest < $streamfile_incr"
+log_must eval "check_prop_source $dest compression 'gzip-2' received"
+log_must eval "check_prop_source $dest '$userprop' '-' '-'"
+
+log_pass "ZFS properties are successfully received and restored."

--- a/usr/src/uts/common/fs/zfs/dsl_prop.c
+++ b/usr/src/uts/common/fs/zfs/dsl_prop.c
@@ -855,11 +855,15 @@ dsl_props_set_sync_impl(dsl_dataset_t *ds, zprop_source_t source,
 
 	while ((elem = nvlist_next_nvpair(props, elem)) != NULL) {
 		nvpair_t *pair = elem;
+		const char *name = nvpair_name(pair);
 
 		if (nvpair_type(pair) == DATA_TYPE_NVLIST) {
 			/*
-			 * dsl_prop_get_all_impl() returns properties in this
-			 * format.
+			 * This usually happens when we reuse the nvlist_t data
+			 * returned by the counterpart dsl_prop_get_all_impl().
+			 * For instance we do this to restore the original
+			 * received properties when an error occurs in the
+			 * zfs_ioc_recv() codepath.
 			 */
 			nvlist_t *attrs = fnvpair_value_nvlist(pair);
 			pair = fnvlist_lookup_nvpair(attrs, ZPROP_VALUE);
@@ -867,14 +871,14 @@ dsl_props_set_sync_impl(dsl_dataset_t *ds, zprop_source_t source,
 
 		if (nvpair_type(pair) == DATA_TYPE_STRING) {
 			const char *value = fnvpair_value_string(pair);
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, 1, strlen(value) + 1, value, tx);
 		} else if (nvpair_type(pair) == DATA_TYPE_UINT64) {
 			uint64_t intval = fnvpair_value_uint64(pair);
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, sizeof (intval), 1, &intval, tx);
 		} else if (nvpair_type(pair) == DATA_TYPE_BOOLEAN) {
-			dsl_prop_set_sync_impl(ds, nvpair_name(pair),
+			dsl_prop_set_sync_impl(ds, name,
 			    source, 0, 0, NULL, tx);
 		} else {
 			panic("invalid nvpair type");


### PR DESCRIPTION
When iterating over the input nvlist in `dsl_props_set_sync_impl()` when we don't preserve the nvpair name before looking up `ZPROP_VALUE`, so when we later go to process it `nvpair_name()` is always "value" instead of the actual property name.

These are properties set on a filesystem when failing to receive a truncated stream:
```
[root@52-54-00-d3-7a-01 ~]# zdb -dddd testpool 49
Dataset mos [META], ID 0, cr_txg 4, 114K, 64 objects, rootbp DVA[0]=<0:17b2e00:200> DVA[1]=<0:17b3000:200> DVA[2]=<0:17b3200:200> [L0 DMU objset] fletcher4 lz4 LE contiguous unique triple size=800L/200P birth=498L/498P fill=64 cksum=11413d065e:672e12e9d76:13ff1f57e066a:2ac3890cc2454c

    Object  lvl   iblk   dblk  dsize  lsize   %full  type
        49    1   128K    512      0    512  100.00  DSL props
    dnode flags: USED_BYTES 
    dnode maxblkid: 0
    microzap: 512 bytes, 2 entries

        value$recvd = 1 
        $hasrecvd = 0
```

References: https://github.com/zfsonlinux/zfs/pull/5497

Reproducer: 

```
# misc functions
function is_linux() {
   if [[ "$(uname)" == "Linux" ]]; then
      return 0
   else
      return 1
   fi
}
# setup
POOLNAME='testpool'
if is_linux; then
   TMPDIR='/var/tmp'
   mountpoint -q $TMPDIR || mount -t tmpfs tmpfs $TMPDIR
   zpool destroy $POOLNAME
   fallocate -l 65m $TMPDIR/zpool.dat
   zpool create $POOLNAME $TMPDIR/zpool.dat
else
   TMPDIR='/tmp'
   zpool destroy $POOLNAME
   mkfile 65m $TMPDIR/zpool.dat
   zpool create $POOLNAME $TMPDIR/zpool.dat
fi
# send first stream, received compression is 'on'
zfs create $POOLNAME/send
zfs set compression=on $POOLNAME/send
zfs snap $POOLNAME/send@snap1
zfs send -p $POOLNAME/send@snap1 > $TMPDIR/snap_full.dat
zfs recv $POOLNAME/recv < $TMPDIR/snap_full.dat
zfs get -o all compression $POOLNAME/recv
# send second stream, compression is 'lz4'
zfs set compression=lz4 $POOLNAME/send
dd if=/dev/urandom of=/$POOLNAME/send/urandom bs=1M count=10
zfs snap $POOLNAME/send@snap2
zfs send -pI $POOLNAME/send@snap1 $POOLNAME/send@snap2 > $TMPDIR/snap_incr.dat
# truncate the stream, fail to receive incremental
dd if=/dev/null of=$TMPDIR/snap_incr.dat bs=1 count=1 seek=9M
zfs recv -F $POOLNAME/recv < $TMPDIR/snap_incr.dat
# zfs receive failed, compression should be 'on'
zfs get -o all compression $POOLNAME/recv
```