### PR TITLE
9195 New coreadm config causes failure in zpool_003_pos

### DIFF
--- a/usr/src/test/zfs-tests/Makefile
+++ b/usr/src/test/zfs-tests/Makefile
@@ -15,6 +15,6 @@
 
 .PARALLEL: $(SUBDIRS)
 
-SUBDIRS:sh = find ./* -maxdepth 0 -type d
+SUBDIRS:sh = ls */Makefile 2>/dev/null | sed 's/\/Makefile//g'
 
 include $(SRC)/test/Makefile.com

--- a/usr/src/test/zfs-tests/Makefile.com
+++ b/usr/src/test/zfs-tests/Makefile.com
@@ -60,4 +60,4 @@ $(TARGETDIR)/%: %
 	$(INS.file)
 
 .PARALLEL: $(SUBDIRS)
-SUBDIRS:sh = find ./* -maxdepth 0 -type d
+SUBDIRS:sh = ls */Makefile 2>/dev/null | sed 's/\/Makefile//g'

--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -176,6 +176,8 @@ export KEEP="^$(echo $KEEP | sed 's/ /$|^/g')\$"
 num_disks=$(echo $DISKS | awk '{print NF}')
 [[ $num_disks -lt 3 ]] && fail "Not enough disks to run ZFS Test Suite"
 
+sudo -k coreadm -e process
+
 # Ensure user has only basic privileges.
 ppriv -s EIP=basic -e $runner $quiet -c $runfile
 ret=$?


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>
Reviewed by: Dan Kimmel dan.kimmel@delphix.com

If a core file is not created in the cwd the test fails. The solution is
to invoke `coreadm -i core` just before running this test.

Also included are Makefile changes in zfstest cannot cope with empty
directories.

Upstream bugs: DLPX-51761, DLPX-51770