### PR TITLE
8552 ZFS LUA code uses floating point math

### DIFF
--- a/usr/src/uts/common/fs/zfs/lua/lstrlib.c
+++ b/usr/src/uts/common/fs/zfs/lua/lstrlib.c
@@ -958,6 +958,7 @@ static int str_format (lua_State *L) {
           nb = str_sprintf(buff, form, ni);
           break;
         }
+#if defined(LUA_USE_FLOAT_FORMATS)
         case 'e': case 'E': case 'f':
 #if defined(LUA_USE_AFORMAT)
         case 'a': case 'A':
@@ -967,6 +968,7 @@ static int str_format (lua_State *L) {
           nb = str_sprintf(buff, form, (LUA_FLTFRM_T)luaL_checknumber(L, arg));
           break;
         }
+#endif
         case 'q': {
           addquoted(L, &b, arg);
           break;


### PR DESCRIPTION
In the LUA interpreter used by "zfs program", the lua format() function
accidentally includes support for '%f' and friends, which can cause
compilation problems when building on platforms that don't support
floating-point math in the kernel (e.g. sparc). Support for
%f %e %E %g %G should be removed, since there's no way to supply a
floating-point value anyway (all numbers in ZFS LUA are int64_t's).