### PR TITLE
0000 ztest assertion failure in zil_lwb_write_issue (v2)

### DIFF
--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -1208,22 +1208,17 @@ zil_lwb_write_issue(zilog_t *zilog, lwb_t *lwb)
 	tx = dmu_tx_create(zilog->zl_os);
 
 	/*
-	 * Since we are not going to create any new dirty data and we can even
-	 * help with clearing the existing dirty data, we should not be subject
-	 * to the dirty data based delays.
-	 * We (ab)use TXG_WAITED to bypass the delay mechanism.
-	 * One side effect from using TXG_WAITED is that dmu_tx_assign() can
-	 * fail if the pool is suspended.  Those are dramatic circumstances,
-	 * so we return NULL to signal that the normal ZIL processing is not
-	 * possible and txg_wait_synced() should be used to ensure that the data
-	 * is on disk.
+	 * Since we are not going to create any new dirty data and we
+	 * can even help with clearing the existing dirty data, we
+	 * should not be subject to the dirty data based delays. We
+	 * (ab)use TXG_WAITED to bypass the delay mechanism.
 	 */
-	error = dmu_tx_assign(tx, TXG_WAITED);
-	if (error != 0) {
-		ASSERT3S(error, ==, EIO);
-		dmu_tx_abort(tx);
-		return (NULL);
+	while ((error = dmu_tx_assign(tx, TXG_WAITED)) != 0) {
+		VERIFY3S(error, ==, ERESTART);
+		dmu_tx_unassign(tx);
+		dmu_tx_wait(tx);
 	}
+
 	dsl_dataset_dirty(dmu_objset_ds(zilog->zl_os), tx);
 	txg = dmu_tx_get_txg(tx);
 


### PR DESCRIPTION
When `dmu_tx_assign` is called from `zil_lwb_write_issue`, it's possible
for either `ERESTART` or `EIO` to be returned.

If `ERESTART` is returned, this will cause an assertion to fail directly
in `zil_lwb_write_issue`, where the code assumes the return value is
`EIO` if `dmu_tx_assign` returns a non-zero value. This can occur if the
SPA is suspended when `dmu_tx_assign` is called, and most often occurs
when running `zloop`.

If `EIO` is returned, this can cause assertions to fail elsewhere in the
ZIL code. For example, `zil_commit_waiter_timeout` contains the
following logic:

    lwb_t *nlwb = zil_lwb_write_issue(zilog, lwb);
    ASSERT3S(lwb->lwb_state, !=, LWB_STATE_OPENED);

In this case, if `dmu_tx_assign` returned `EIO` from within
`zil_lwb_write_issue`, the `lwb` variable passed in will not be issued
to disk. Thus, it's `lwb_state` field will remain `LWB_STATE_OPENED` and
this assertion will fail. `zil_commit_waiter_timeout` assumes that after
it calls `zil_lwb_write_issue`, the `lwb` will be issued to disk, and
doesn't handle the case where this is not true; i.e. it doesn't handle
the case where `dmu_tx_assign` returns `EIO`.

This change modifies `zil_lwb_write_issue` to verify that the return
code from `dmu_tx_assign` is either `ERESTART` or `0`.

If `EIO` is returned, the system will panic. This behavior is similar to
how we use `VERIFY0` when calling `dmu_tx_assign` elsewhere in the ZFS
code.

If `ERESTART` is returned, `zil_lwb_write_issue` will retry the
operation, and continually attempt to assign the transation until it
succeeds.

Upstream bugs: DLPX-54873