### PR TITLE
8965 zfs_acl_ls_001_pos fails due to no longer supported grep regex

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/acl/acl_common.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/acl/acl_common.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/acl/acl.cfg
@@ -185,7 +185,7 @@ function plus_sign_check_l #<obj>
 		return 1
 	fi
 
-	ls -ld $obj | awk '{print $1}' | grep "+\>" > /dev/null
+	ls -ld $obj | awk '{print $1}' | grep "+$" > /dev/null
 
         return $?
 }
@@ -202,7 +202,7 @@ function plus_sign_check_v #<obj>
 		return 1
 	fi
 
-	ls -vd $obj | nawk '(NR == 1) {print $1}' | grep "+\>" > /dev/null
+	ls -vd $obj | awk '(NR == 1) {print $1}' | grep "+$" > /dev/null
 
         return $?
 }


### PR DESCRIPTION
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Akash Ayare <aayare@delphix.com>

The test used `\>` to detect the end of a string, but this no longer works,
so use `$` which works as well since the string ends the line anyway.