### PR TITLE
9064 ZFS test remove_mirror should wait for device removal to complete

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/removal/remove_mirror.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/removal/remove_mirror.ksh
@@ -15,7 +15,7 @@
 #
 
 #
-# Copyright (c) 2014, 2017 by Delphix. All rights reserved.
+# Copyright (c) 2014, 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -25,7 +25,8 @@ TMPDIR=${TMPDIR:-/tmp}
 log_must mkfile $(($MINVDEVSIZE * 2)) $TMPDIR/dsk1
 log_must mkfile $(($MINVDEVSIZE * 2)) $TMPDIR/dsk2
 log_must mkfile $(($MINVDEVSIZE * 2)) $TMPDIR/dsk3
-DISKS="$TMPDIR/dsk1 mirror $TMPDIR/dsk2 $TMPDIR/dsk3"
+DISKS="$TMPDIR/dsk1 $TMPDIR/dsk2 $TMPDIR/dsk3"
+VDEVS="$TMPDIR/dsk1 mirror $TMPDIR/dsk2 $TMPDIR/dsk3"
 
 function cleanup
 {
@@ -33,11 +34,12 @@ function cleanup
 	log_must rm -f $DISKS
 }
 
-log_must default_setup_noexit "$DISKS"
+log_must default_setup_noexit "$VDEVS"
 log_onexit cleanup
 
 # Attempt to remove the non mirrored disk.
 log_must zpool remove $TESTPOOL $TMPDIR/dsk1
+log_must wait_for_removal $TESTPOOL
 
 # Attempt to remove one of the disks in the mirror.
 log_mustnot zpool remove $TESTPOOL $TMPDIR/dsk2


### PR DESCRIPTION
Fixes the transient failure of `remove_mirror` zfs-test run(s). 