### PR TITLE
arc_loan_compressed_buf() can increment arc_loaned_bytes by the wrong value

### DIFF
--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -2557,7 +2557,7 @@ arc_loan_buf(spa_t *spa, boolean_t is_metadata, int size)
 	arc_buf_t *buf = arc_alloc_buf(spa, arc_onloan_tag,
 	    is_metadata ? ARC_BUFC_METADATA : ARC_BUFC_DATA, size);
 
-	arc_loaned_bytes_update(size);
+	arc_loaned_bytes_update(arc_buf_size(buf));
 
 	return (buf);
 }

--- a/usr/src/uts/common/fs/zfs/arc.c
+++ b/usr/src/uts/common/fs/zfs/arc.c
@@ -2569,7 +2569,7 @@ arc_loan_compressed_buf(spa_t *spa, uint64_t psize, uint64_t lsize,
 	arc_buf_t *buf = arc_alloc_compressed_buf(spa, arc_onloan_tag,
 	    psize, lsize, compression_type);
 
-	arc_loaned_bytes_update(psize);
+	arc_loaned_bytes_update(arc_buf_size(buf));
 
 	return (buf);
 }


### PR DESCRIPTION
arc_loan_compressed_buf() increments arc_loaned_bytes by psize unconditionally.

In the case of zfs_compressed_arc_enabled=0, when the buf is returned via arc_return_buf(), if ARC_BUF_COMPRESSED(buf) is false, then arc_loaned_bytes is decremented by lsize, not psize.

Switch to using arc_buf_size(buf), instead of psize, which will return psize or lsize, depending on the result of ARC_BUF_COMPRESSED(buf)

To recreate the issue:
- disable compressed ARC
- recv a compressed incremental replication stream (-c), and arc_loaned_bytes will underflow, triggering an assert:

panic: solaris assert: atomic_add_64_nv(&arc_loaned_bytes, 0) >= 0 (0xffffffffffff20cc >= 0x0), file: /zroot/zfs_zstd/head/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/arc.c, line: 2834
cpuid = 1
time = 1519069857
KDB: stack backtrace:
db_trace_self_wrapper() at db_trace_self_wrapper+0x2b/frame 0xfffffe002e5de990
vpanic() at vpanic+0x18d/frame 0xfffffe002e5de9f0
panic() at panic+0x43/frame 0xfffffe002e5dea50
assfail3() at assfail3+0x2c/frame 0xfffffe002e5dea70
dbuf_assign_arcbuf() at dbuf_assign_arcbuf+0x16e/frame 0xfffffe002e5deac0
dmu_assign_arcbuf() at dmu_assign_arcbuf+0x171/frame 0xfffffe002e5deb10
receive_writer_thread() at receive_writer_thread+0x938/frame 0xfffffe002e5debb0
fork_exit() at fork_exit+0x84/frame 0xfffffe002e5debf0
fork_trampoline() at fork_trampoline+0xe/frame 0xfffffe002e5debf0