### PR TITLE
Limit the uptime of Jenkins slaves to 12 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,7 +217,7 @@ def run_test(script, instance_type, spot_price, limit, disks, parameters) {
                 ['ADD_DISKS_FOR', disks]
             ]).trim()
 
-            timeout(time: 2 * limit, unit: 'HOURS') {
+            timeout(time: 1.5 * limit, unit: 'HOURS') {
                 if (!instance_id) {
                     error('Unable to create instance.')
                 }

--- a/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
+++ b/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+#
+# The purpose of this script is to automatically shutdown the system, to
+# provide some extra assurance that we don't "leak" EC2 resources. Since
+# EC2 Spot instances are being used exclusively (i.e. no other instances
+# types are being used), we can lean on the fact that they will be
+# automatically terminated when they are shutdown. Thus, this script is
+# used as a way to try and ensure the VMs are always shutdown and
+# terminated in a timely manner; e.g. in case the normal mechanism for
+# doing this, fails to do so.
+#
+
+BOOT=$(kstat -n system_misc | awk '/boot_time/ { print $2 }')
+LIMIT=$((12 * 60 * 60))
+
+CURRENT=$(date +%s)
+while [[ $CURRENT -lt $((BOOT + LIMIT)) ]]; do
+	sleep $((RANDOM % 100))
+	CURRENT=$(date +%s)
+done
+
+shutdown -y -g 0 -i 5
+exit 0

--- a/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
+++ b/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
@@ -27,7 +27,7 @@
 #
 
 BOOT=$(kstat -n system_misc | awk '/boot_time/ { print $2 }')
-LIMIT=$((12 * 60 * 60))
+LIMIT=$((1 * 60 * 60))
 
 CURRENT=$(date +%s)
 while [[ $CURRENT -lt $((BOOT + LIMIT)) ]]; do

--- a/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
+++ b/jenkins/ansible/roles/openzfs.jenkins-slave/files/var/jenkins/automatic-shutdown
@@ -27,7 +27,7 @@
 #
 
 BOOT=$(kstat -n system_misc | awk '/boot_time/ { print $2 }')
-LIMIT=$((1 * 60 * 60))
+LIMIT=$((12 * 60 * 60))
 
 CURRENT=$(date +%s)
 while [[ $CURRENT -lt $((BOOT + LIMIT)) ]]; do

--- a/jenkins/ansible/roles/openzfs.jenkins-slave/tasks/main.yml
+++ b/jenkins/ansible/roles/openzfs.jenkins-slave/tasks/main.yml
@@ -88,8 +88,14 @@
     mode: 0755
     owner: "{{ jenkins_user }}"
     group: "{{ jenkins_group }}"
-  with_items:
-    - jenkins-slave-connect
+
+- name: copy automatic shutdown script
+  copy:
+    src: "var/jenkins/automatic-shutdown"
+    dest: "{{ jenkins_directory }}/automatic-shutdown"
+    mode: 0755
+    owner: "root"
+    group: "root"
 
 - name: ensure supervisord package is present
   easy_install:
@@ -122,6 +128,13 @@
       autostart=true
       redirect_stderr=true
       stdout_logfile=/var/log/jenkins-slave.log
+
+      [program:automatic-shutdown]
+      command={{ jenkins_directory }}/automatic-shutdown
+      user=root
+      autostart=true
+      redirect_stderr=true
+      stdout_logfile=/var/log/automatic-shutdown.log
 
 - name: start supervisord
   command: supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
To try and prevent EC2 instance "leaks", this patch adds an additional
daemon that is managed by supervisord. The purpose of this new daemon
is to shutdown the system after it has been running for a specified
amount of time. As a result of the shutdown, the instance should be
automatically terminated by AWS since we're exclusively using EC2 Spot
Instances for all Jenkins slaves.