### PR TITLE
8477 Assertion failed in vdev_state_dirty(): spa_writeable(spa)

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -1290,6 +1290,9 @@ file \
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_003_neg \
     mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_readonly \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_create/cleanup \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_create/setup mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -230,7 +230,8 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
 tests = ['zpool_attach_001_neg']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear_readonly']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -221,7 +221,8 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
 tests = ['zpool_attach_001_neg']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear_readonly']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -221,7 +221,8 @@ tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
 tests = ['zpool_attach_001_neg']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_clear]
-tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg']
+tests = ['zpool_clear_001_pos', 'zpool_clear_002_neg', 'zpool_clear_003_neg',
+    'zpool_clear_readonly']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_create]
 tests = ['zpool_create_001_pos', 'zpool_create_002_pos',

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_readonly.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_clear/zpool_clear_readonly.ksh
@@ -1,0 +1,71 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_clear/zpool_clear.cfg
+
+#
+# DESCRIPTION:
+# Verify 'zpool clear' cannot be used on readonly pools.
+#
+# STRATEGY:
+# 1. Create a pool.
+# 2. Export the pool and import it readonly.
+# 3. Verify 'zpool clear' on the pool (and each device) returns an error.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	destroy_pool $TESTPOOL1
+	rm -f $TESTDIR/file.*
+}
+
+log_assert "Verify 'zpool clear' cannot be used on readonly pools."
+log_onexit cleanup
+
+# 1. Create a pool.
+log_must truncate -s $FILESIZE $TESTDIR/file.{1,2,3}
+log_must zpool create $TESTPOOL1 raidz $TESTDIR/file.*
+
+# 2. Export the pool and import it readonly.
+log_must zpool export $TESTPOOL1
+log_must zpool import -d $TESTDIR -o readonly=on $TESTPOOL1
+if [[ "$(get_pool_prop readonly $TESTPOOL1)" != 'on' ]]; then
+	log_fail "Pool $TESTPOOL1 was not imported readonly."
+fi
+
+# 3. Verify 'zpool clear' on the pool (and each device) returns an error.
+log_mustnot zpool clear $TESTPOOL1
+for i in {1..3}; do
+	# Device must be online
+	log_must check_state $TESTPOOL1 $TESTDIR/file.$i 'online'
+	# Device cannot be cleared if the pool was imported readonly
+	log_mustnot zpool clear $TESTPOOL1 $TESTDIR/file.$i
+done
+
+log_pass "'zpool clear' fails on readonly pools as expected."

--- a/usr/src/uts/common/fs/zfs/zfs_ioctl.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ioctl.c
@@ -5869,7 +5869,7 @@ zfs_ioctl_init(void)
 	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_NONE);
 
 	zfs_ioctl_register_pool(ZFS_IOC_CLEAR, zfs_ioc_clear,
-	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_NONE);
+	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_READONLY);
 	zfs_ioctl_register_pool(ZFS_IOC_POOL_REOPEN, zfs_ioc_pool_reopen,
 	    zfs_secpolicy_config, B_TRUE, POOL_CHECK_SUSPENDED);
 


### PR DESCRIPTION
Illumos 4080 inadvertently allows `zpool clear` on readonly pools: fix this by reintroducing a check (`POOL_CHECK_READONLY`) in the `zfs_ioc_clear` registration code. Because i don't think we should be allowed to clear readonly pools. Probably.

Completely related to this, when we try to `zpool clear` a readonly pool the following failure occurs:

```
> ::status
debugging crash dump vmcore.1 (64-bit) from openindiana
operating system: 5.11 master-0-g8dcfe5e5a1 (i86pc)
image uuid: 49f26dc4-a94a-6177-c9d4-b1ca68f101e3
panic message: assertion failed: spa_writeable(spa), file: ../../common/fs/zfs/vdev.c, line: 3110
dump content: kernel pages only
> ::stack
vpanic()
0xfffffffffbdfed08()
vdev_state_dirty+0x100(ffffff04e130ac80)
vdev_clear+0x1d8(ffffff04e19fa000, ffffff04e1309f80)
vdev_clear+0xa6(ffffff04e19fa000, ffffff04e130ac80)
vdev_clear+0xa6(ffffff04e19fa000, 0)
zfs_ioc_clear+0x11a(ffffff04e1c50000)
zfsdev_ioctl+0x50f(10e00000000, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
cdev_ioctl+0x39(10e00000000, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
spec_ioctl+0x60(ffffff04c44e5800, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
fop_ioctl+0x55(ffffff04c44e5800, 5a21, 8042b48, 100003, ffffff04c6b7b0e8, ffffff001436ae58)
ioctl+0x9b(3, 5a21, 8042b48)
_sys_sysenter_post_swapgs+0x237()
> ffffff04e130ac80::print vdev_t vdev_spa->spa_mode
vdev_spa->spa_mode = 0x1
> ffffff04e130ac80::print vdev_t vdev_cant_write   
vdev_cant_write = 0 (0)
> 
```

To be honest i'm not entirely convinced this fix is complete: it's not yet clear to me how we managed to have a readonly SPA with, at least, one writable VDEV. This issue cannot be reproduced on single-device and stripe pools, only mirror and raidz are affected. The writable device seems to be a non-leaf VDEV in every failure. (Copy/pasted from my comment in the ZFS on Linux pull request)

Illumos issue: https://www.illumos.org/issues/8477
ZFS on Linux commit: https://github.com/zfsonlinux/zfs/commit/92e43c17188d47f47b69318e4884096dec380e36