### PR TITLE
Use segkpm for single-page slabs

### DIFF
--- a/usr/src/uts/common/sys/vmem.h
+++ b/usr/src/uts/common/sys/vmem.h
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 1999, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
  */
 
 #ifndef _SYS_VMEM_H
@@ -66,6 +66,15 @@ extern "C" {
  * Has no effect if VM_NEXTFIT is active.
  */
 #define	VM_ENDALLOC	0x00004000
+
+/*
+ * flag that can be passed to segkmem_alloc() to indicate that
+ * a segkpm address can be returned.  Note that such pages will not be
+ * included in the dump, because they do not have page table entries.
+ * Even if the pages were dumped, mdb doesn't recognize segkpm addresses,
+ * so they couldn't be dereferenced.
+ */
+#define	VM_KPM_OK	0x00008000
 
 #define	VM_FLAGS	0x0000FFFF
 

--- a/usr/src/uts/i86pc/os/startup.c
+++ b/usr/src/uts/i86pc/os/startup.c
@@ -23,7 +23,7 @@
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2015 Joyent, Inc.
- * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2017 by Delphix. All rights reserved.
  */
 /*
  * Copyright (c) 2010, Intel Corporation.
@@ -758,7 +758,7 @@ startup(void)
 	extern cpuset_t cpu_ready_set;
 
 	/*
-	 * Make sure that nobody tries to use sekpm until we have
+	 * Make sure that nobody tries to use segkpm until we have
 	 * initialized it properly.
 	 */
 #if defined(__amd64)


### PR DESCRIPTION
I'm not an expert in the VM system so I'm looking for input on if this potential change is a good idea or not.  The idea is to use segkpm (the mapping of all of physical memory) to reference single-page slabs, rather than setting up and tearing down new TLB mappings in the kernel's heap.

This roughly doubles the performance of kmem_reap() of impacted caches.  We only do this for ZFS's caches, because they are not dumped.  More work would be required to dump these pages, and to allow mdb to access them via segkpm.

I noticed that seg_map has code to do something similar, but it's disabled on x86 (segmap_kpm=0).  So I was wondering if there's something wrong with this approach?  Unfortunately there weren't any comments explaining *why* it's disabled on x86.

