### PR TITLE
8426 mark immutable buffer arguments as such in abd.h

### DIFF
--- a/usr/src/uts/common/fs/zfs/sys/abd.h
+++ b/usr/src/uts/common/fs/zfs/sys/abd.h
@@ -113,7 +113,7 @@ abd_copy(abd_t *dabd, abd_t *sabd, size_t size)
 }
 
 inline void
-abd_copy_from_buf(abd_t *abd, void *buf, size_t size)
+abd_copy_from_buf(abd_t *abd, const void *buf, size_t size)
 {
 	abd_copy_from_buf_off(abd, buf, 0, size);
 }
@@ -125,7 +125,7 @@ abd_copy_to_buf(void* buf, abd_t *abd, size_t size)
 }
 
 inline int
-abd_cmp_buf(abd_t *abd, void *buf, size_t size)
+abd_cmp_buf(abd_t *abd, const void *buf, size_t size)
 {
 	return (abd_cmp_buf_off(abd, buf, 0, size));
 }


### PR DESCRIPTION
https://www.illumos.org/issues/8426