### PR TITLE
8655 remove more gender specific language

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/pppd/ipv6cp.c
@@ -885,7 +885,7 @@ ipv6cp_reqci(f, p, lenp, dont_nak)
 		/*
 		 * If it has no interface identifier, or if we both
 		 * have same identifier then NAK it with new idea.  In
-		 * particular, if we don't know his identifier, but it
+		 * particular, if we don't know its identifier, but it
 		 * does, then accept that identifier.
 		 */
 		eui64_get(ifaceid, p);

--- a/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipseckey.c
@@ -1728,7 +1728,7 @@ doaddup(int cmd, int satype, char *argv[], char *ebuf)
 			switch (token) {
 			case TOK_SPI:
 				/*
-				 * If some cretin types in "spi 0" then they
+				 * If they type in "spi 0" then they
 				 * can type in another SPI.
 				 */
 				if (assoc->sadb_sa_spi != 0) {

--- a/usr/src/cmd/format/main.c
+++ b/usr/src/cmd/format/main.c
@@ -492,7 +492,7 @@ init_globals(disk)
 			fmt_print("]");
 		/*
 		 * Drive wasn't formatted.  Tell the user in case they
-		 * disagrees.
+		 * disagree.
 		 */
 		} else if (EMBEDDED_SCSI) {
 			fmt_print("[disk unformatted]");

--- a/usr/src/cmd/tar/tar.c
+++ b/usr/src/cmd/tar/tar.c
@@ -1465,8 +1465,8 @@ dorep(char *argv[])
  *	endtape checks the entry in dblock.dbuf to see if its the
  *	special EOT entry.  Endtape is usually called after getdir().
  *
- *	endtape used to call backtape; it no longer does, it who
- *	wants it backed up must call backtape himself
+ *	endtape used to call backtape; it no longer does. If the caller
+ *	wants the tape backed up, it must call backtape itself
  *	RETURNS:	0 if not EOT, tape position unaffected
  *			1 if	 EOT, tape position unaffected
  */

--- a/usr/src/cmd/vi/port/ex_cmdsub.c
+++ b/usr/src/cmd/vi/port/ex_cmdsub.c
@@ -1621,7 +1621,7 @@ addmac(unsigned char *src, unsigned char *dest, unsigned char *dname,
 		if (src[1] == 0 && src[0] == dest[strlen(dest)-1])
 			error(gettext("No tail recursion"));
 		/*
-		 * We don't let the user rob himself of ":", and making
+		 * We don't let the user rob themself of ":", and making
 		 * multi char words is a bad idea so we don't allow it.
 		 * Note that if user sets mapinput and maps all of return,
 		 * linefeed, and escape, they can hurt themself. This is

--- a/usr/src/head/arpa/telnet.h
+++ b/usr/src/head/arpa/telnet.h
@@ -245,8 +245,8 @@ extern char *slc_names[];
  */
 #define	AUTH_REJECT	0	/* Rejected */
 #define	AUTH_UNKNOWN	1	/* We don't know who it is, but it's okay */
-#define	AUTH_OTHER	2	/* We know it, but not it's name */
-#define	AUTH_USER	3	/* We know it's name */
+#define	AUTH_OTHER	2	/* We know it, but not its name */
+#define	AUTH_USER	3	/* We know its name */
 #define	AUTH_VALID	4	/* We know it, and it needs no password */
 
 /*

--- a/usr/src/lib/libbc/libc/gen/common/ndbm.c
+++ b/usr/src/lib/libbc/libc/gen/common/ndbm.c
@@ -495,10 +495,9 @@ dbm_do_nextkey(DBM *db, datum inkey)
 		else key=nullkey;
 
 	/* the keyptr pagbuf have failed us, the user must
-	be an extra clever moron who depends on
-	these variables and their former meaning.
+	depend on these variables and their former meaning.
 	If we set the variables this would have got
-	us the key for sure! So give him the old algorithm.*/
+	us the key for sure! So give the user the old algorithm.*/
 		if (key.dptr == NULL) return (dbm_slow_nextkey(db));
 	}
 

--- a/usr/src/lib/libc/port/threads/thr.c
+++ b/usr/src/lib/libc/port/threads/thr.c
@@ -1818,7 +1818,7 @@ force_continue(ulwp_t *ulwp)
 		if (error != 0 && error != EINTR)
 			break;
 		error = 0;
-		if (ulwp->ul_stopping) {	/* it is stopping itsself */
+		if (ulwp->ul_stopping) {	/* it is stopping itself */
 			ts.tv_sec = 0;		/* give it a chance to run */
 			ts.tv_nsec = 100000;	/* 100 usecs or clock tick */
 			(void) __nanosleep(&ts, NULL);


### PR DESCRIPTION
I recently came across https://github.com/illumos/illumos-gate/commit/48bbca816818409505a6e214d0911fda44e622e3 which was removing gender specific language. In reviewing it (because unemployment leaves me with a lot of free time, whoo) I noticed a few oversights and typos. This PR fixes them.