### PR TITLE
XXX Does removing bootfs_008_pos change anything?

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,11 +175,11 @@ node('master') {
         }
     } finally {
         stage('delete image') {
-            if (env.BUILD_IMAGE_ID && env.BUILD_IMAGE_ID != env.BASE_IMAGE_ID) {
-                shscript('aws-delete-image', false, [
-                    ['IMAGE_ID', env.BUILD_IMAGE_ID]
-                ])
-            }
+//            if (env.BUILD_IMAGE_ID && env.BUILD_IMAGE_ID != env.BASE_IMAGE_ID) {
+//                shscript('aws-delete-image', false, [
+//                    ['IMAGE_ID', env.BUILD_IMAGE_ID]
+//                ])
+//            }
 
             if (env.BUILD_INSTANCE_ID) {
                 shscript('aws-terminate-instances', false, [
@@ -297,11 +297,11 @@ def run_test(script, instance_type, spot_price, limit, disks, parameters) {
                 }
             }
         } finally {
-            if (instance_id) {
-                shscript('aws-terminate-instances', false, [
-                    ['INSTANCE_ID', instance_id]
-                ])
-            }
+//            if (instance_id) {
+//                shscript('aws-terminate-instances', false, [
+//                    ['INSTANCE_ID', instance_id]
+//                ])
+//            }
         }
     }
 }

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -56,6 +56,13 @@ tests = ['zfs_acl_chmod_001_pos', 'zfs_acl_compress_001_pos',
 [/opt/zfs-tests/tests/functional/atime]
 tests = ['atime_001_pos', 'atime_002_neg']
 
+[/opt/zfs-tests/tests/functional/bootfs]
+tests = ['bootfs_001_pos', 'bootfs_002_neg', 'bootfs_003_pos',
+    'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos',
+    'bootfs_008_pos']
+pre =
+post =
+
 [/opt/zfs-tests/tests/functional/cache]
 tests = ['cache_001_pos', 'cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg', 'cache_006_pos', 'cache_007_neg', 'cache_008_neg',

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -58,8 +58,7 @@ tests = ['atime_001_pos', 'atime_002_neg']
 
 [/opt/zfs-tests/tests/functional/bootfs]
 tests = ['bootfs_001_pos', 'bootfs_002_neg', 'bootfs_003_pos',
-    'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos',
-    'bootfs_008_pos']
+    'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos']
 pre =
 post =
 

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -56,12 +56,6 @@ tests = ['zfs_acl_chmod_001_pos', 'zfs_acl_compress_001_pos',
 [/opt/zfs-tests/tests/functional/atime]
 tests = ['atime_001_pos', 'atime_002_neg']
 
-[/opt/zfs-tests/tests/functional/bootfs]
-tests = ['bootfs_001_pos', 'bootfs_002_neg', 'bootfs_003_pos',
-    'bootfs_004_neg', 'bootfs_005_neg', 'bootfs_006_pos', 'bootfs_007_pos']
-pre =
-post =
-
 [/opt/zfs-tests/tests/functional/cache]
 tests = ['cache_001_pos', 'cache_002_pos', 'cache_003_pos', 'cache_004_neg',
     'cache_005_neg', 'cache_006_pos', 'cache_007_neg', 'cache_008_neg',


### PR DESCRIPTION
This isn't to be landed; just seeing if removing the bootfs_008_pos test
case will allow the zfs-test suite to run successfully.