### PR TITLE
8590 memory leak in dsl_destroy_snapshots_nvl()

### DIFF
--- a/usr/src/uts/common/fs/zfs/dsl_destroy.c
+++ b/usr/src/uts/common/fs/zfs/dsl_destroy.c
@@ -501,6 +501,7 @@ dsl_destroy_snapshots_nvl(nvlist_t *snaps, boolean_t defer,
 		    nvpair_name(pair), B_TRUE);
 	}
 	fnvlist_add_nvlist(arg, "snaps", snaps_normalized);
+	fnvlist_free(snaps_normalized);
 	fnvlist_add_boolean_value(arg, "defer", defer);
 
 	nvlist_t *wrapper = fnvlist_alloc();


### PR DESCRIPTION
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Steve Gonczi <steve.gonczi@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>

In dsl_destroy_snapshots_nvl(), "snaps_normalized" is not
freed after it is added to "arg".

Upstream bugs: DLPX-45440