### PR TITLE
8941 Assertion failed in get_replication() with nested interior VDEVs

### DIFF
--- a/usr/src/cmd/zpool/zpool_vdev.c
+++ b/usr/src/cmd/zpool/zpool_vdev.c
@@ -628,9 +628,11 @@ get_replication(nvlist_t *nvroot, boolean_t fatal)
 
 				/*
 				 * If this is a replacing or spare vdev, then
-				 * get the real first child of the vdev.
+				 * get the real first child of the vdev: do this
+				 * in a loop because replacing and spare vdevs
+				 * can be nested.
 				 */
-				if (strcmp(childtype,
+				while (strcmp(childtype,
 				    VDEV_TYPE_REPLACING) == 0 ||
 				    strcmp(childtype, VDEV_TYPE_SPARE) == 0) {
 					nvlist_t **rchild;

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -1250,6 +1250,9 @@ file path=opt/zfs-tests/tests/functional/cli_root/zpool/zpool_002_pos \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool/zpool_003_pos \
     mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_add/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_add/setup mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zpool_add/zpool_add.cfg \

--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -1471,6 +1471,31 @@ function check_hotspare_state # pool disk state{inuse,avail}
 }
 
 #
+# Wait until a hotspare transitions to a given state or times out.
+#
+# Return 0 when  pool/disk matches expected state, 1 on timeout.
+#
+function wait_hotspare_state # pool disk state timeout
+{
+	typeset pool=$1
+	typeset disk=${2#$/DEV_DSKDIR/}
+	typeset state=$3
+	typeset timeout=${4:-60}
+	typeset -i i=0
+
+	while [[ $i -lt $timeout ]]; do
+		if check_hotspare_state $pool $disk $state; then
+			return 0
+		fi
+
+		i=$((i+1))
+		sleep 1
+	done
+
+	return 1
+}
+
+#
 # Verify a given slog disk is inuse or avail
 #
 # Return 0 is pool/disk matches expected state, 1 otherwise
@@ -1506,6 +1531,31 @@ function check_vdev_state # pool disk state{online,offline,unavail}
 		return 1
 	fi
 	return 0
+}
+
+#
+# Wait until a vdev transitions to a given state or times out.
+#
+# Return 0 when  pool/disk matches expected state, 1 on timeout.
+#
+function wait_vdev_state # pool disk state timeout
+{
+	typeset pool=$1
+	typeset disk=${2#$/DEV_DSKDIR/}
+	typeset state=$3
+	typeset timeout=${4:-60}
+	typeset -i i=0
+
+	while [[ $i -lt $timeout ]]; do
+		if check_vdev_state $pool $disk $state; then
+			return 0
+		fi
+
+		i=$((i+1))
+		sleep 1
+	done
+
+	return 1
 }
 
 #

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -224,7 +224,8 @@ tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 [/opt/zfs-tests/tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_005_pos', 'zpool_add_006_pos',
-    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg']
+    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
+    'add_nested_replacing_spare']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg']

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -215,7 +215,8 @@ tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 [/opt/zfs-tests/tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_005_pos', 'zpool_add_006_pos',
-    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg']
+    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
+    'add_nested_replacing_spare']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg']

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -215,7 +215,8 @@ tests = ['zpool_001_neg', 'zpool_002_pos', 'zpool_003_pos']
 [/opt/zfs-tests/tests/functional/cli_root/zpool_add]
 tests = ['zpool_add_001_pos', 'zpool_add_002_pos', 'zpool_add_003_pos',
     'zpool_add_004_pos', 'zpool_add_005_pos', 'zpool_add_006_pos',
-    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg']
+    'zpool_add_007_neg', 'zpool_add_008_neg', 'zpool_add_009_neg',
+    'add_nested_replacing_spare']
 
 [/opt/zfs-tests/tests/functional/cli_root/zpool_attach]
 tests = ['zpool_attach_001_neg']

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_add/add_nested_replacing_spare.ksh
@@ -1,0 +1,103 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2017, loli10K <ezomori.nozomu@gmail.com>. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zpool_create/zpool_create.shlib
+
+#
+# DESCRIPTION:
+#	'zpool add' works with nested replacing/spare vdevs
+#
+# STRATEGY:
+#	1. Create a redundant pool with a spare device
+#	2. Manually fault a device, wait for the hot-spare and then replace it:
+#	   this creates a situation where replacing and spare vdevs are nested.
+#	3. Verify 'zpool add' is able to add new devices to the pool.
+#
+
+verify_runnable "global"
+
+function cleanup
+{
+	log_must zinject -c all
+	poolexists $TESTPOOL && \
+		destroy_pool $TESTPOOL
+	log_must rm -f $DATA_DEVS $SPARE_DEVS
+}
+
+log_assert "'zpool add' works with nested replacing/spare vdevs"
+log_onexit cleanup
+
+TMPDIR='/var/tmp'
+FAULT_DEV="$TMPDIR/fault-dev"
+SAFE_DEV1="$TMPDIR/safe-dev1"
+SAFE_DEV2="$TMPDIR/safe-dev2"
+SAFE_DEV3="$TMPDIR/safe-dev3"
+SAFE_DEVS="$SAFE_DEV1 $SAFE_DEV2 $SAFE_DEV3"
+REPLACE_DEV="$TMPDIR/replace-dev"
+ADD_DEV="$TMPDIR/add-dev"
+DATA_DEVS="$FAULT_DEV $SAFE_DEVS $REPLACE_DEV $ADD_DEV"
+SPARE_DEV1="$TMPDIR/spare-dev1"
+SPARE_DEV2="$TMPDIR/spare-dev2"
+SPARE_DEVS="$SPARE_DEV1 $SPARE_DEV2"
+
+for type in "mirror" "raidz1" "raidz2" "raidz3"
+do
+	# 1. Create a redundant pool with a spare device
+	truncate -s $SPA_MINDEVSIZE $DATA_DEVS $SPARE_DEVS
+	log_must zpool create $TESTPOOL $type $FAULT_DEV $SAFE_DEVS
+	log_must zpool add $TESTPOOL spare $SPARE_DEV1
+
+	# 2.1 Fault a device, verify the spare is kicked in
+	log_must zinject -d $FAULT_DEV -e nxio -T all -f 100 $TESTPOOL
+	log_must zpool scrub $TESTPOOL
+	log_must wait_vdev_state $TESTPOOL $FAULT_DEV "UNAVAIL" 60
+	log_must wait_vdev_state $TESTPOOL $SPARE_DEV1 "ONLINE" 60
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV1 "INUSE"
+	log_must check_state $TESTPOOL "$type-0" "DEGRADED"
+
+	# 2.2 Replace the faulted device: this creates a replacing vdev inside a
+	#     spare vdev
+	log_must zpool replace $TESTPOOL $FAULT_DEV $REPLACE_DEV
+	log_must wait_vdev_state $TESTPOOL $REPLACE_DEV "ONLINE" 60
+	zpool status | nawk -v poolname="$TESTPOOL" -v type="$type" 'BEGIN {s=""}
+	    $1 ~ poolname {c=4}; (c && c--) { s=s$1":" }
+	    END { if (s != poolname":"type"-0:spare-0:replacing-0:") exit 1; }'
+	if [[ $? -ne 0 ]]; then
+		log_fail "Pool does not contain nested replacing/spare vdevs"
+	fi
+
+	# 3. Verify 'zpool add' is able to add new devices
+	log_must zpool add $TESTPOOL spare $SPARE_DEV2
+	log_must wait_hotspare_state $TESTPOOL $SPARE_DEV2 "AVAIL"
+	log_must zpool add -f $TESTPOOL $ADD_DEV
+	log_must wait_vdev_state $TESTPOOL $ADD_DEV "ONLINE" 60
+
+	# Cleanup
+	cleanup
+done
+
+log_pass "'zpool add' works with nested replacing/spare vdevs"


### PR DESCRIPTION
When replacing a faulted device which was previously handled by a spare multiple levels of nested interior VDEVs will be present in the pool configuration: `get_replication()` needs to handle this situation gracefully to let zpool add new devices to the pool:

```
root@openindiana:~# POOLNAME='testpool'
root@openindiana:~# TMPDIR='/var/tmp'
root@openindiana:~# sudo zinject -c all
removed all registered handlers
root@openindiana:~# sudo zpool destroy -f $POOLNAME
root@openindiana:~# rm -f $TMPDIR/file-vdev* rm -f $TMPDIR/file-spare*
root@openindiana:~# truncate -s 512m $TMPDIR/file-vdev1
root@openindiana:~# truncate -s 512m $TMPDIR/file-vdev2
root@openindiana:~# sudo zpool create -f -O mountpoint=none $POOLNAME mirror $TMPDIR/file-vdev1 $TMPDIR/file-vdev2
root@openindiana:~# truncate -s 512m $TMPDIR/file-spare1
root@openindiana:~# sudo zpool add $POOLNAME spare $TMPDIR/file-spare1
root@openindiana:~# sudo zinject -d $TMPDIR/file-vdev2 -e nxio -T all -f 100 $POOLNAME
Added handler 1 with the following properties:
  pool: testpool
  vdev: 79ad17dc1b97bcd5
root@openindiana:~# sudo zpool scrub $POOLNAME
root@openindiana:~# sleep 1
root@openindiana:~# truncate -s 512m $TMPDIR/file-vdev3
root@openindiana:~# sudo zpool replace $POOLNAME $TMPDIR/file-vdev2 $TMPDIR/file-vdev3
root@openindiana:~# truncate -s 512m $TMPDIR/file-spare2
root@openindiana:~# sudo zpool add $POOLNAME spare $TMPDIR/file-spare2
Assertion failed: nvlist_lookup_string(cnv, "path", &path) == 0, file zpool_vdev.c, line 651
Abort
root@openindiana:~# sudo zpool add $POOLNAME $TMPDIR/file-spare2
Assertion failed: nvlist_lookup_string(cnv, "path", &path) == 0, file zpool_vdev.c, line 651
Abort
root@openindiana:~# uname -a
SunOS openindiana 5.11 master-0-gb3c0a3b184 i86pc i386 i86pc
root@openindiana:~# zpool status $POOLNAME
  pool: testpool
 state: DEGRADED
  scan: resilvered 308K in 0h0m with 0 errors on Thu Dec 28 21:46:20 2017
config:

        NAME                         STATE     READ WRITE CKSUM
        testpool                     DEGRADED     0     0     0
          mirror-0                   DEGRADED     0     0     0
            /var/tmp/file-vdev1      ONLINE       0     0     0
            spare-1                  UNAVAIL      0     0     0
              replacing-0            UNAVAIL      0     0     0
                /var/tmp/file-vdev2  UNAVAIL      0     0     0  cannot open
                /var/tmp/file-vdev3  ONLINE       0     0     0
              /var/tmp/file-spare1   ONLINE       0     0     0
        spares
          /var/tmp/file-spare1       INUSE     currently in use

errors: No known data errors
root@openindiana:~# 
```


Illumos issue: https://www.illumos.org/issues/8941
ZFS on Linux PR: https://github.com/zfsonlinux/zfs/pull/6996