### PR TITLE
0000 a number of light-weight extensions to libzfs_core

### DIFF
--- a/usr/src/lib/libzfs_core/common/libzfs_core.h
+++ b/usr/src/lib/libzfs_core/common/libzfs_core.h
@@ -94,6 +94,13 @@ int lzc_rollback_to(const char *, const char *);
 int lzc_rename(const char *, const char *);
 int lzc_destroy(const char *);
 
+int lzc_set_prop(const char *, nvlist_t *);
+int lzc_inherit_prop(const char *, const char *);
+int lzc_get_props(const char *, nvlist_t **);
+
+int lzc_list_children(const char *, uint64_t *, char *);
+int lzc_list_snaps(const char *, uint64_t *, char *);
+
 int lzc_channel_program(const char *, const char *, uint64_t,
     uint64_t, nvlist_t *, nvlist_t **);
 int lzc_channel_program_nosync(const char *, const char *, uint64_t,

--- a/usr/src/lib/libzfs_core/common/mapfile-vers
+++ b/usr/src/lib/libzfs_core/common/mapfile-vers
@@ -37,6 +37,16 @@
 
 $mapfile_version 2
 
+SYMBOL_VERSION ILLUMOS_0.5 {
+	global:
+
+	lzc_get_props;
+	lzc_inherit_prop;
+	lzc_list_children;
+	lzc_list_snaps;
+	lzc_set_prop;
+} ILLUMOS_0.4;
+
 SYMBOL_VERSION ILLUMOS_0.4 {
 	global:
 


### PR DESCRIPTION
This change adds a number of simple (simplistic, even!) interfaces to libzfs_core.
It's quite possible that I have not thought through all required details or possible use-cases.
But not having any functionality to, for example, rename or destroy a dataset is a big limitation of the current interface.
The new functions are:
- `lzc_rename`
- `lzc_destroy`
- `lzc_set_prop` (works only for a single property)
- `lzc_get_props` (all properties, no filter / selector in the current implementation)
- `lzc_inherit_prop` (only a plain inherit or revert to default, no way to revert to a received value)
- `lzc_list_children` (actually makes a single iteration step over children)
- `lzc_list_snaps` (same as above)

All functions are very thin wrappers around the corresponding ioctls.
Maybe, that makes the functions less convenient to use than they could be.
But the change is really small and is really easy to understand.
