### PR TITLE
9191 dump vdev tree to zfs_dbgmsg when spa load fails due to missing …

### DIFF
--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -1770,6 +1770,7 @@ spa_check_for_missing_logs(spa_t *spa)
 
 		if (idx > 0) {
 			spa_load_failed(spa, "some log devices are missing");
+			vdev_dbgmsg_print_tree(rvd, 2);
 			return (SET_ERROR(ENXIO));
 		}
 	} else {
@@ -1781,6 +1782,7 @@ spa_check_for_missing_logs(spa_t *spa)
 				spa_set_log_state(spa, SPA_LOG_CLEAR);
 				spa_load_note(spa, "some log devices are "
 				    "missing, ZIL is dropped.");
+				vdev_dbgmsg_print_tree(rvd, 2);
 				break;
 			}
 		}


### PR DESCRIPTION
…log devices

Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Prakash Surya <prakash.surya@delphix.com>
Reviewed by: Matt Ahrens <matt@delphix.com>

Add vdev_print_tree() in spa_check_for_missing_logs() when some log
devices are missing to ease debugging

Upstream bug: DLPX-49060