### PR TITLE
9324 zfs-recv can be broken by some ZFS-ioctls (PROPOSAL)

### DIFF
--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
- * Copyright 2016 Nexenta Systems, Inc. All rights reserved.
+ * Copyright 2018 Nexenta Systems, Inc. All rights reserved.
  */
 
 /* Portions Copyright 2010 Robert Milkowski */
@@ -2046,7 +2046,7 @@ zfs_resume_fs(zfsvfs_t *zfsvfs, dsl_dataset_t *ds)
 	VERIFY0(dmu_objset_from_ds(ds, &os));
 
 	err = zfsvfs_init(zfsvfs, os);
-	if (err != 0)
+	if (err != 0 || zfsvfs->z_vfs == NULL)
 		goto bail;
 
 	VERIFY(zfsvfs_setup(zfsvfs, B_FALSE) == 0);


### PR DESCRIPTION
Some ZFS-IOCTLS create zfsvfs_t for non-mounted filesystems, that implicitly set long-hold and owner for the filesystem, that can break last stage of zfs-recv, that checks long-holds, so that zfs-recv returned EBUSY.

Also there is a race betwee receiving a mounted filesystem and umounting of it, that caused system-panic.

Both bugs are fixed by the PR because they are related to the same code-block.

Solution for the first bug (zfs-recv returns EBUSY):
Use zfsvfs_create() if getzfsvfs() returns error to be sure that received unmounted filesystem will not be owned by the ioctls, that described above. Do retry if zfsvfs_create() also returns an error.

Solution for second bug (reboot + zfs-recv = possible panic):
Do retry if the received FS cannot be suspend.

We locally tested the fix, but not yet integrated and would be nice to see comments regarding to the solution.