### PR TITLE
9077 zloop misses core files because they're no longer written into cwd

### DIFF
--- a/usr/src/cmd/ztest/zloop.bash
+++ b/usr/src/cmd/ztest/zloop.bash
@@ -16,7 +16,7 @@
 #
 
 #
-# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2017 by Delphix. All rights reserved.
 #
 
 set -x
@@ -145,6 +145,9 @@ fi
 
 or_die /bin/rm -f ztest.history
 or_die /bin/rm -f ztest.cores
+
+# Allow core files to be written to cwd if that's currently disabled.
+sudo coreadm -e process
 
 ztrc=0		# ztest return value
 foundcrashes=0	# number of crashes found so far


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>

To make zloop for resilient to coreadm configuration differences on the various
illumos distributions, we should enable per process core dumps at the start of
zloop.

Upstream bug: DLPX-52252