### PR TITLE
Add Jenkins job to verify illumos commits

### DIFF
--- a/jenkins/jobs/verify_illumos_commits.groovy
+++ b/jenkins/jobs/verify_illumos_commits.groovy
@@ -1,0 +1,38 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2018 by Delphix. All rights reserved.
+ */
+
+pipelineJob('verify-illumos-commits') {
+    quietPeriod(0)
+    concurrentBuild(false)
+
+    environmentVariables {
+        env('OPENZFS_REMOTE', 'openzfs')
+        env('OPENZFS_REPOSITORY', System.getenv('OPENZFS_REPOSITORY'))
+        env('OPENZFS_BRANCH', System.getenv('OPENZFS_BRANCH'))
+
+        env('ILLUMOS_REMOTE', 'illumos')
+        env('ILLUMOS_REPOSITORY', 'illumos/illumos-gate')
+        env('ILLUMOS_BRANCH', 'master')
+    }
+
+    definition {
+        cps {
+            script(readFileFromWorkspace('jenkins/pipelines/verify_illumos_commits.groovy'))
+            sandbox()
+        }
+    }
+}
+
+// vim: tabstop=4 shiftwidth=4 expandtab textwidth=112 colorcolumn=120

--- a/jenkins/pipelines/miscellaneous.groovy
+++ b/jenkins/pipelines/miscellaneous.groovy
@@ -10,8 +10,10 @@
  */
 
 /*
- * Copyright (c) 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2017, 2018 by Delphix. All rights reserved.
  */
+
+BASE_IMAGE_ID = 'ami-c5c0a7d3'
 
 def shscript(script, returnStdout, parameters) {
     def ret = null

--- a/jenkins/pipelines/verify_illumos_commits.groovy
+++ b/jenkins/pipelines/verify_illumos_commits.groovy
@@ -1,0 +1,115 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright (c) 2018 by Delphix. All rights reserved.
+ */
+
+currentBuild.displayName = "#${env.BUILD_NUMBER} ${env.OPENZFS_REPOSITORY}"
+
+node('master') {
+    def misc = null
+    stage('checkout') {
+        /*
+         * The script that's used to open the pull request implicitly assumes the only git remotes that will be
+         * contained in the local git repository are "OPENZFS_REMOTE" and "ILLUMOS_REMOTE". Thus, we can't
+         * simply use the GitSCM's "WipeWorkspace" extension, as that won't remove any extra remotes that might
+         * be contained in the repository. By using "deleteDir", we ensure a new git repository will be generated
+         * for each build.
+         */
+        deleteDir()
+        checkout([$class: 'GitSCM', changelog: false, poll: false,
+                  userRemoteConfigs: [[name: env.ILLUMOS_REMOTE,
+                                       url: "https://github.com/${env.ILLUMOS_REPOSITORY}"],
+                                      [name: env.OPENZFS_REMOTE,
+                                       url: "https://github.com/${env.OPENZFS_REPOSITORY}"]],
+                  branches: [[name: "${env.OPENZFS_REMOTE}/${env.OPENZFS_BRANCH}"]]])
+
+        /*
+         * If these settings aren't configured, "git cherry-pick" will fail when used below.
+         */
+        sh('git config user.name zettabot')
+        sh('git config user.email zettabot@open-zfs.org')
+
+        misc = load('jenkins/pipelines/miscellaneous.groovy')
+    }
+
+    def commits = null
+    stage('get commits') {
+        commits = misc.shscript('get-illumos-commits', true, [
+            ['ILLUMOS_REMOTE', env.ILLUMOS_REMOTE],
+            ['ILLUMOS_BRANCH', env.ILLUMOS_BRANCH],
+        ]).trim().split('\n')
+    }
+
+    for (commit in commits) {
+        try {
+            stage(commit.take(11)) {
+                sh("git cherry-pick ${commit}")
+                stash(name: 'openzfs', useDefaultExcludes: false)
+
+                def instance = null
+                try {
+                    instance = misc.shscript('aws-request-spot-instances', true, [
+                        ['IMAGE_ID', misc.BASE_IMAGE_ID],
+                        ['INSTANCE_TYPE', 'c4.2xlarge'],
+                        ['ADD_DISKS_FOR', 'none'],
+                        ['SPOT_PRICE', '0.398']
+                    ]).trim()
+
+                    timeout(time: 6, unit: 'HOURS') {
+                        if (!instance)
+                            error('Failed to create AWS instance.')
+
+                        misc.shscript('ansible-deploy-roles', false, [
+                            ['INSTANCE_ID', instance],
+                            ['ROLES', 'openzfs.build-slave openzfs.jenkins-slave'],
+                            ['WAIT_FOR_SSH', 'yes']
+                        ])
+
+                        node(instance) {
+                            unstash('openzfs')
+
+                            misc.shscript('nightly-build', false, [
+                                ['BUILD_NONDEBUG', 'no'],
+                                ['BUILD_DEBUG', 'yes'],
+                                ['RUN_LINT', 'no']
+                            ])
+
+                            misc.shscript('nightly-install', false, [
+                                ['INSTALL_DEBUG', 'yes']
+                            ])
+                        }
+
+                        misc.shscript('reboot-and-wait', false, [
+                            ['INSTANCE_ID', instance]
+                        ])
+                    }
+                } finally {
+                    if (instance) {
+                        misc.shscript('aws-terminate-instances', false, [
+                            ['INSTANCE_ID', instance]
+                        ])
+                    }
+                }
+            }
+        } catch (e) {
+            /*
+             * On failure, we want to proceed on to the next commit, to ensure a single bad commit (or failure
+             * due to flakey infrastructure) doesn't halt the entire process. Further, due to JENKINS-28822, we
+             * can't distinguish between failures and a user initiated abort/cancel of the job; so these also
+             * get ignored, and we proceed to the next commit in ths list.
+             */
+        }
+    }
+}
+
+// vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab textwidth=112 colorcolumn=120

--- a/jenkins/sh/get-illumos-commits/get-illumos-commits.sh
+++ b/jenkins/sh/get-illumos-commits/get-illumos-commits.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+source ${JENKINS_DIRECTORY}/sh/library/common.sh
+
+check_env OPENZFS_DIRECTORY ILLUMOS_REMOTE ILLUMOS_BRANCH
+
+log_must cd "$OPENZFS_DIRECTORY"
+log_must git fetch "$ILLUMOS_REMOTE" >&2
+log_must git cherry HEAD "$ILLUMOS_REMOTE/$ILLUMOS_BRANCH" \
+	| log_must grep '^+' \
+	| log_must cut -c '3-'

--- a/jenkins/sh/library/ssh.sh
+++ b/jenkins/sh/library/ssh.sh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2017 by Delphix. All rights reserved.
+# Copyright (c) 2017, 2018 by Delphix. All rights reserved.
 #
 
 source ${JENKINS_DIRECTORY}/sh/library/common.sh
@@ -20,12 +20,7 @@ source ${JENKINS_DIRECTORY}/sh/library/common.sh
 function ssh_log_must() {
 	check_env HOST
 
-	#
-	# We need to be careful not to use "log_must" with "echo" below, as
-	# that could leak the password (print to whatever happened to be
-	# capturing the output of this function; e.g. a Jenkins job log).
-	#
-	echo "root" | log_must sshpass ssh \
+	log_must ssh \
 		-o UserKnownHostsFile=/dev/null \
 		-o StrictHostKeyChecking=no \
 		"root@$HOST" "$@"

--- a/jenkins/sh/nightly-build/nightly-build.sh
+++ b/jenkins/sh/nightly-build/nightly-build.sh
@@ -12,7 +12,7 @@
 #
 
 #
-# Copyright (c) 2017 by Delphix. All rights reserved.
+# Copyright (c) 2017, 2018 by Delphix. All rights reserved.
 #
 
 source ${JENKINS_DIRECTORY}/sh/library/common.sh
@@ -145,8 +145,8 @@ else
 	#
 	log_must cp usr/src/tools/env/illumos.sh illumos.sh
 
-	PKGVERS_BRANCH=$(pkg info -r pkg://openindiana.org/SUNWcs \
-		| awk '$1 == "Branch:" {print $2}')
+	PKGVERS_BRANCH=$(log_must pkg info -r pkg://openindiana.org/SUNWcs \
+		| log_must awk '$1 == "Branch:" {print $2}')
 
 	log_must nightly_env_set_var "PKGVERS_BRANCH" "'$PKGVERS_BRANCH'"
 	log_must nightly_env_set_var "ONNV_BUILDNUM" "'$PKGVERS_BRANCH'"

--- a/jenkins/sh/reboot-and-wait/reboot-and-wait.sh
+++ b/jenkins/sh/reboot-and-wait/reboot-and-wait.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+source ${JENKINS_DIRECTORY}/sh/library/common.sh
+source ${JENKINS_DIRECTORY}/sh/library/aws.sh
+source ${JENKINS_DIRECTORY}/sh/library/ssh.sh
+
+check_env INSTANCE_ID
+
+aws_setup_environment
+
+HOST=$(log_must aws ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+	| jq -M -r .Reservations[0].Instances[0].PublicIpAddress)
+
+log_must pushd "$JENKINS_DIRECTORY/ansible" >/dev/null
+ssh_wait_for inventory.txt playbook.yml
+log_must popd >/dev/null
+
+ssh_log_must <<-EOF
+	nohup sudo /usr/sbin/shutdown -g 1 -i 6 -y &
+	disown %1
+	exit 0
+EOF
+
+#
+# Before we begin to wait on the SSH service below, we want pause here,
+# to try and ensure the SSH is shutdown as part of the reboot prior to
+# us waiting below. Otherwise, we might detect SSH is up simply because
+# it hasn't been shutdown yet because the reboot hasn't yet initiated.
+#
+log_must sleep 10
+
+log_must pushd "$JENKINS_DIRECTORY/ansible" >/dev/null
+ssh_wait_for inventory.txt playbook.yml
+log_must popd >/dev/null


### PR DESCRIPTION
In an effort to more easily find "bad" commits when syncing with the
upstream illumos repository, this change adds a Jenkins job that will
iterate through all of the illumos commits not yet applied to OpenZFS,
and verify the build, upgrade, and boot of each commit.