### PR TITLE
9004 Some ZFS tests used files removed with 32 bit kernel

### DIFF
--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 #
@@ -22,6 +22,7 @@
 # and maintenance.
 #
 export USR_BIN_FILES='awk
+    base64
     basename
     bc
     bunzip2

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_cp_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_cp_002_pos.ksh
@@ -26,7 +26,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/acl/acl_common.kshlib
@@ -53,8 +53,7 @@ function cleanup
 	if datasetexists $TESTPOOL/$TESTFS1; then
 		log_must zfs destroy -f $TESTPOOL/$TESTFS1
 	fi
-	[[ -d $TESTDIR1 ]] && log_must rm -rf $TESTDIR1
-	[[ -d $TESTDIR ]] && log_must rm -rf $TESTDIR/*
+	log_must rm -rf $TESTDIR1 $TESTDIR/* $mytestfile
 }
 
 log_assert "Verify that 'cp [-p]' supports ZFS ACLs."
@@ -68,7 +67,9 @@ log_must chmod 777 $TESTDIR1
 
 # Define target directory.
 dstdir=$TESTDIR1/dstdir.$$
-mytestfile=/kernel/drv/zfs
+mytestfile=$(mktemp -t file.XXXX)
+log_must dd if=/dev/urandom of=$mytestfile bs=1024k count=1
+log_must chmod 644 $mytestfile
 
 for user in root $ZFS_ACL_STAFF1; do
 	# Set the current user

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_cpio_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_cpio_002_pos.ksh
@@ -28,7 +28,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/acl/acl_common.kshlib
@@ -57,8 +57,7 @@ function cleanup
 	if (( ${#orig_dir} != 0 )); then
 		cd $orig_dir
 	fi
-	[[ -d $TESTDIR1 ]] && log_must rm -rf $TESTDIR1
-	[[ -d $TESTDIR ]] && log_must rm -rf $TESTDIR/*
+	log_must rm -rf $TESTDIR1 $TESTDIR/* $mytestfile
 }
 
 log_assert "Verify that 'cpio' command supports to archive ZFS ACLs & xattrs."
@@ -81,7 +80,9 @@ CPIOFILE=cpiofile.$$
 file=$TESTFILE0
 dir=dir.$$
 orig_dir=$PWD
-mytestfile=/kernel/drv/zfs
+mytestfile=$(mktemp -t file.XXXX)
+log_must dd if=/dev/urandom of=$mytestfile bs=1024k count=1
+log_must chmod 644 $mytestfile
 
 typeset user
 for user in root $ZFS_ACL_STAFF1; do

--- a/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_tar_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/acl/nontrivial/zfs_acl_tar_002_pos.ksh
@@ -28,7 +28,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2016, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/acl/acl_common.kshlib
@@ -57,8 +57,7 @@ function cleanup
 	fi
 
 	(( ${#cwd} != 0 )) && cd $cwd
-	[[ -d $TESTDIR1 ]] && log_must rm -rf $TESTDIR1
-	[[ -d $TESTDIR/ ]] && log_must rm -rf $TESTDIR/*
+	log_must rm -rf $TESTDIR1 $TESTDIR/* $mytestfile
 }
 
 log_assert "Verify that 'tar' command supports to archive ZFS ACLs & xattrs."
@@ -67,7 +66,9 @@ log_onexit cleanup
 
 set -A ops " A+user:other1:add_file:allow" "A+everyone@:execute:allow" "a-x" \
     "777"
-mytestfile=/kernel/drv/zfs
+mytestfile=$(mktemp -t file.XXXX)
+log_must dd if=/dev/urandom of=$mytestfile bs=1024k count=1
+log_must chmod 644 $mytestfile
 
 TARFILE=tarfile.$$.tar
 cwd=$PWD

--- a/usr/src/test/zfs-tests/tests/functional/rsend/send-cD.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/rsend/send-cD.ksh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2015 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/tests/functional/rsend/rsend.kshlib
@@ -46,7 +46,7 @@ log_must zfs create -o compress=lz4 $sendfs
 log_must zfs create -o compress=lz4 $recvfs
 typeset dir=$(get_prop mountpoint $sendfs)
 # Don't use write_compressible: we want compressible but undedupable data here.
-log_must cp /kernel/genunix $dir/file
+log_must eval "dd if=/dev/urandom bs=1024k count=4 | base64 >$dir/file"
 log_must zfs snapshot $sendfs@snap0
 log_must eval "zfs send -D -c $sendfs@snap0 >$stream0"
 


### PR DESCRIPTION
The tests should avoid using OS files that might disappear if possible.