### PR TITLE
8942 zfs promote .../%recv should be an error

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -3737,6 +3737,9 @@ zfs_promote(zfs_handle_t *zhp)
 		return (zfs_error(hdl, EZFS_BADTYPE, errbuf));
 	}
 
+	if (!zfs_validate_name(hdl, zhp->zfs_name, zhp->zfs_type, B_TRUE))
+		return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
+
 	ret = lzc_promote(zhp->zfs_name, snapname, sizeof (snapname));
 
 	if (ret != 0) {
@@ -4079,6 +4082,10 @@ zfs_rename(zfs_handle_t *zhp, const char *target, boolean_t recursive,
 
 	(void) snprintf(errbuf, sizeof (errbuf), dgettext(TEXT_DOMAIN,
 	    "cannot rename to '%s'"), target);
+
+	/* make sure source name is valid */
+	if (!zfs_validate_name(hdl, zhp->zfs_name, zhp->zfs_type, B_TRUE))
+		return (zfs_error(hdl, EZFS_INVALIDNAME, errbuf));
 
 	/*
 	 * Make sure the target name is valid

--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -264,6 +264,41 @@ function create_bookmark
 	log_must zfs bookmark $fs_vol@$snap $fs_vol#$bkmark
 }
 
+#
+# Create a temporary clone result of an interrupted resumable 'zfs receive'
+# $1 Destination filesystem name. Must not exist, will be created as the result
+#    of this function along with its %recv temporary clone
+# $2 Source filesystem name. Must not exist, will be created and destroyed
+#
+function create_recv_clone
+{
+	typeset recvfs="$1"
+	typeset sendfs="${2:-$TESTPOOL/create_recv_clone}"
+	typeset snap="$sendfs@snap1"
+	typeset incr="$sendfs@snap2"
+	typeset mountpoint="$TESTDIR/create_recv_clone"
+	typeset sendfile="$TESTDIR/create_recv_clone.zsnap"
+
+	[[ -z $recvfs ]] && log_fail "Recv filesystem's name is undefined."
+
+	datasetexists $recvfs && log_fail "Recv filesystem must not exist."
+	datasetexists $sendfs && log_fail "Send filesystem must not exist."
+
+	log_must zfs create -o mountpoint="$mountpoint" $sendfs
+	log_must zfs snapshot $snap
+	log_must eval "zfs send $snap | zfs recv -u $recvfs"
+	log_must mkfile 1m "$mountpoint/data"
+	log_must zfs snapshot $incr
+	log_must eval "zfs send -i $snap $incr | dd bs=10k count=1 > $sendfile"
+	log_mustnot eval "zfs recv -su $recvfs < $sendfile"
+	log_must zfs destroy -r $sendfs
+	log_must rm -f "$sendfile"
+
+	if [[ $(get_prop 'inconsistent' "$recvfs/%recv") -ne 1 ]]; then
+		log_fail "Error creating temporary $recvfs/%recv clone"
+	fi
+}
+
 function default_mirror_setup
 {
 	default_mirror_setup_noexit $1 $2 $3

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_promote/zfs_promote_006_neg.ksh
@@ -40,6 +40,7 @@
 #		pool, fs, snapshot,volume
 #	(4) too many arguments.
 #	(5) invalid options
+#	(6) temporary %recv datasets
 #
 # STRATEGY:
 #	1. Create an array of invalid arguments
@@ -50,16 +51,23 @@
 verify_runnable "both"
 
 snap=$TESTPOOL/$TESTFS@$TESTSNAP
+clone=$TESTPOOL/$TESTCLONE
+recvfs=$TESTPOOL/recvfs
 set -A args "" \
 	"$TESTPOOL/blah" \
 	"$TESTPOOL" "$TESTPOOL/$TESTFS" "$snap" \
 	"$TESTPOOL/$TESTVOL" "$TESTPOOL $TESTPOOL/$TESTFS" \
-	"$clone $TESTPOOL/$TESTFS" "- $clone" "-? $clone"
+	"$clone $TESTPOOL/$TESTFS" "- $clone" "-? $clone" \
+	"$recvfs/%recv"
 
 function cleanup
 {
 	if datasetexists $clone; then
 		log_must zfs destroy $clone
+	fi
+
+	if datasetexists $recvfs; then
+		log_must zfs destroy -r $recvfs
 	fi
 
 	if snapexists $snap; then
@@ -70,10 +78,9 @@ function cleanup
 log_assert "'zfs promote' will fail with invalid arguments. "
 log_onexit cleanup
 
-snap=$TESTPOOL/$TESTFS@$TESTSNAP
-clone=$TESTPOOL/$TESTCLONE
 log_must zfs snapshot $snap
 log_must zfs clone $snap $clone
+create_recv_clone $recvfs
 
 typeset -i i=0
 while (( i < ${#args[*]} )); do

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.cfg
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.cfg
@@ -36,3 +36,4 @@ export BS=512
 export CNT=2048
 export VOL_R_PATH=/dev/zvol/rdsk/$TESTPOOL/$TESTVOL
 export VOLDATA=$TESTDIR2/voldata.rename
+export RECVFS=recvfs

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename.kshlib
@@ -63,6 +63,8 @@ function additional_setup
 		log_must cp $DATA $(get_prop mountpoint $TESTPOOL/$TESTVOL)/$TESTFILE0
 	fi
 
+	# Create temporary %recv clone
+	create_recv_clone $TESTPOOL/$RECVFS
 }
 
 function rename_dataset # src dest
@@ -109,6 +111,9 @@ function cleanup
 		log_must zfs destroy -fR $TESTPOOL/$TESTFS@snapshot
 	fi
 
+	if datasetexists $TESTPOOL/$RECVFS; then
+		log_must zfs destroy -r $TESTPOOL/$RECVFS
+	fi
 }
 
 function cmp_data #<$1 src data, $2 tgt data>

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_004_neg.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_rename/zfs_rename_004_neg.ksh
@@ -77,8 +77,8 @@ set -A bad_dataset $TESTPOOL/$TESTFS1 $TESTPOOL/$TESTCTR1 \
 	$TESTPOOL/$TESTFS1 $TESTPOOL/${TESTFS1}%x \
 	$TESTPOOL/$TESTFS1 $TESTPOOL/${TESTFS1}%p \
 	$TESTPOOL/$TESTFS1 $TESTPOOL/${TESTFS1}%s \
-	$TESTPOOL/$TESTFS@snapshot \
-	$TESTPOOL/$TESTFS@snapshot/fs
+	$TESTPOOL/$TESTFS@snapshot $TESTPOOL/$TESTFS@snapshot/fs \
+	$TESTPOOL/$RECVFS/%recv $TESTPOOL/renamed.$$
 
 #
 # cleanup defined in zfs_rename.kshlib

--- a/usr/src/uts/common/fs/zfs/zfs_ioctl.c
+++ b/usr/src/uts/common/fs/zfs/zfs_ioctl.c
@@ -3755,9 +3755,12 @@ zfs_ioc_rename(zfs_cmd_t *zc)
 	boolean_t recursive = zc->zc_cookie & 1;
 	char *at;
 
+	/* "zfs rename" from and to ...%recv datasets should both fail */
+	zc->zc_name[sizeof (zc->zc_name) - 1] = '\0';
 	zc->zc_value[sizeof (zc->zc_value) - 1] = '\0';
-	if (dataset_namecheck(zc->zc_value, NULL, NULL) != 0 ||
-	    strchr(zc->zc_value, '%'))
+	if (dataset_namecheck(zc->zc_name, NULL, NULL) != 0 ||
+	    dataset_namecheck(zc->zc_value, NULL, NULL) != 0 ||
+	    strchr(zc->zc_name, '%') || strchr(zc->zc_value, '%'))
 		return (SET_ERROR(EINVAL));
 
 	at = strchr(zc->zc_name, '@');
@@ -4779,6 +4782,11 @@ zfs_ioc_promote(zfs_cmd_t *zc)
 	char origin[ZFS_MAX_DATASET_NAME_LEN];
 	char *cp;
 	int error;
+
+	zc->zc_name[sizeof (zc->zc_name) - 1] = '\0';
+	if (dataset_namecheck(zc->zc_name, NULL, NULL) != 0 ||
+	    strchr(zc->zc_name, '%'))
+		return (SET_ERROR(EINVAL));
 
 	error = dsl_pool_hold(zc->zc_name, FTAG, &dp);
 	if (error != 0)


### PR DESCRIPTION
If we are in the middle of an incremental 'zfs receive', the child .../%recv will exist. If we run 'zfs promote' .../%recv, it will "work", but then zfs gets confused about the status of the new dataset.
Attempting to do this promote should be an error. Similarly renaming .../%recv datasets should not be allowed.

```
root@openindiana:~# POOLNAME='testpool'
root@openindiana:~# TMPDIR='/tmp'
root@openindiana:~# zpool destroy -f $POOLNAME
root@openindiana:~# rm -f $TMPDIR/zpool_$POOLNAME.dat
root@openindiana:~# mkfile 128m $TMPDIR/zpool.dat
root@openindiana:~# zpool create -O mountpoint=$TMPDIR/$POOLNAME $POOLNAME $TMPDIR/zpool.dat
root@openindiana:~# zfs create -o mountpoint=$TMPDIR/$POOLNAME/src $POOLNAME/src 
root@openindiana:~# dd if=/dev/urandom of=/$TMPDIR/$POOLNAME/src/file.dat bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes transferred in 1.332270 secs (7870596 bytes/sec)
root@openindiana:~# zfs snap $POOLNAME/src@snap1
root@openindiana:~# dd if=/dev/urandom of=/$TMPDIR/$POOLNAME/src/file.dat bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes transferred in 1.186960 secs (8834133 bytes/sec)
root@openindiana:~# zfs snap $POOLNAME/src@snap2
root@openindiana:~# dd if=/dev/urandom of=/$TMPDIR/$POOLNAME/src/file.dat bs=1M count=10
10+0 records in
10+0 records out
10485760 bytes transferred in 4.167742 secs (2515933 bytes/sec)
root@openindiana:~# zfs snap $POOLNAME/src@snap3
root@openindiana:~# zfs send -p $POOLNAME/src@snap1 | zfs recv -vu $POOLNAME/dst
receiving full stream of testpool/src@snap1 into testpool/dst@snap1
received 10.1MB stream in 2 seconds (5.04MB/sec)
root@openindiana:~# zfs send -pI $POOLNAME/src@snap1 $POOLNAME/src@snap3 | dd bs=1M count=15 | zfs recv -svu $POOLNAME/dst
0+15 records in
0+15 records out
7492 bytes transferred in 0.047300 secs (158394 bytes/sec)
receiving incremental stream of testpool/src@snap2 into testpool/dst@snap2
cannot receive incremental stream: checksum mismatch or incomplete stream.
Partially received snapshot is saved.
A resuming stream can be generated on the sending system by running:
    zfs send -t 1-d1172b276-e8-789c636064000310a501c49c50360710a715e5e7a69766a63040c124fbd9856f99765a2b00d9ec48eaf293b252934b207c10c0904f4b2b4e2d618003903c1b927c5265496a3103aa3cb2fe927c882b7c22ce963d29dbd4658024cf0996cf4bcc4d05d2a9c52505f9f939fac545c90ec57989054608330126352022
root@openindiana:~# zfs get name,inconsistent,mountpoint,origin $POOLNAME/dst/%recv
NAME                PROPERTY      VALUE                    SOURCE
testpool/dst/%recv  name          testpool/dst/%recv       -
testpool/dst/%recv  inconsistent  1                        -
testpool/dst/%recv  mountpoint    /tmp/testpool/src/%recv  inherited from testpool/dst
testpool/dst/%recv  origin        testpool/dst@snap1       -
root@openindiana:~# zfs promote $POOLNAME/dst/%recv
root@openindiana:~# 
root@openindiana:~# zfs destroy $POOLNAME/dst
cannot destroy 'testpool/dst': dataset already exists
root@openindiana:~# zfs destroy -r $POOLNAME/dst
cannot destroy 'testpool/dst': dataset already exists
root@openindiana:~# zfs destroy -rR $POOLNAME/dst
cannot destroy 'testpool/dst': dataset already exists
root@openindiana:~# 
```

Illumos issue: https://www.illumos.org/issues/8942
ZFS on Linux PR: zfsonlinux/zfs#6339