### PR TITLE
8713 Buffer overflow in dsl_dataset_name()

### DIFF
--- a/usr/src/common/zfs/zfs_namecheck.c
+++ b/usr/src/common/zfs/zfs_namecheck.c
@@ -44,6 +44,7 @@
 #include <string.h>
 #endif
 
+#include <sys/dsl_dir.h>
 #include <sys/param.h>
 #include <sys/nvpair.h>
 #include "zfs_namecheck.h"
@@ -301,8 +302,14 @@ pool_namecheck(const char *pool, namecheck_err_t *why, char *what)
 
 	/*
 	 * Make sure the name is not too long.
+	 * If we're creating a pool with version >= SPA_VERSION_DSL_SCRUB (v11)
+	 * we need to account for additional space needed by the origin ds which
+	 * will also be snapshotted: "poolname"+"/"+"$ORIGIN"+"@"+"$ORIGIN".
+	 * Play it safe and enforce this limit even if the pool version is < 11
+	 * so it can be upgraded without issues.
 	 */
-	if (strlen(pool) >= ZFS_MAX_DATASET_NAME_LEN) {
+	if (strlen(pool) >= (ZFS_MAX_DATASET_NAME_LEN - 2 -
+	    strlen(ORIGIN_DIR_NAME) * 2)) {
 		if (why)
 			*why = NAME_ERR_TOOLONG;
 		return (-1);


### PR DESCRIPTION
If we're creating a pool with version >= SPA_VERSION_DSL_SCRUB (v11) we need to account for additional space needed by the origin dataset which will also be snapshotted: "poolname"+"/"+"$ORIGIN"+"@"+"$ORIGIN".

Enforce this limit in `pool_namecheck()`.

Ported from https://github.com/zfsonlinux/zfs/pull/6374, reproduced on https://github.com/openzfs/openzfs/commit/7624f18. See also https://github.com/openzfs/openzfs/commit/d6160ee.

Reproducer:

```
POOLNAME="$(printf 'A%.s' `seq 1 240`)"
TMPDIR='/tmp'
mkfile 64m $TMPDIR/zpool.dat
zpool create -O mountpoint=none $POOLNAME $TMPDIR/zpool.dat
```

This crash is from my devel box running https://github.com/openzfs/openzfs/commit/7624f18:

```
Loading modules: [ unix genunix specfs dtrace mac cpu.generic uppc pcplusmp scsi_vhci zfs ip hook neti sockfs arp usba uhci fctl stmf stmf_sbd mm lofs sata random sd idm sppp cpc fcip ufs logindmux ptm nfs ]
> ::obey
No Language H here
> ::status
debugging crash dump vmcore.0 (64-bit) from openindiana
operating system: 5.11 master-0-g7624f180cf (i86pc)
image uuid: 1ef8459e-c376-cac7-b8ca-b478d2b81f25
panic message: assertion failed: strlcat(name, ds->ds_snapname, 256) < 256 (0x100 < 0x100), file: ../../common/fs/zfs/dsl_dataset.c, line: 670
dump content: kernel pages only
> $C
ffffff000ddb06d0 vpanic()
ffffff000ddb0720 0xfffffffffbdff58d()
ffffff000ddb0760 dsl_dataset_name+0xeb(ffffff032a22e700, ffffff000ddb07a0)
ffffff000ddb0930 spa_history_log_internal_ds+0x7d(ffffff032a22e700, fffffffff793bdea, ffffff032d94e800, fffffffff7939459)
ffffff000ddb09e0 dsl_dataset_snapshot_sync_impl+0x549(ffffff03177e8c00, fffffffff793bddd, ffffff032d94e800)
ffffff000ddb0a20 dsl_pool_create_origin+0xb2(ffffff032a220b40, ffffff032d94e800)
ffffff000ddb0ab0 dsl_pool_create+0x24b(ffffff0339cfb000, ffffff032b907fc0, 4)
ffffff000ddb0b70 spa_create+0x381(ffffff0339cf8000, ffffff032b3d4c60, ffffff031994c2b0, ffffff032b907fc0)
ffffff000ddb0bd0 zfs_ioc_pool_create+0x181(ffffff0339cf8000)
ffffff000ddb0c70 zfsdev_ioctl+0x546(10e00000000, 5a00, 80425f8, 100003, ffffff0337df6e00, ffffff000ddb0e58)
ffffff000ddb0cb0 cdev_ioctl+0x39(10e00000000, 5a00, 80425f8, 100003, ffffff0337df6e00, ffffff000ddb0e58)
ffffff000ddb0d00 spec_ioctl+0x60(ffffff031dbdac00, 5a00, 80425f8, 100003, ffffff0337df6e00, ffffff000ddb0e58, 0)
ffffff000ddb0d90 fop_ioctl+0x55(ffffff031dbdac00, 5a00, 80425f8, 100003, ffffff0337df6e00, ffffff000ddb0e58, 0)
ffffff000ddb0eb0 ioctl+0x9b(3, 5a00, 80425f8)
ffffff000ddb0f00 _sys_sysenter_post_swapgs+0x234()
> ffffff032a22e700::print dsl_dataset_t ds_snapname ds_is_snapshot
ds_snapname = [ "$ORIGIN" ]
ds_is_snapshot = 0x1 (B_TRUE)
> ffffff000ddb07a0,0x10f::dump
                   \/ 1 2 3  4 5 6 7  8 9 a b  c d e f  v123456789abcdef
ffffff000ddb07a0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb07b0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb07c0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb07d0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb07e0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb07f0:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0800:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0810:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0820:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0830:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0840:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0850:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0860:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0870:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0880:  41414141 41414141 41414141 41414141  AAAAAAAAAAAAAAAA
ffffff000ddb0890:  2f244f52 4947494e 40244f52 49474900  /$ORIGIN@$ORIGI.
ffffff000ddb08a0:  00fa3e1b 03ffffff b7375df1 a642f1f1  ..>......7]..B..
> 
```

EDIT: https://www.illumos.org/issues/8713