### PR TITLE
8430 dir_is_empty_readdir() doesn't properly handle error from fdopendir()

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -210,6 +210,7 @@ dir_is_empty_readdir(const char *dirname)
 	}
 
 	if ((dirp = fdopendir(dirfd)) == NULL) {
+		(void) close(dirfd);
 		return (B_TRUE);
 	}
 


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>

dir_is_empty_readdir() immediately returns if fdopendir() fails.
We should close dirfd when that happens.