### PR TITLE
9091 Add mdb smart write

### DIFF
--- a/usr/src/cmd/mdb/common/mdb/mdb_fmt.c
+++ b/usr/src/cmd/mdb/common/mdb/mdb_fmt.c
@@ -22,6 +22,7 @@
  * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  * Copyright 2016 Joyent, Inc.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 /*
@@ -118,6 +119,7 @@ static const char help_match32[] = "int";
 static const char help_match64[] = "long long";
 static const char help_match16[] = "short";
 static const char help_uintptr[] = "hexadecimal uintptr_t";
+static const char help_ctf[] = "whose size is inferred by CTF info";
 
 /*ARGSUSED*/
 static mdb_tgt_addr_t
@@ -618,7 +620,7 @@ static const mdb_fmt_desc_t fmttab[] = {
 	{ FMT_PRINTF|FMT_WRITE, "%-8hr", NULL, 2 },		/* 119 = w */
 	{ FMT_PRINTF, "%-8hx", NULL, 2 },			/* 120 = x */
 	{ FMT_FUNC, FUNCP(fmt_time64), help_time64, 8 },	/* 121 = y */
-	{ FMT_NONE, NULL, NULL, 0 },				/* 122 = z */
+	{ FMT_WRITE, NULL, help_ctf, 0 },			/* 122 = z */
 };
 
 mdb_tgt_addr_t

--- a/usr/src/cmd/mdb/common/mdb/mdb_lex.l
+++ b/usr/src/cmd/mdb/common/mdb/mdb_lex.l
@@ -27,6 +27,7 @@
 
 /*
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -213,7 +214,7 @@ RGX_COMMENT	"//".*\n
 		return (MDB_TOK_DCMD);
 	}
 
-<S_INITIAL>[/\\?][ \t]*[vwWZlLM]	{
+<S_INITIAL>[/\\?][ \t]*[vwzWZlLM]	{
 		/*
 		 * Format verb followed by write or match signifier -- switch
 		 * to the value list state and return the verb character.  We

--- a/usr/src/man/man1/mdb.1
+++ b/usr/src/man/man1/mdb.1
@@ -1,6 +1,7 @@
 '\" te
 .\" Copyright (c) 2005, Sun Microsystems, Inc. All Rights Reserved.
 .\" Copyright (c) 2012, Joyent, Inc. All Rights Reserved.
+.\" Copyright (c) 2014, 2017 by Delphix. All rights reserved.
 .\" The contents of this file are subject to the terms of the Common Development and Distribution License (the "License").  You may not use this file except in compliance with the License.
 .\" You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE or http://www.opensolaris.org/os/licensing.  See the License for the specific language governing permissions and limitations under the License.
 .\" When distributing Covered Code, include this CDDL HEADER in each file and include the License file at usr/src/OPENSOLARIS.LICENSE.  If applicable, add the following below this CDDL HEADER, with the fields enclosed by brackets "[]" replaced with your own identifying information: Portions Copyright [yyyy] [name of copyright owner]
@@ -1379,6 +1380,7 @@ v	decimal signed int (1 byte)
 w	default radix unsigned short (2 bytes)
 x	hexadecimal short (2 bytes)
 y	decoded time64_t (8 bytes)
+z	write whose size is inferred by CTF info (variable size)
 .TE
 
 .sp


### PR DESCRIPTION
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

Currently, if you want to write to a kernel tunable using
mdb, you need to use the /Z or /W flags to write 8 or 4
bytes respectively. If you use the wrong one, you will either
overwrite only part of the tunable, or overrun the end of the
tunable and zero out the next 4 bytes of memory. That second
option in particular can be disastrous. Given that MDB knows
the size of the tunables because it has CTF data, it would be
nice if MDB supported a "smart write" format string that
selected the size of the write based on the size of the thing
being written to. It should fail or require a size be specified
if we're writing to an area without a specific size.

A new dcmd and a new format for writing are added to mdb.

New format:
- Looks like this -> [address]/z [value]
- Writes the value in the address starting from the specified
  address
- The size of the write is inferred by the CTF data of the
  symbol at the address provided
- If no CTF data exist at the given address, the write fails

New dcmd:
- Looks like this -> [address]::write [value]
- Works exactly like the format specifier above
- For physical writes specify the -p argument
  (i.e. [address]\z [value])
- For object file writes specify the -o argument
  (i.e. [address]?z [value])
- If no CTF data was found and the write fails the
  user can force a write with -l [size]
- The allowed lengths of a forced write are 1, 2, 4,
  and 8 bytes.

Both of the above work with integer, pointer, and enum types
(except the -l option in the dcmd that doesn't care about the type).

Upstream Bugs: DLPX-48741