### PR TITLE
9237 "zpool add" fails for very large pools

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -895,6 +895,7 @@ zpool_read_label(int fd, nvlist_t **config)
 
 	free(label);
 	*config = NULL;
+	errno = ENOENT;
 	return (-1);
 }
 


### PR DESCRIPTION
8567 changed the return value of zpool_read_label. Error paths that
previously returned 0 began to return -1 instead. However, not all error
paths initialized errno. When adding vdevs to a very large pool, errno
could be prepopulated with ENOMEM, causing the operation to fail. Fix
the bug by setting errno=ENOENT in the case that no ZFS label is found.

Obtained from:	FreeBSD