### PR TITLE
9190 Fix cleanup routine in import_cachefile_device_replaced.ksh

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool_import/zpool_import.kshlib
@@ -23,6 +23,9 @@
 #
 function cleanup
 {
+	# clear any remaining zinjections
+	log_must zinject -c all > /dev/null
+
 	destroy_pool $TESTPOOL1
 
 	log_must rm -f $CPATH $CPATHBKP $CPATHBKP2 $MD5FILE $MD5FILE2


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

Must clear slow-disk zinject injections in test cleanup routine.
Otherwise, when this test fails, it causes most subsequent tests to fail.

Upstream bug: DLPX-48060