### PR TITLE
8567 Inconsistent return value in zpool_read_label

### DIFF
--- a/usr/src/cmd/fs.d/zfs/fstyp/fstyp.c
+++ b/usr/src/cmd/fs.d/zfs/fstyp/fstyp.c
@@ -89,8 +89,7 @@ fstyp_mod_ident(fstyp_mod_handle_t handle)
 	uint64_t u64;
 	char	buf[64];
 
-	if (zpool_read_label(h->fd, &h->config) != 0 ||
-	    h->config == NULL) {
+	if (zpool_read_label(h->fd, &h->config) != 0) {
 		return (FSTYP_ERR_NO_MATCH);
 	}
 

--- a/usr/src/cmd/zpool/zpool_main.c
+++ b/usr/src/cmd/zpool/zpool_main.c
@@ -707,7 +707,7 @@ zpool_do_labelclear(int argc, char **argv)
 		return (1);
 	}
 
-	if (zpool_read_label(fd, &config) != 0 || config == NULL) {
+	if (zpool_read_label(fd, &config) != 0) {
 		(void) fprintf(stderr,
 		    gettext("failed to read label from %s\n"), vdev);
 		return (1);

--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -841,6 +841,7 @@ label_offset(uint64_t size, int l)
 /*
  * Given a file descriptor, read the label information and return an nvlist
  * describing the configuration, if there is one.
+ * Return 0 on success, or -1 on failure
  */
 int
 zpool_read_label(int fd, nvlist_t **config)
@@ -853,7 +854,7 @@ zpool_read_label(int fd, nvlist_t **config)
 	*config = NULL;
 
 	if (fstat64(fd, &statbuf) == -1)
-		return (0);
+		return (-1);
 	size = P2ALIGN_TYPED(statbuf.st_size, sizeof (vdev_label_t), uint64_t);
 
 	if ((label = malloc(sizeof (vdev_label_t))) == NULL)
@@ -887,7 +888,7 @@ zpool_read_label(int fd, nvlist_t **config)
 
 	free(label);
 	*config = NULL;
-	return (0);
+	return (-1);
 }
 
 typedef struct rdsk_node {
@@ -1052,7 +1053,7 @@ zpool_open_func(void *arg)
 		check_slices(rn->rn_avl, fd, rn->rn_name);
 	}
 
-	if ((zpool_read_label(fd, &config)) != 0) {
+	if ((zpool_read_label(fd, &config)) != 0 && errno == ENOMEM) {
 		(void) close(fd);
 		(void) no_memory(rn->rn_hdl);
 		return;
@@ -1517,7 +1518,7 @@ zpool_in_use(libzfs_handle_t *hdl, int fd, pool_state_t *state, char **namestr,
 
 	*inuse = B_FALSE;
 
-	if (zpool_read_label(fd, &config) != 0) {
+	if (zpool_read_label(fd, &config) != 0 && errno == ENOMEM) {
 		(void) no_memory(hdl);
 		return (-1);
 	}


### PR DESCRIPTION
Make zpool_read_label's return value consistent, and adjust its consumers accordingly.