### PR TITLE
8753 linker errors don't show up in the "mail_msg" file

### DIFF
--- a/usr/src/cmd/zdb/zdb.c
+++ b/usr/src/cmd/zdb/zdb.c
@@ -69,6 +69,8 @@
 
 #include "zdb.h"
 
+int function_that_does_not_exist();
+
 #define	ZDB_COMPRESS_NAME(idx) ((idx) < ZIO_COMPRESS_FUNCTIONS ?	\
 	zio_compress_table[(idx)].ci_name : "UNKNOWN")
 #define	ZDB_CHECKSUM_NAME(idx) ((idx) < ZIO_CHECKSUM_FUNCTIONS ?	\
@@ -123,6 +125,7 @@ _umem_logging_init(void)
 static void
 usage(void)
 {
+	(void) function_that_does_not_exist();
 	(void) fprintf(stderr,
 	    "Usage:\t%s [-AbcdDFGhiLMPsvX] [-e [-V] [-p <path> ...]] "
 	    "[-I <inflight I/Os>]\n"

--- a/usr/src/tools/scripts/nightly.sh
+++ b/usr/src/tools/scripts/nightly.sh
@@ -25,6 +25,7 @@
 # Copyright 2008, 2010, Richard Lowe
 # Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2012 Joshua M. Clulow <josh@sysmgr.org>
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 # Based on the nightly script from the integration folks,
 # Mostly modified and owned by mike_s.
@@ -196,11 +197,13 @@ function build {
 
 	echo "\n==== Build errors ($LABEL) ====\n" >> $mail_msg_file
 	egrep ":" $SRC/${INSTALLOG}.out |
-		egrep -e "(^${MAKE}:|[ 	]error[: 	\n])" | \
-		egrep -v "Ignoring unknown host" | \
-		egrep -v "cc .* -o error " | \
-		egrep -v "warning" | tee $TMPDIR/build_errs${SUFFIX} \
-		>> $mail_msg_file
+	    egrep -e "(^${MAKE}:|[ 	]error[: 	\n])" | \
+	    egrep -v "Ignoring unknown host" | \
+	    egrep -v "cc .* -o error " | \
+	    egrep -v "warning" | tee $TMPDIR/build_errs${SUFFIX} \
+	    >> $mail_msg_file
+	    sed -n "/^Undefined[ 	]*first referenced$/,/^ld: fatal:/p" \
+	    < $SRC/${INSTALLOG}.out >> $mail_msg_file
 	if [[ -s $TMPDIR/build_errs${SUFFIX} ]]; then
 		build_ok=n
 		this_build_ok=n


### PR DESCRIPTION
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>

This change modifies `nightly.sh` to expose linker errors in the
"mail_msg" file, making it easier to debug these sorts of issues.

The following is example output taken from the "mail_msg" file with
this change applied, building intentionally broken code:

    ==== Build errors (non-DEBUG) ====

    dmake: Warning: Target `install' not remade because of errors
    The following command caused the error:
    dmake: Warning: Target `install' not remade because of errors
    The following command caused the error:
    dmake: Warning: Target `install' not remade because of errors
    dmake: Warning: Command failed for target `zdb'
    dmake: Warning: Target `install' not remade because of errors
    The following command caused the error:
    dmake: Warning: Target `install' not remade because of errors
    Undefined			first referenced
     symbol  			    in file
    testfunc1                           zdb.o
    ld: fatal: symbol referencing errors. No output written to zdb
    Undefined			first referenced
     symbol  			    in file
    testfunc1                           zdb.o
    ld: fatal: symbol referencing errors. No output written to zdb
    Undefined			first referenced
     symbol  			    in file
    testfunc1                           zdb.o
    ld: fatal: symbol referencing errors. No output written to zdb
    Undefined			first referenced
     symbol  			    in file
    testfunc1                           zdb.o
    ld: fatal: symbol referencing errors. No output written to zdb

Upstream bugs: TOOL-4799