### PR TITLE
8940 Sending an intra-pool resumable send stream may result in EXDEV

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_iter.c
+++ b/usr/src/lib/libzfs/common/libzfs_iter.c
@@ -424,16 +424,20 @@ zfs_iter_snapspec(zfs_handle_t *fs_zhp, const char *spec_orig,
 
 /*
  * Iterate over all children, snapshots and filesystems
+ * Process snapshots before filesystems because they are nearer the input
+ * handle: this is extremely important when used with zfs_iter_f functions
+ * looking for data, following the logic that we would like to find it as soon
+ * and as close as possible.
  */
 int
 zfs_iter_children(zfs_handle_t *zhp, zfs_iter_f func, void *data)
 {
 	int ret;
 
-	if ((ret = zfs_iter_filesystems(zhp, func, data)) != 0)
+	if ((ret = zfs_iter_snapshots(zhp, B_FALSE, func, data)) != 0)
 		return (ret);
 
-	return (zfs_iter_snapshots(zhp, B_FALSE, func, data));
+	return (zfs_iter_filesystems(zhp, func, data));
 }
 
 

--- a/usr/src/lib/libzfs/common/libzfs_sendrecv.c
+++ b/usr/src/lib/libzfs/common/libzfs_sendrecv.c
@@ -1577,6 +1577,7 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 	int error = 0;
 	char name[ZFS_MAX_DATASET_NAME_LEN];
 	enum lzc_send_flags lzc_flags = 0;
+	FILE *fout = (flags->verbose && flags->dryrun) ? stdout : stderr;
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 	    "cannot resume send"));
@@ -1591,9 +1592,9 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 		return (zfs_error(hdl, EZFS_FAULT, errbuf));
 	}
 	if (flags->verbose) {
-		(void) fprintf(stderr, dgettext(TEXT_DOMAIN,
+		(void) fprintf(fout, dgettext(TEXT_DOMAIN,
 		    "resume token contents:\n"));
-		nvlist_print(stderr, resume_nvl);
+		nvlist_print(fout, resume_nvl);
 	}
 
 	if (nvlist_lookup_string(resume_nvl, "toname", &toname) != 0 ||
@@ -1650,7 +1651,7 @@ zfs_send_resume(libzfs_handle_t *hdl, sendflags_t *flags, int outfd,
 		    lzc_flags, &size);
 		if (error == 0)
 			size = MAX(0, (int64_t)(size - bytes));
-		send_print_verbose(stderr, zhp->zfs_name, fromname,
+		send_print_verbose(fout, zhp->zfs_name, fromname,
 		    size, flags->parsable);
 	}
 

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend.kshlib
@@ -512,11 +512,13 @@ function test_fs_setup
 {
 	typeset sendfs=$1
 	typeset recvfs=$2
+	typeset streamfs=$3
 	typeset sendpool=${sendfs%%/*}
 	typeset recvpool=${recvfs%%/*}
 
 	datasetexists $sendfs && log_must zfs destroy -r $sendpool
 	datasetexists $recvfs && log_must zfs destroy -r $recvpool
+	datasetexists $streamfs && log_must zfs destroy -r $streamfs
 
 	if $(datasetexists $sendfs || zfs create -o compress=lz4 $sendfs); then
 		mk_files 1000 256 0 $sendfs &
@@ -545,10 +547,7 @@ function test_fs_setup
 		    ">/$sendpool/incremental.zsend"
 	fi
 
-	if datasetexists $streamfs; then
-		log_must zfs destroy -r $streamfs
-	fi
-	log_must zfs create -o compress=lz4 $sendpool/stream
+	log_must zfs create -o compress=lz4 $streamfs
 }
 
 #
@@ -661,9 +660,10 @@ function resume_cleanup
 {
 	typeset sendfs=$1
 	typeset streamfs=$2
+	typeset sendpool=${sendfs%%/*}
 
 	datasetexists $sendfs && log_must zfs destroy -r $sendfs
 	datasetexists $streamfs && log_must zfs destroy -r $streamfs
 	cleanup_pool $POOL2
-	rm -f /$POOL/initial.zsend /$POOL/incremental.zsend
+	rm -f /$sendpool/initial.zsend /$sendpool/incremental.zsend
 }

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_019_pos.ksh
@@ -43,8 +43,8 @@ sendfs=$POOL/sendfs
 recvfs=$POOL3/recvfs
 streamfs=$POOL2/stream
 
-for sendfs in $POOL2/sendfs $POOL2; do
-	test_fs_setup $sendfs $recvfs
+for sendfs in $POOL2/sendfs $POOL3; do
+	test_fs_setup $sendfs $recvfs $streamfs
 	resume_test "zfs send -v $sendfs@a" $streamfs $recvfs
 	resume_test "zfs send -v -i @a $sendfs@b" $streamfs $recvfs
 	file_check $sendfs $recvfs

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_020_pos.ksh
@@ -42,7 +42,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -D -v $sendfs@a" $streamfs $recvfs
 file_check $sendfs $recvfs
 

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_021_pos.ksh
@@ -44,7 +44,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -v -e $sendfs@a" $streamfs $recvfs
 resume_test "zfs send -v -e -i @a $sendfs@b" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_022_pos.ksh
@@ -47,7 +47,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 log_must zfs bookmark $sendfs@a $sendfs#bm_a
 log_must zfs destroy $sendfs@a
 log_must zfs receive -v $recvfs </$POOL/initial.zsend

--- a/usr/src/test/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/rsend_024_pos.ksh
@@ -44,7 +44,7 @@ streamfs=$POOL/stream
 
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 log_must zfs unmount $sendfs
 resume_test "zfs send $sendfs" $streamfs $recvfs
 file_check $sendfs $recvfs

--- a/usr/src/test/zfs-tests/tests/functional/rsend/send-c_resume.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/send-c_resume.ksh
@@ -41,7 +41,7 @@ streamfs=$POOL/stream
 log_assert "Verify compressed send streams can be resumed if interrupted"
 log_onexit resume_cleanup $sendfs $streamfs
 
-test_fs_setup $sendfs $recvfs
+test_fs_setup $sendfs $recvfs $streamfs
 resume_test "zfs send -c -v $sendfs@a" $streamfs $recvfs
 resume_test "zfs send -c -v -i @a $sendfs@b" $streamfs $recvfs
 file_check $sendfs $recvfs


### PR DESCRIPTION
`zfs send -t <token>` for an incremental send should be able to resume successfully when sending to the same pool: a subtle issue in `zfs_iter_children()` doesn't currently allow this.

Because resuming from a token requires "guid" -> "dataset" mapping (`guid_to_name()`), we have to walk the whole hierarchy to find the right snapshots to send.
When resuming an incremental send both source and destination live in the same pool and have the same guid: this is where `zfs_iter_children()` gets confused and picks up the wrong snapshot, so we end up trying to send an incremental "destination@snap1 -> source@snap2" stream instead of "source@snap1 -> source@snap2": this fails with an "Invalid cross-device link" (EXDEV) error.

```
root@openindiana:~# uname -a
SunOS openindiana 5.11 master-0-gb3c0a3b184 i86pc i386 i86pc
root@openindiana:~# 
root@openindiana:~# 
root@openindiana:~# POOLNAME='testpool'
root@openindiana:~# TMPDIR='/tmp'
root@openindiana:~# zpool destroy -f $POOLNAME
root@openindiana:~# rm -f $TMPDIR/zpool_$POOLNAME.dat
root@openindiana:~# mkfile 128m $TMPDIR/zpool_$POOLNAME.dat
root@openindiana:~# zpool create $POOLNAME $TMPDIR/zpool_$POOLNAME.dat
root@openindiana:~# #
root@openindiana:~# dd if=/dev/urandom of=/$POOLNAME/data.bin bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes transferred in 2.964483 secs (3537130 bytes/sec)
root@openindiana:~# zfs snapshot $POOLNAME@snap1
root@openindiana:~# zfs send $POOLNAME@snap1 | zfs recv -s $POOLNAME/mirror
root@openindiana:~# #
root@openindiana:~# dd if=/dev/urandom of=/$POOLNAME/data.bin bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes transferred in 2.655169 secs (3949188 bytes/sec)
root@openindiana:~# zfs snapshot $POOLNAME@snap2
root@openindiana:~# zfs send -i $POOLNAME@snap1 $POOLNAME@snap2 | dd bs=1M count=1 | zfs recv -s $POOLNAME/mirror
0+1 records in
0+1 records out
312 bytes transferred in 0.010768 secs (28975 bytes/sec)
cannot receive incremental stream: checksum mismatch or incomplete stream.
Partially received snapshot is saved.
A resuming stream can be generated on the sending system by running:
    zfs send -t 1-c12d90fb3-e0-789c636064000310a501c49c50360710a715e5e7a69766a63040814f53c88cd7367f5a14806c762475f94959a9c925103e0860c8a7a515a79630c001489e0d493ea9b224b59801551e597f493ec4155bb5a6a41dccbdd4a08124cf0996cf4bcc4d05d2a9c52505f9f9390ec57989054610b30083501f20
root@openindiana:~# #
root@openindiana:~# TOKEN=$(zfs get -H -o value receive_resume_token $POOLNAME/mirror)
root@openindiana:~# zfs send -nP -t $TOKEN > /dev/null
resume token contents:
nvlist version: 0
        fromguid = 0x84fc3ceb9854824c
        object = 0x1
        offset = 0x0
        bytes = 0x0
        toguid = 0x80d26dc166942ab5
        toname = testpool@snap2
incremental     testpool/mirror@snap1   testpool@snap2
root@openindiana:~# zfs send -t $TOKEN > /dev/null
warning: cannot send 'testpool@snap2': Cross-device link
root@openindiana:~# 
```

Illumos issue: https://www.illumos.org/issues/8940
ZFS on Linux PR: https://github.com/zfsonlinux/zfs/pull/6623

NOTE: the original pull request contained also a small fix for another issue (_zfs send -n -t <token> should dump its output to stdout, not stderr, for consistency with other dry-run commands_): can we squeeze it in this PR or should we open a separate Illumos issue?