### PR TITLE
Fix formatting in spa_history_log_version()

### DIFF
--- a/usr/src/uts/common/fs/zfs/spa_history.c
+++ b/usr/src/uts/common/fs/zfs/spa_history.c
@@ -614,7 +614,7 @@ void
 spa_history_log_version(spa_t *spa, const char *operation)
 {
 	spa_history_log_internal(spa, operation, NULL,
-	    "pool version %llu; software version %llu/%d; uts %s %s %s %s",
+	    "pool version %llu; software version %llu/%llu; uts %s %s %s %s",
 	    (u_longlong_t)spa_version(spa), SPA_VERSION, ZPL_VERSION,
 	    utsname.nodename, utsname.release, utsname.version,
 	    utsname.machine);


### PR DESCRIPTION
ZPL_VERSION is a unsigned long long, not an int.  On 64-bit systems this
isn't generally a problem because long long is the same size as a native
word, and alignment (in memory or registers) treats it as a word sized
argument.  However, on 32-bit systems this may not be the case, and
instead treats the second 4 bytes as a pointer.  Given the current
values of ZPL_VERSION, this will be either an invalid pointer or a NULL
pointer, resulting in a panic.