### PR TITLE
8565 zpool dumps core trying to destroy unavail/faulted pool and try export it

### DIFF
--- a/usr/src/lib/libshare/common/libshare_zfs.c
+++ b/usr/src/lib/libshare/common/libshare_zfs.c
@@ -1018,8 +1018,7 @@ sa_get_one_zfs_share(sa_handle_t handle, char *groupname,
 		    zfsgroup);
 	}
 
-	return (0);
-
+	return (err);
 }
 
 /*

--- a/usr/src/lib/libshare/common/libshare_zfs.c
+++ b/usr/src/lib/libshare/common/libshare_zfs.c
@@ -997,18 +997,29 @@ sa_get_one_zfs_share(sa_handle_t handle, char *groupname,
 		return (SA_OK);
 
 	*paths_len = sharearg->zhandle_len;
-	*paths = malloc(sizeof (char *) * (*paths_len));
+	*paths = calloc(*paths_len, sizeof (char *));
 	for (int i = 0; i < sharearg->zhandle_len; ++i) {
 		zfs_handle_t *fs_handle =
 		    ((zfs_handle_t **)(sharearg->zhandle_arr))[i];
 		if (fs_handle == NULL) {
+			/* Free non-null elements of the paths array */
+			for (int free_idx = 0; free_idx < *paths_len;
+			    ++free_idx) {
+				if ((*paths)[free_idx] != NULL)
+					free((*paths)[free_idx]);
+			}
+			free(*paths);
+			*paths = NULL;
+			*paths_len = 0;
 			return (SA_SYSTEM_ERR);
 		}
 		(*paths)[i] = malloc(sizeof (char) * ZFS_MAXPROPLEN);
 		err |= sa_get_zfs_share_common(handle, fs_handle, (*paths)[i],
 		    zfsgroup);
 	}
-	return (err);
+
+	return (0);
+
 }
 
 /*


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>

There are cases where sa_get_one_zfs_share() of libshare doens't
fill in all the paths[] due to a specific handle being NULL and
returns SA_SYSTEM_ERR.

Currently regardless of whether this error is returned or not
we always free each of those paths in sa_init_impl() which
can lead to a double-freeing fault.

Since sa_get_one_zfs_share() is also the function that allocates
the memory that will later be pointed by paths[], it should
also be responsible for freeing any no-null elements of that
array in the case of error and also set paths_len to 0 so
the caller doesn't attempt to do anything wrong.

Upstream bugs: DLPX-53732
Upstream Original Title: libshare can cause free of non-allocated space when pools are faulted