### PR TITLE
9074 domount() interprets ZFS filesystem names as relative paths

### DIFF
--- a/usr/src/uts/common/fs/hsfs/hsfs_vfsops.c
+++ b/usr/src/uts/common/fs/hsfs/hsfs_vfsops.c
@@ -22,6 +22,7 @@
  * Copyright (c) 1990, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Bayard G. Bell. All rights reserved.
  * Copyright 2013 Joyent, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -150,7 +151,7 @@ static vfsdef_t vfw = {
 	"hsfs",
 	hsfsinit,
 	/* We don't suppport remounting */
-	VSW_HASPROTO|VSW_STATS|VSW_CANLOFI,
+	VSW_HASPROTO|VSW_STATS|VSW_CANLOFI|VSW_MOUNTDEV,
 	&hsfs_proto_opttbl
 };
 

--- a/usr/src/uts/common/fs/pcfs/pc_vfsops.c
+++ b/usr/src/uts/common/fs/pcfs/pc_vfsops.c
@@ -23,6 +23,9 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
+/*
+ * Copyright (c) 2017 by Delphix. All rights reserved.
+ */
 
 #include <sys/param.h>
 #include <sys/systm.h>
@@ -156,7 +159,7 @@ static vfsdef_t vfw = {
 	VFSDEF_VERSION,
 	"pcfs",
 	pcfsinit,
-	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI,
+	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI|VSW_MOUNTDEV,
 	&pcfs_mntopts
 };
 

--- a/usr/src/uts/common/fs/udfs/udf_vfsops.c
+++ b/usr/src/uts/common/fs/udfs/udf_vfsops.c
@@ -22,6 +22,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright (c) 2011 Bayard G. Bell. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -121,7 +122,7 @@ static vfsdef_t vfw = {
 	VFSDEF_VERSION,
 	"udfs",
 	udfinit,
-	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI,
+	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI|VSW_MOUNTDEV,
 	&udfs_mntopts
 };
 
@@ -177,7 +178,7 @@ _NOTE(SCHEME_PROTECTS_DATA("safe sharing", rootvp))
 #endif
 static int32_t
 udf_mount(struct vfs *vfsp, struct vnode *mvp,
-	struct mounta *uap, struct cred *cr)
+    struct mounta *uap, struct cred *cr)
 {
 	dev_t dev;
 	struct vnode *lvp = NULL;
@@ -489,8 +490,7 @@ udf_sync(struct vfs *vfsp, int16_t flag, struct cred *cr)
 
 /* ARGSUSED */
 static int32_t
-udf_vget(struct vfs *vfsp,
-	struct vnode **vpp, struct fid *fidp)
+udf_vget(struct vfs *vfsp, struct vnode **vpp, struct fid *fidp)
 {
 	int32_t error = 0;
 	struct udf_fid *udfid;
@@ -612,9 +612,8 @@ udf_mountroot(struct vfs *vfsp, enum whymountroot why)
 
 
 static int32_t
-ud_mountfs(struct vfs *vfsp,
-	enum whymountroot why, dev_t dev, char *name,
-	struct cred *cr, int32_t isroot)
+ud_mountfs(struct vfs *vfsp, enum whymountroot why, dev_t dev, char *name,
+    struct cred *cr, int32_t isroot)
 {
 	struct vnode *devvp = NULL;
 	int32_t error = 0;
@@ -1554,7 +1553,7 @@ ud_destroy_fsp(struct udf_vfs *udf_vfsp)
 
 void
 ud_convert_to_superblock(struct udf_vfs *udf_vfsp,
-	struct log_vol_int_desc *lvid)
+    struct log_vol_int_desc *lvid)
 {
 	int32_t i, c;
 	uint32_t *temp;
@@ -1652,7 +1651,7 @@ int32_t ud_sub_count = 4;
  */
 static int32_t
 ud_val_get_vat(struct udf_vfs *udf_vfsp, dev_t dev,
-	daddr_t blkno, struct ud_map *udm)
+    daddr_t blkno, struct ud_map *udm)
 {
 	struct buf *secbp;
 	struct file_entry *fe;
@@ -1776,7 +1775,7 @@ end:
 
 int32_t
 ud_read_sparing_tbls(struct udf_vfs *udf_vfsp,
-	dev_t dev, struct ud_map *map, struct pmap_typ2 *typ2)
+    dev_t dev, struct ud_map *map, struct pmap_typ2 *typ2)
 {
 	int32_t index, valid = 0;
 	uint32_t sz;

--- a/usr/src/uts/common/fs/ufs/ufs_vfsops.c
+++ b/usr/src/uts/common/fs/ufs/ufs_vfsops.c
@@ -23,6 +23,7 @@
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*	Copyright (c) 1983, 1984, 1985, 1986, 1987, 1988, 1989 AT&T	*/
@@ -196,7 +197,7 @@ static vfsdef_t vfw = {
 	VFSDEF_VERSION,
 	"ufs",
 	ufsinit,
-	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI,
+	VSW_HASPROTO|VSW_CANREMOUNT|VSW_STATS|VSW_CANLOFI|VSW_MOUNTDEV,
 	&ufs_mntopts
 };
 
@@ -258,8 +259,7 @@ static int mountfs(struct vfs *, enum whymountroot, struct vnode *, char *,
 
 static int
 ufs_mount(struct vfs *vfsp, struct vnode *mvp, struct mounta *uap,
-	struct cred *cr)
-
+    struct cred *cr)
 {
 	char *data = uap->dataptr;
 	int datalen = uap->datalen;
@@ -796,7 +796,7 @@ int ufs_mount_timeout = 60000;	/* default to 1 minute */
 
 static int
 mountfs(struct vfs *vfsp, enum whymountroot why, struct vnode *devvp,
-	char *path, cred_t *cr, int isroot, void *raw_argsp, int args_len)
+    char *path, cred_t *cr, int isroot, void *raw_argsp, int args_len)
 {
 	dev_t dev = devvp->v_rdev;
 	struct fs *fsp;

--- a/usr/src/uts/common/fs/vfs.c
+++ b/usr/src/uts/common/fs/vfs.c
@@ -23,7 +23,7 @@
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Joyent, Inc.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.
  * Copyright 2017 RackTop Systems.
  */
@@ -1291,7 +1291,8 @@ domount(char *fsname, struct mounta *uap, vnode_t *vp, struct cred *credp,
 		 * successful for later cleanup and addition to
 		 * the mount in progress table.
 		 */
-		if ((uap->flags & MS_GLOBAL) == 0 &&
+		if ((vswp->vsw_flag & VSW_MOUNTDEV) &&
+		    (uap->flags & MS_GLOBAL) == 0 &&
 		    lookupname(uap->spec, fromspace,
 		    FOLLOW, NULL, &bvp) == 0) {
 			addmip = 1;
@@ -1507,7 +1508,8 @@ domount(char *fsname, struct mounta *uap, vnode_t *vp, struct cred *credp,
 	 * wlock above. This case is for a non-spliced, non-global filesystem.
 	 */
 	if (!addmip) {
-		if ((uap->flags & MS_GLOBAL) == 0 &&
+		if ((vswp->vsw_flag & VSW_MOUNTDEV) &&
+		    (uap->flags & MS_GLOBAL) == 0 &&
 		    lookupname(uap->spec, fromspace, FOLLOW, NULL, &bvp) == 0) {
 			addmip = 1;
 		}

--- a/usr/src/uts/common/sys/vfs.h
+++ b/usr/src/uts/common/sys/vfs.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 1988, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Toomas Soome <tsoome@me.com>
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  * Copyright 2016 Nexenta Systems, Inc.
  */
 
@@ -416,6 +416,7 @@ enum {
 #define	VSW_XID		0x40	/* file system supports extended ids */
 #define	VSW_CANLOFI	0x80	/* file system supports lofi mounts */
 #define	VSW_ZMOUNT	0x100	/* file system always allowed in a zone */
+#define	VSW_MOUNTDEV	0x200	/* file system is mounted via device path */
 
 #define	VSW_INSTALLED	0x8000	/* this vsw is associated with a file system */
 


### PR DESCRIPTION
Problem
=======

The domount() function that is called by the mount() system call erroneously
calls lookupname() (a VFS filename lookup function) on ZFS filesystem names
when mounting ZFS filesystems. This causes spurious short-lived vnode holds to
be placed on vnode_t's unrelated to the filesystem being mounted, as described
below.

domount() maintains a VFS "mount-in-progress table" which contains a mapping
of dev_t's being mounted to filesystems (see vfs_addmip()). The idea is that
filesystems like UFS can, when processing a mount request, look at the table
to determine if a device is already in the process of being mounted (see
vfs_devmounting()). In order to add a device to the "mount-in-progress table"
domount() calls lookupname() on the mount "spec" (e.g. for a UFS filesystem,
that would be /dev/dsk/blabla) to obtain the vnode associated with that
pathname, and adds the vnode's v_rdev to the table (under the assumption that
it's a device...).

The lookupname() function does its work by starting at the root of the path,
and calling VOP_LOOKUP() on the "next" component of the path. Once it has held
the vnode associated with the top-most directory, it iteratively calls
VOP_LOOKUP() on the next component, and so on, until it has resolved the
entire path, and has a vnode hold on the leaf filesystem entry (it also
follows symbolic links, etc.). The guts of this algorithm is implemented in
lookuppnvp(). The entire call chain for this lookupname() call from domount()
looks like:

    domount()
      lookupname()
        lookupnameatcred()
          lookuppnatcred()
            lookuppnvp()
              (loops over components of the path doing VOP_LOOKUP() calls on each one)

This all seems reasonable so far, but as you might have guessed from the
summary for this bug, none of this makes a lick of sense when mounting a ZFS
filesystem. The mount spec that is passed into the mount system call for ZFS
isn't a path at all, but a ZFS filesystem name, which doesn't exist in the VFS
namespace.

What ends up happening in that case is that domount() passes a filesystem name
into lookupname(). That filesystem name kind of looks like a path, and
specifically, it looks like a relative path name (a path without a leading
'/'). As it turns out, the lookuppnatcred() call in the call chain above
handles this by pre-pending the current working directory to the path in this
case:

    if (pnp->pn_path[0] == '/') {
            vp = rootvp;
    } else {
            vp = (startvp == NULL) ? PTOU(p)->u_cdir : startvp;
    }

This code results in a fully-qualified path getting ultimately passed in to
lookuppnvp(), and is part of the generic lookup code. The end result is that
if I mount a ZFS filesystem named "mypool/seb", and my PWD is "/home/seb",
lookuppnvp() will attempt to get a hold on the path named
"/home/seb/mypool/seb", which is non-sensical, and fails. This failure is
ultimately gracefully handled by domount(), which simply silently doesn't
enter a device into the "mount-in-progress table" in this case.

So you might then think, "if domount() silently handles this gracefully, then
this could just be left alone, as it's harmless." Unfortunately, it's not
harmless, as the lookuppnvp() function iteratively places vnode holds on each
component of the path that it's looking up. Consider the following scenario
where we have the following filesystems and associated mountpoints:

    NAME       MOUNTPOINT
    seb        /seb
    seb/data   /data

These two mountpoints are unrelated to one another. I should be able to
simultaneously mount these two filesystems. Let's say I do that, and my CWD is
"/". Unfortunately, due to the lookupname() call described above in domount(),
the mounting of the "seb" filesystem might fail with EBUSY if the mount for
"seb/data" happens to be in the middle of attempting to resolve the bogus path
"/seb/data", a very short-lived vnode hold on "/seb" will cause the mount for
the "seb" filesystem to fail with "EBUSY" when it attempts to check if its
mountpoint is "busy".

As such, the lookupname() code in domount() should only be called if the mount
spec passed in is a path, and not an opaque filesystem-dependent string as it
is for ZFS.

Also note that this problem exists not only for ZFS, but for any filesystem
whose mount spec isn't a device path (e.g. NFS, swapfs, tmpfs, ctfs, autofs,
procfs, etc.).

Solution
========

There are a few possible approaches to a fix. One way would be to check if a
mount is for a ZFS filesystem in domount(), and if it is, skip the device path
lookup. This would be fine for ZFS, but as mentioned in the description, this
bug actually exists for a plethora of other filesystems that don't mount from
a device path.

As such, the fix is to add a VSW VFS flag that indicates that the filesystem
is mounted from a device path. If the flag is set, then domount() will know
not to bother with the device path lookup and mount-in-progress table
management for this mount.

How to Reproduce
================

Create two filesystems as described above on a test pool:

    # zpool create seb /dev/dsk/c1t1d0
    # zfs create -o mountpoint=/data seb/data
    # zfs list -o name,mountpoint -r seb
    NAME      MOUNTPOINT
    seb       /seb
    seb/data  /data

Now, create a simple unmount/mount looping script as follows:

    # cat ~/mount-stress.sh
    #!/usr/bin/bash

    while true; do
        zfs unmount $1 || exit 1
        zfs mount $1 || exit 1
    done

Now, simply invoke this script on each filesystem in parallel as follows:

    # ./mount-stress.sh seb &
    [1] 734
    # ./mount-stress.sh seb/data &
    [2] 1212

I've found that in less than a second, one of the "zfs mount seb" invocations
will fail with EBUSY as described above:

Notes
=====

The root-cause analysis for this issue was facilitated by the static DTrace
probes added in commit e15e026e38850c2df8dfce29873a46a089d5e215.

Upstream bugs: DLPX-49847