### PR TITLE
9256 zfs send space estimation off by > 10% on some datasets

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_006_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_send/zfs_send_006_pos.ksh
@@ -36,6 +36,7 @@ verify_runnable "both"
 
 function cleanup
 {
+	mdb_set_uint32 zfs_override_estimate_recordsize 8192
 	for ds in $datasets; do
                 datasetexists $ds && zfs destroy -rf $ds
 	done
@@ -92,6 +93,7 @@ function verify_size_estimates
 
 log_assert "Verify 'zfs send -nvP' generates valid stream estimates"
 log_onexit cleanup
+mdb_set_uint32 zfs_override_estimate_recordsize 0
 typeset -l block_count=0
 typeset -l block_size
 typeset -i PERCENT=1

--- a/usr/src/uts/common/fs/zfs/dmu_send.c
+++ b/usr/src/uts/common/fs/zfs/dmu_send.c
@@ -66,6 +66,11 @@ int zfs_send_set_freerecords_bit = B_TRUE;
 static char *dmu_recv_tag = "dmu_recv_tag";
 const char *recv_clone_name = "%recv";
 
+/*
+ * Use this to override the recordsize calculation for fast zfs send estimates.
+ */
+uint64_t zfs_override_estimate_recordsize = 0;
+
 #define	BP_SPAN(datablkszsec, indblkshift, level) \
 	(((uint64_t)datablkszsec) << (SPA_MINBLOCKSHIFT + \
 	(level) * (indblkshift - SPA_BLKPTRSHIFT)))
@@ -1093,7 +1098,7 @@ static int
 dmu_adjust_send_estimate_for_indirects(dsl_dataset_t *ds, uint64_t uncompressed,
     uint64_t compressed, boolean_t stream_compressed, uint64_t *sizep)
 {
-	int err;
+	int err = 0;
 	uint64_t size;
 	/*
 	 * Assume that space (both on-disk and in-stream) is dominated by
@@ -1106,7 +1111,9 @@ dmu_adjust_send_estimate_for_indirects(dsl_dataset_t *ds, uint64_t uncompressed,
 	VERIFY0(dmu_objset_from_ds(ds, &os));
 
 	/* Assume all (uncompressed) blocks are recordsize. */
-	if (os->os_phys->os_type == DMU_OST_ZVOL) {
+	if (zfs_override_estimate_recordsize != 0) {
+		recordsize = zfs_override_estimate_recordsize;
+	} else if (os->os_phys->os_type == DMU_OST_ZVOL) {
 		err = dsl_prop_get_int_ds(ds,
 		    zfs_prop_to_name(ZFS_PROP_VOLBLOCKSIZE), &recordsize);
 	} else {


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

Here is an instance where we see a big discrepancy.

estimate is : 431217656 bytes
actual size is : 492215048 bytes

Without the -e flag, the discrepancy is much higher.

Upstream bug: DLPX-45514