### PR TITLE
9186 performance test suite should use checksum=edonr

### DIFF
--- a/usr/src/test/zfs-tests/tests/perf/perf.shlib
+++ b/usr/src/test/zfs-tests/tests/perf/perf.shlib
@@ -10,7 +10,7 @@
 #
 
 #
-# Copyright (c) 2015, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2015, 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -24,7 +24,7 @@ export PERF_RUNTIME_NIGHTLY=$((10 * 60))
 
 # Default fs creation options
 export PERF_FS_OPTS=${PERF_FS_OPTS:-'-o recsize=8k -o compress=lz4' \
-    ' -o checksum=sha256 -o redundant_metadata=most'}
+    ' -o checksum=edonr -o redundant_metadata=most'}
 
 function get_sync_str
 {


### PR DESCRIPTION
Reviewed by: Paul Dagnelie  <pcd@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

The zfs performance test suite should be using checksum=edonr.

Upstream bug: DLPX-50672