### PR TITLE
8435 zpool.1m and zfs.1m: minor cleanup 

### DIFF
--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -341,7 +341,7 @@ intervals.
 The visibility of the
 .Pa .zfs
 directory can be controlled by the
-snapdir
+.Sy snapdir
 property.
 .Ss Clones
 A clone is a writable volume or file system whose initial contents are the same
@@ -1358,7 +1358,7 @@ bytes in the dataset.
 This property can also be referred to by its shortened column name,
 .Sy refreserv .
 .It Sy reservation Ns = Ns Em size Ns | Ns Sy none
-The minimum amount of space guaranteed to a dataset and its descendents.
+The minimum amount of space guaranteed to a dataset and its descendants.
 When the amount of space used is below this value, the dataset is treated as if
 it were taking up the amount of space specified by its reservation.
 Reservations are accounted for in the parent datasets' space used, and count
@@ -1410,7 +1410,7 @@ command is invoked with options equivalent to the contents of this property.
 Because SMB shares requires a resource name, a unique resource name is
 constructed from the dataset name.
 The constructed name is a copy of the dataset name except that the characters in
-the dataset name, which would be illegal in the resource name, are replaced with
+the dataset name, which would be invalid in the resource name, are replaced with
 underscore
 .Pq Sy _
 characters.
@@ -2116,7 +2116,8 @@ subcommand can be used to rename any conflicting snapshots.
 .Op Fl f
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
-.br
+.Xc
+.It Xo
 .Nm
 .Cm rename
 .Op Fl fp
@@ -2909,7 +2910,8 @@ for more details.
 .Op Fl Fnsuv
 .Op Fl o Sy origin Ns = Ns Ar snapshot
 .Ar filesystem Ns | Ns Ar volume Ns | Ns Ar snapshot
-.br
+.Xc
+.It Xo
 .Nm
 .Cm receive
 .Op Fl Fnsuv
@@ -3145,31 +3147,35 @@ property.
 The following permissions are available:
 .Bd -literal
 NAME             TYPE           NOTES
-allow            subcommand     Must also have the permission that is being
-                                allowed
-clone            subcommand     Must also have the 'create' ability and 'mount'
-                                ability in the origin file system
+allow            subcommand     Must also have the permission that is
+                                being allowed
+clone            subcommand     Must also have the 'create' ability and
+                                'mount' ability in the origin file system
 create           subcommand     Must also have the 'mount' ability
 destroy          subcommand     Must also have the 'mount' ability
 diff             subcommand     Allows lookup of paths within a dataset
-                                given an object number, and the ability to
-                                create snapshots necessary to 'zfs diff'.
+                                given an object number, and the ability
+                                to create snapshots necessary to
+                                'zfs diff'.
 mount            subcommand     Allows mount/umount of ZFS datasets
-promote          subcommand     Must also have the 'mount'
-                                and 'promote' ability in the origin file system
-receive          subcommand     Must also have the 'mount' and 'create' ability
+promote          subcommand     Must also have the 'mount' and 'promote'
+                                ability in the origin file system
+receive          subcommand     Must also have the 'mount' and 'create'
+                                ability
 rename           subcommand     Must also have the 'mount' and 'create'
                                 ability in the new parent
 rollback         subcommand     Must also have the 'mount' ability
 send             subcommand
-share            subcommand     Allows sharing file systems over NFS or SMB
-                                protocols
+share            subcommand     Allows sharing file systems over NFS
+                                or SMB protocols
 snapshot         subcommand     Must also have the 'mount' ability
 
-groupquota       other          Allows accessing any groupquota@... property
+groupquota       other          Allows accessing any groupquota@...
+                                property
 groupused        other          Allows reading any groupused@... property
 userprop         other          Allows changing any user property
-userquota        other          Allows accessing any userquota@... property
+userquota        other          Allows accessing any userquota@...
+                                property
 userused         other          Allows reading any userused@... property
 
 aclinherit       property

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -23,8 +23,9 @@
 .\" Copyright (c) 2013 by Delphix. All rights reserved.
 .\" Copyright 2017 Nexenta Systems, Inc.
 .\" Copyright (c) 2017 Datto Inc.
+.\" Copyright (c) 2017 George Melikov. All Rights Reserved.
 .\"
-.Dd June 21, 2017
+.Dd August 23, 2017
 .Dt ZPOOL 1M
 .Os
 .Sh NAME
@@ -389,7 +390,7 @@ If a pool has a shared spare that is currently being used, the pool can not be
 exported since other pools may use this shared spare, which may lead to
 potential data corruption.
 .Pp
-An in-progress spare replacement can be cancelled by detaching the hot spare.
+An in-progress spare replacement can be canceled by detaching the hot spare.
 If the original faulted device is detached, then the hot spare assumes its
 place in the configuration, and is removed from the spare list of all active
 pools.
@@ -661,7 +662,7 @@ to the enabled state.
 See
 .Xr zpool-features 5
 for details on feature states.
-.It Sy listsnaps Ns = Ns Sy on Ns | Ns Sy off
+.It Sy listsnapshots Ns = Ns Sy on Ns | Ns Sy off
 Controls whether information about snapshots associated with this pool is
 output when
 .Nm zfs Cm list
@@ -670,6 +671,8 @@ is run without the
 option.
 The default value is
 .Sy off .
+This property can also be referred to by its shortened name,
+.Sy listsnaps .
 .It Sy version Ns = Ns Ar version
 The current on-disk version of the pool.
 This can be increased, but never decreased.
@@ -677,7 +680,7 @@ The preferred method of updating pools is with the
 .Nm zpool Cm upgrade
 command, though this property can be used when a specific version is needed for
 backwards compatibility.
-Once feature flags is enabled on a pool this property will no longer have a
+Once feature flags are enabled on a pool this property will no longer have a
 value.
 .El
 .Ss Subcommands
@@ -1541,7 +1544,7 @@ for
 .Ar newpool
 to
 .Ar root
-and automaticaly import it.
+and automatically import it.
 .El
 .It Xo
 .Nm
@@ -1606,7 +1609,7 @@ to enable all features on all pools.
 .Fl v
 .Xc
 Displays legacy ZFS versions supported by the current software.
- See
+See
 .Xr zpool-features 5
 for a description of feature flags features supported by the current software.
 .It Xo
@@ -1746,7 +1749,7 @@ The failed device can be replaced using the following command:
 .Ed
 .Pp
 Once the data has been resilvered, the spare is automatically removed and is
-made available should another device fails.
+made available for use should another device fail.
 The hot spare can be permanently removed from the pool using the following
 command:
 .Bd -literal
@@ -1806,7 +1809,7 @@ is:
 # zpool remove tank mirror-2
 .Ed
 .It Sy Example 15 No Displaying expanded space on a device
-The following command dipslays the detailed information for the pool
+The following command displays the detailed information for the pool
 .Em data .
 This pool is comprised of a single raidz vdev where one of its devices
 increased its capacity by 10GB.


### PR DESCRIPTION
This commit is a result of re-read while porting zpool.1m to ZFSonLinux.

See https://github.com/zfsonlinux/zfs/commit/cda0317e4d2a1277b328e4fc42ee3699bbe46c12

Signed-off-by: George Melikov <mail@gmelikov.ru>
Closes #8435
Closes #3796