### PR TITLE
Build failures may "leak" the EC2 instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,6 +138,13 @@ node('master') {
             shscript('aws-terminate-instances', false, [
                 ['INSTANCE_ID', env.BUILD_INSTANCE_ID]
             ])
+
+            /*
+             * Since the build instance was just terminated above, we want to prevent the "finally" clause below
+             * from attempting to terminate the instance a second time. Otherwise, the second attempt to
+             * terminate the instance would fail, and then prevent the build image from being deleted.
+             */
+            env.BUILD_INSTANCE_ID = ''
         }
 
         stage('run tests') {
@@ -169,6 +176,12 @@ node('master') {
             if (env.BUILD_IMAGE_ID && env.BUILD_IMAGE_ID != env.BASE_IMAGE_ID) {
                 shscript('aws-delete-image', false, [
                     ['IMAGE_ID', env.BUILD_IMAGE_ID]
+                ])
+            }
+
+            if (env.BUILD_INSTANCE_ID) {
+                shscript('aws-terminate-instances', false, [
+                    ['INSTANCE_ID', env.BUILD_INSTANCE_ID]
                 ])
             }
         }


### PR DESCRIPTION
Since integrating the following change:

    commit ffa59080374b94e49ea6df62df0d8753cf5dbad8
    Author: Prakash Surya <prakash.surya@delphix.com>
    Date:   Fri Jun 23 16:41:41 2017 -0700

        Use EC2 "Spot Instances" with Jenkins Automation

It's possible for an EC2 instance to be "leaked" when a build fails.
This patch attempts fix the problem by re-introducing the logic to
terminate the build instance from within the "finally" clause.