### PR TITLE
8605 zfs channel programs: zfs.exists undocumented and non-working

### DIFF
--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -289,6 +289,18 @@ msg (string)
 .Bd -ragged -compact -offset "xxxx"
 Debug message to be printed.
 .Ed
+.It Em zfs.exists(dataset)
+Returns true if the given dataset exists, or false if it doesn't.
+A fatal error will be thrown if the dataset is not in the target pool.
+That is, in a channel program running on rpool,
+zfs.exists("rpool/nonexistent_fs") returns false, but
+zfs.exists("somepool/fs_that_may_exist") will error.
+.Pp
+dataset (string)
+.Bd -ragged -compact -offset "xxxx"
+Dataset to check for existence.
+Must be in the target pool.
+.Ed
 .It Em zfs.get_prop(dataset, property)
 Returns two values.
 First, a string, number or table containing the property value for the given

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -403,6 +403,11 @@ file \
 file \
     path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.divide_by_zero.zcp \
     mode=0444
+file path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.exists \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp \
+    mode=0444
 file \
     path=opt/zfs-tests/tests/functional/channel_program/lua_core/tst.integer_illegal \
     mode=0555

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.ksh
@@ -1,0 +1,45 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION:
+#       zfs.exists should accurately report whether a dataset exists, and
+#       report an error if a dataset is in another pool.
+
+verify_runnable "global"
+
+# create $TESTSNAP and $TESTCLONE
+create_snapshot
+create_clone
+
+function cleanup
+{
+	datasetexists $TESTPOOL/$TESTFS@$TESTSNAP && \
+	    log_must zfs destroy -R $TESTPOOL/$TESTFS@$TESTSNAP
+}
+
+log_must_program $TESTPOOL $ZCP_ROOT/lua_core/tst.exists.zcp \
+    $TESTPOOL $TESTPOOL/$TESTFS $TESTPOOL/$TESTFS@$TESTSNAP \
+    $TESTPOOL/$TESTCLONE
+
+log_mustnot_checkerr_program "not in the target pool" \
+    $TESTPOOL - <<-EOF
+	return zfs.exists('rpool')
+EOF
+
+log_pass "zfs.exists() gives correct results"

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/lua_core/tst.exists.zcp
@@ -1,0 +1,26 @@
+--
+-- This file and its contents are supplied under the terms of the
+-- Common Development and Distribution License ("CDDL"), version 1.0.
+-- You may only use this file in accordance with the terms of version
+-- 1.0 of the CDDL.
+--
+-- A full copy of the text of the CDDL should have accompanied this
+-- source.  A copy of the CDDL is also available via the Internet at
+-- http://www.illumos.org/license/CDDL.
+--
+
+--
+-- Copyright (c) 2017 by Delphix. All rights reserved.
+--
+
+-- ensure zfs.exists works as expected.
+
+args = ...
+argv = args['argv']
+pool = argv[1]
+
+for i = 1,4 do
+	assert(zfs.exists(argv[i]))
+end
+
+assert(not zfs.exists(pool .. '/notadataset'))

--- a/usr/src/uts/common/fs/zfs/zcp.c
+++ b/usr/src/uts/common/fs/zfs/zcp.c
@@ -710,7 +710,7 @@ zcp_exists(lua_State *state)
 		return (luaL_error(state, "unexpected error %d", error));
 	}
 
-	return (0);
+	return (1);
 }
 
 /*


### PR DESCRIPTION
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: Matt Ahrens <mahrens@delphix.com>

zfs.exists() in channel programs doesn't return any result, and should
have a man page entry. This patch corrects zfs.exists so that it
returns a value indicating if the dataset exists or not. It also adds
documentation about it in the man page.

Upstream Bugs: DLPX-50908