### PR TITLE
0000 ztest assertion failure in zil_lwb_write_issue

### DIFF
--- a/usr/src/uts/common/fs/zfs/dmu_tx.c
+++ b/usr/src/uts/common/fs/zfs/dmu_tx.c
@@ -872,7 +872,7 @@ dmu_tx_try_assign(dmu_tx_t *tx, txg_how_t txg_how)
 		 * of the failuremode setting.
 		 */
 		if (spa_get_failmode(spa) == ZIO_FAILURE_MODE_CONTINUE &&
-		    txg_how != TXG_WAIT)
+		    txg_how == TXG_NOWAIT)
 			return (SET_ERROR(EIO));
 
 		return (SET_ERROR(ERESTART));

--- a/usr/src/uts/common/fs/zfs/dmu_tx.c
+++ b/usr/src/uts/common/fs/zfs/dmu_tx.c
@@ -1000,7 +1000,7 @@ dmu_tx_assign(dmu_tx_t *tx, txg_how_t txg_how)
 	while ((err = dmu_tx_try_assign(tx, txg_how)) != 0) {
 		dmu_tx_unassign(tx);
 
-		if (err != ERESTART || txg_how != TXG_WAIT)
+		if (err != ERESTART || txg_how == TXG_NOWAIT)
 			return (err);
 
 		dmu_tx_wait(tx);

--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -1220,22 +1220,13 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 	tx = dmu_tx_create(zilog->zl_os);
 
 	/*
-	 * Since we are not going to create any new dirty data and we can even
-	 * help with clearing the existing dirty data, we should not be subject
-	 * to the dirty data based delays.
-	 * We (ab)use TXG_WAITED to bypass the delay mechanism.
-	 * One side effect from using TXG_WAITED is that dmu_tx_assign() can
-	 * fail if the pool is suspended.  Those are dramatic circumstances,
-	 * so we return NULL to signal that the normal ZIL processing is not
-	 * possible and txg_wait_synced() should be used to ensure that the data
-	 * is on disk.
+	 * Since we are not going to create any new dirty data and we
+	 * can even help with clearing the existing dirty data, we
+	 * should not be subject to the dirty data based delays. We
+	 * (ab)use TXG_WAITED to bypass the delay mechanism.
 	 */
-	error = dmu_tx_assign(tx, TXG_WAITED);
-	if (error != 0) {
-		ASSERT3S(error, ==, EIO);
-		dmu_tx_abort(tx);
-		return (NULL);
-	}
+	VERIFY0(dmu_tx_assign(tx, TXG_WAITED));
+
 	dsl_dataset_dirty(dmu_objset_ds(zilog->zl_os), tx);
 	txg = dmu_tx_get_txg(tx);
 


### PR DESCRIPTION
Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Don Brady <don.brady@delphix.com>

When TXG_WAITED is passed in to dmu_tx_assign(), it's possible that
ERESTART will be returned, which can cause an assertion to fail in
zil_lwb_write_issue(). To fix this, dmu_tx_assign() was modifed to only
return ERESTART if TXG_NOWAIT is passed in.

Upstream bugs: DLPX-54873