### PR TITLE
8115 parallel zfs mount (v3)

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -60,6 +60,7 @@
 #include <sys/fs/zfs.h>
 #include <sys/types.h>
 #include <time.h>
+#include <synch.h>
 
 #include <libzfs.h>
 #include <libzfs_core.h>
@@ -5759,7 +5760,12 @@ zfs_do_holds(int argc, char **argv)
 
 #define	CHECK_SPINNER 30
 #define	SPINNER_TIME 3		/* seconds */
-#define	MOUNT_TIME 5		/* seconds */
+#define	MOUNT_TIME 1		/* seconds */
+
+typedef struct get_all_state {
+	boolean_t	ga_verbose;
+	get_all_cb_t	*ga_cbp;
+} get_all_state_t;
 
 static int
 get_one_dataset(zfs_handle_t *zhp, void *data)
@@ -5768,10 +5774,10 @@ get_one_dataset(zfs_handle_t *zhp, void *data)
 	static int spinval = 0;
 	static int spincheck = 0;
 	static time_t last_spin_time = (time_t)0;
-	get_all_cb_t *cbp = data;
+	get_all_state_t *state = data;
 	zfs_type_t type = zfs_get_type(zhp);
 
-	if (cbp->cb_verbose) {
+	if (state->ga_verbose) {
 		if (--spincheck < 0) {
 			time_t now = time(NULL);
 			if (last_spin_time + SPINNER_TIME < now) {
@@ -5797,25 +5803,23 @@ get_one_dataset(zfs_handle_t *zhp, void *data)
 		zfs_close(zhp);
 		return (0);
 	}
-	libzfs_add_handle(cbp, zhp);
-	assert(cbp->cb_used <= cbp->cb_alloc);
+	libzfs_add_handle(state->ga_cbp, zhp);
+	assert(state->ga_cbp->cb_used <= state->ga_cbp->cb_alloc);
 
 	return (0);
 }
 
 static void
-get_all_datasets(zfs_handle_t ***dslist, size_t *count, boolean_t verbose)
+get_all_datasets(get_all_cb_t *cbp, boolean_t verbose)
 {
-	get_all_cb_t cb = { 0 };
-	cb.cb_verbose = verbose;
-	cb.cb_getone = get_one_dataset;
+	get_all_state_t state = {
+	    .ga_verbose = verbose,
+	    .ga_cbp = cbp
+	};
 
 	if (verbose)
 		set_progress_header(gettext("Reading ZFS config"));
-	(void) zfs_iter_root(g_zfs, get_one_dataset, &cb);
-
-	*dslist = cb.cb_handles;
-	*count = cb.cb_used;
+	(void) zfs_iter_root(g_zfs, get_one_dataset, &state);
 
 	if (verbose)
 		finish_progress(gettext("done."));
@@ -5826,8 +5830,19 @@ get_all_datasets(zfs_handle_t ***dslist, size_t *count, boolean_t verbose)
  * similar, we have a common function with an extra parameter to determine which
  * mode we are using.
  */
-#define	OP_SHARE	0x1
-#define	OP_MOUNT	0x2
+typedef enum { OP_SHARE, OP_MOUNT } share_mount_op_t;
+
+typedef struct share_mount_state {
+	share_mount_op_t	sm_op;
+	boolean_t	sm_verbose;
+	int	sm_flags;
+	char	*sm_options;
+	char	*sm_proto; /* only valid for OP_SHARE */
+	mutex_t	sm_lock; /* protects the remaining fields */
+	uint_t	sm_total; /* number of filesystems to process */
+	uint_t	sm_done; /* number of filesystems processed */
+	int	sm_status; /* -1 if any of the share/mount operations failed */
+} share_mount_state_t;
 
 /*
  * Share or mount a dataset.
@@ -6069,6 +6084,29 @@ report_mount_progress(int current, int total)
 		update_progress(info);
 }
 
+/*
+ * zfs_foreach_mountpoint() callback that mounts or shares one filesystem and
+ * updates the progress meter.
+ */
+static int
+share_mount_one_cb(zfs_handle_t *zhp, void *arg)
+{
+	share_mount_state_t *sms = arg;
+	int ret;
+
+	ret = share_mount_one(zhp, sms->sm_op, sms->sm_flags, sms->sm_proto,
+	    B_FALSE, sms->sm_options);
+
+	mutex_enter(&sms->sm_lock);
+	if (ret != 0)
+		sms->sm_status = ret;
+	sms->sm_done++;
+	if (sms->sm_verbose)
+		report_mount_progress(sms->sm_done, sms->sm_total);
+	mutex_exit(&sms->sm_lock);
+	return (ret);
+}
+
 static void
 append_options(char *mntopts, char *newopts)
 {
@@ -6141,8 +6179,6 @@ share_mount(int op, int argc, char **argv)
 
 	/* check number of arguments */
 	if (do_all) {
-		zfs_handle_t **dslist = NULL;
-		size_t i, count = 0;
 		char *protocol = NULL;
 
 		if (op == OP_SHARE && argc > 0) {
@@ -6163,33 +6199,44 @@ share_mount(int op, int argc, char **argv)
 		}
 
 		start_progress_timer();
-		get_all_datasets(&dslist, &count, verbose);
+		get_all_cb_t cb = { 0 };
+		get_all_datasets(&cb, verbose);
 
-		if (count == 0)
+		if (cb.cb_used == 0)
 			return (0);
 
-		qsort(dslist, count, sizeof (void *), libzfs_dataset_cmp);
-		sa_init_selective_arg_t sharearg;
-		sharearg.zhandle_arr = dslist;
-		sharearg.zhandle_len = count;
-		if ((ret = zfs_init_libshare_arg(zfs_get_handle(dslist[0]),
-		    SA_INIT_SHARE_API_SELECTIVE, &sharearg)) != SA_OK) {
-			(void) fprintf(stderr,
-			    gettext("Could not initialize libshare, %d"), ret);
-			return (ret);
+		if (op == OP_SHARE) {
+			sa_init_selective_arg_t sharearg;
+			sharearg.zhandle_arr = cb.cb_handles;
+			sharearg.zhandle_len = cb.cb_used;
+			if ((ret = zfs_init_libshare_arg(g_zfs,
+			    SA_INIT_SHARE_API_SELECTIVE, &sharearg)) != SA_OK) {
+				(void) fprintf(stderr, gettext(
+				    "Could not initialize libshare, %d"), ret);
+				return (ret);
+			}
 		}
 
-		for (i = 0; i < count; i++) {
-			if (verbose)
-				report_mount_progress(i, count);
+		share_mount_state_t share_mount_state = { 0 };
+		share_mount_state.sm_op = op;
+		share_mount_state.sm_verbose = verbose;
+		share_mount_state.sm_flags = flags;
+		share_mount_state.sm_options = options;
+		share_mount_state.sm_proto = protocol;
+		share_mount_state.sm_total = cb.cb_used;
+		(void) mutex_init(&share_mount_state.sm_lock,
+		    LOCK_NORMAL | LOCK_ERRORCHECK, NULL);
+		/*
+		 * libshare isn't mt-safe, so only do the operation in parallel
+		 * if we're mounting.
+		 */
+		zfs_foreach_mountpoint(g_zfs, cb.cb_handles, cb.cb_used,
+		    share_mount_one_cb, &share_mount_state, op == OP_MOUNT);
+		ret = share_mount_state.sm_status;
 
-			if (share_mount_one(dslist[i], op, flags, protocol,
-			    B_FALSE, options) != 0)
-				ret = 1;
-			zfs_close(dslist[i]);
-		}
-
-		free(dslist);
+		for (int i = 0; i < cb.cb_used; i++)
+			zfs_close(cb.cb_handles[i]);
+		free(cb.cb_handles);
 	} else if (argc == 0) {
 		struct mnttab entry;
 

--- a/usr/src/lib/Makefile
+++ b/usr/src/lib/Makefile
@@ -599,7 +599,7 @@ libdiskmgt:	libdevid libdevinfo libadm libefi libkstat libsysevent
 $(INTEL_BLD)libdiskmgt: libfdisk
 libdladm:	libdevinfo libinetutil libscf librcm libexacct libkstat \
 		libpool
-libdll: 	libast
+libdll:		libast
 libdlpi:	libinetutil libdladm
 libds:		libsysevent
 libdscfg:	libnsctl libunistat libadm
@@ -657,8 +657,8 @@ libsmbfs:	libkrb5 libsec libidmap pkcs11
 libsmbios:	libdevinfo
 libsrpt:	libstmf
 libstmf:	libscf
-libstmfproxy: 	libstmf libpthread
-libsum: 	libast
+libstmfproxy:	libstmf libpthread
+libsum:		libast
 libsun_ima:	libdevinfo libsysevent
 libsysevent:	libsecdb
 libtecla:	libcurses
@@ -673,7 +673,7 @@ libvolmgt:	libadm
 libvrrpadm:	libdladm libscf
 libvscan:	libscf libsecdb
 libzfs:		libdevid libgen libuutil libadm libavl libefi libidmap \
-		libumem libtsol libzfs_core libcmdutils
+		libumem libtsol libzfs_core
 libzfs_jni:	libdiskmgt libzfs
 libzonecfg:	libuuid libsysevent libsec libbrand libpool libscf libproc \
 		libuutil libbsm libsecdb
@@ -688,7 +688,7 @@ passwdutil:	libsldap
 pkcs11:		libcryptoutil libgen libuuid
 policykit:	dbusdeps
 print:		libldap5 libmd5 libsendfile
-pylibbe: 	libbe libzfs
+pylibbe:	libbe libzfs
 pysolaris:	libsec libidmap
 pyzfs:		libzfs
 raidcfg_plugins: libraidcfg librcm libcfgadm libpicl libpicltree

--- a/usr/src/lib/libzfs/Makefile.com
+++ b/usr/src/lib/libzfs/Makefile.com
@@ -21,7 +21,7 @@
 #
 # Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
-# Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+# Copyright (c) 2011, 2017 by Delphix. All rights reserved.
 #
 
 LIBRARY= libzfs.a
@@ -49,7 +49,8 @@ OBJS_COMMON=			\
 	libzfs_pool.o		\
 	libzfs_sendrecv.o	\
 	libzfs_status.o		\
-	libzfs_util.o
+	libzfs_util.o		\
+	libzfs_taskq.o
 
 OBJECTS= $(OBJS_COMMON) $(OBJS_SHARED)
 

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -576,12 +576,11 @@ typedef struct get_all_cb {
 	zfs_handle_t	**cb_handles;
 	size_t		cb_alloc;
 	size_t		cb_used;
-	boolean_t	cb_verbose;
-	int		(*cb_getone)(zfs_handle_t *, void *);
 } get_all_cb_t;
 
+void zfs_foreach_mountpoint(libzfs_handle_t *, zfs_handle_t **, size_t,
+    zfs_iter_f, void *, boolean_t);
 void libzfs_add_handle(get_all_cb_t *, zfs_handle_t *);
-int libzfs_dataset_cmp(const void *, const void *);
 
 /*
  * Functions to create and destroy datasets.

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -54,6 +54,7 @@
 #include <idmap.h>
 #include <aclutils.h>
 #include <directory.h>
+#include <time.h>
 
 #include <sys/dnode.h>
 #include <sys/spa.h>
@@ -785,6 +786,8 @@ libzfs_mnttab_cache_compare(const void *arg1, const void *arg2)
 void
 libzfs_mnttab_init(libzfs_handle_t *hdl)
 {
+	(void) mutex_init(&hdl->libzfs_mnttab_cache_lock,
+	    LOCK_NORMAL | LOCK_ERRORCHECK, NULL);
 	assert(avl_numnodes(&hdl->libzfs_mnttab_cache) == 0);
 	avl_create(&hdl->libzfs_mnttab_cache, libzfs_mnttab_cache_compare,
 	    sizeof (mnttab_node_t), offsetof(mnttab_node_t, mtn_node));
@@ -825,6 +828,7 @@ libzfs_mnttab_fini(libzfs_handle_t *hdl)
 		free(mtn);
 	}
 	avl_destroy(&hdl->libzfs_mnttab_cache);
+	(void) mutex_destroy(&hdl->libzfs_mnttab_cache_lock);
 }
 
 void
@@ -839,6 +843,7 @@ libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
 {
 	mnttab_node_t find;
 	mnttab_node_t *mtn;
+	int ret = ENOENT;
 
 	if (!hdl->libzfs_mnttab_enable) {
 		struct mnttab srch = { 0 };
@@ -854,6 +859,7 @@ libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
 			return (ENOENT);
 	}
 
+	mutex_enter(&hdl->libzfs_mnttab_cache_lock);
 	if (avl_numnodes(&hdl->libzfs_mnttab_cache) == 0)
 		libzfs_mnttab_update(hdl);
 
@@ -861,9 +867,10 @@ libzfs_mnttab_find(libzfs_handle_t *hdl, const char *fsname,
 	mtn = avl_find(&hdl->libzfs_mnttab_cache, &find, NULL);
 	if (mtn) {
 		*entry = mtn->mtn_mt;
-		return (0);
+		ret = 0;
 	}
-	return (ENOENT);
+	mutex_exit(&hdl->libzfs_mnttab_cache_lock);
+	return (ret);
 }
 
 void
@@ -872,14 +879,16 @@ libzfs_mnttab_add(libzfs_handle_t *hdl, const char *special,
 {
 	mnttab_node_t *mtn;
 
-	if (avl_numnodes(&hdl->libzfs_mnttab_cache) == 0)
-		return;
-	mtn = zfs_alloc(hdl, sizeof (mnttab_node_t));
-	mtn->mtn_mt.mnt_special = zfs_strdup(hdl, special);
-	mtn->mtn_mt.mnt_mountp = zfs_strdup(hdl, mountp);
-	mtn->mtn_mt.mnt_fstype = zfs_strdup(hdl, MNTTYPE_ZFS);
-	mtn->mtn_mt.mnt_mntopts = zfs_strdup(hdl, mntopts);
-	avl_add(&hdl->libzfs_mnttab_cache, mtn);
+	mutex_enter(&hdl->libzfs_mnttab_cache_lock);
+	if (avl_numnodes(&hdl->libzfs_mnttab_cache) != 0) {
+		mtn = zfs_alloc(hdl, sizeof (mnttab_node_t));
+		mtn->mtn_mt.mnt_special = zfs_strdup(hdl, special);
+		mtn->mtn_mt.mnt_mountp = zfs_strdup(hdl, mountp);
+		mtn->mtn_mt.mnt_fstype = zfs_strdup(hdl, MNTTYPE_ZFS);
+		mtn->mtn_mt.mnt_mntopts = zfs_strdup(hdl, mntopts);
+		avl_add(&hdl->libzfs_mnttab_cache, mtn);
+	}
+	mutex_exit(&hdl->libzfs_mnttab_cache_lock);
 }
 
 void
@@ -888,6 +897,7 @@ libzfs_mnttab_remove(libzfs_handle_t *hdl, const char *fsname)
 	mnttab_node_t find;
 	mnttab_node_t *ret;
 
+	mutex_enter(&hdl->libzfs_mnttab_cache_lock);
 	find.mtn_mt.mnt_special = (char *)fsname;
 	if ((ret = avl_find(&hdl->libzfs_mnttab_cache, (void *)&find, NULL))
 	    != NULL) {
@@ -898,6 +908,7 @@ libzfs_mnttab_remove(libzfs_handle_t *hdl, const char *fsname)
 		free(ret->mtn_mt.mnt_mntopts);
 		free(ret);
 	}
+	mutex_exit(&hdl->libzfs_mnttab_cache_lock);
 }
 
 int

--- a/usr/src/lib/libzfs/common/libzfs_impl.h
+++ b/usr/src/lib/libzfs/common/libzfs_impl.h
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2011 Pawel Jakub Dawidek. All rights reserved.
- * Copyright (c) 2011, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2011, 2017 by Delphix. All rights reserved.
  */
 
 #ifndef	_LIBZFS_IMPL_H
@@ -33,6 +33,7 @@
 #include <sys/nvpair.h>
 #include <sys/dmu.h>
 #include <sys/zfs_ioctl.h>
+#include <synch.h>
 
 #include <libuutil.h>
 #include <libzfs.h>
@@ -73,6 +74,13 @@ struct libzfs_handle {
 	int libzfs_storeerr; /* stuff error messages into buffer */
 	void *libzfs_sharehdl; /* libshare handle */
 	boolean_t libzfs_mnttab_enable;
+	/*
+	 * We need a lock to handle the case where parallel mount
+	 * threads are populating the mnttab cache simultaneously. The
+	 * lock only protects the integrity of the avl tree, and does
+	 * not protect the contents of the mnttab entries themselves.
+	 */
+	mutex_t libzfs_mnttab_cache_lock;
 	avl_tree_t libzfs_mnttab_cache;
 	int libzfs_pool_iter;
 	topo_hdl_t *libzfs_topo_hdl;

--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -22,7 +22,7 @@
 /*
  * Copyright 2015 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2014, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2014, 2017 by Delphix. All rights reserved.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 Joyent, Inc.
  * Copyright 2017 RackTop Systems.
@@ -34,25 +34,25 @@
  * they are used by mount and unmount and when changing a filesystem's
  * mountpoint.
  *
- * 	zfs_is_mounted()
- * 	zfs_mount()
- * 	zfs_unmount()
- * 	zfs_unmountall()
+ *	zfs_is_mounted()
+ *	zfs_mount()
+ *	zfs_unmount()
+ *	zfs_unmountall()
  *
  * This file also contains the functions used to manage sharing filesystems via
  * NFS and iSCSI:
  *
- * 	zfs_is_shared()
- * 	zfs_share()
- * 	zfs_unshare()
+ *	zfs_is_shared()
+ *	zfs_share()
+ *	zfs_unshare()
  *
- * 	zfs_is_shared_nfs()
- * 	zfs_is_shared_smb()
- * 	zfs_share_proto()
- * 	zfs_shareall();
- * 	zfs_unshare_nfs()
- * 	zfs_unshare_smb()
- * 	zfs_unshareall_nfs()
+ *	zfs_is_shared_nfs()
+ *	zfs_is_shared_smb()
+ *	zfs_share_proto()
+ *	zfs_shareall();
+ *	zfs_unshare_nfs()
+ *	zfs_unshare_smb()
+ *	zfs_unshareall_nfs()
  *	zfs_unshareall_smb()
  *	zfs_unshareall()
  *	zfs_unshareall_bypath()
@@ -60,8 +60,8 @@
  * The following functions are available for pool consumers, and will
  * mount/unmount and share/unshare all datasets within pool:
  *
- * 	zpool_enable_datasets()
- * 	zpool_disable_datasets()
+ *	zpool_enable_datasets()
+ *	zpool_disable_datasets()
  */
 
 #include <dirent.h>
@@ -83,11 +83,15 @@
 #include <libzfs.h>
 
 #include "libzfs_impl.h"
+#include "libzfs_taskq.h"
 
 #include <libshare.h>
 #include <sys/systeminfo.h>
 #define	MAXISALEN	257	/* based on sysinfo(2) man page */
 
+static int mount_tq_nthr = 512;	/* taskq threads for multi-threaded mounting */
+
+static void zfs_mount_task(void *);
 static int zfs_share_proto(zfs_handle_t *, zfs_share_proto_t *);
 zfs_share_type_t zfs_is_shared_proto(zfs_handle_t *, char **,
     zfs_share_proto_t);
@@ -1077,25 +1081,32 @@ remove_mountpoint(zfs_handle_t *zhp)
 	}
 }
 
+/*
+ * Add the given zfs handle to the cb_handles array, dynamically reallocating
+ * the array if it is out of space.
+ */
 void
 libzfs_add_handle(get_all_cb_t *cbp, zfs_handle_t *zhp)
 {
 	if (cbp->cb_alloc == cbp->cb_used) {
 		size_t newsz;
-		void *ptr;
+		zfs_handle_t **newhandles;
 
-		newsz = cbp->cb_alloc ? cbp->cb_alloc * 2 : 64;
-		ptr = zfs_realloc(zhp->zfs_hdl,
-		    cbp->cb_handles, cbp->cb_alloc * sizeof (void *),
-		    newsz * sizeof (void *));
-		cbp->cb_handles = ptr;
+		newsz = cbp->cb_alloc != 0 ? cbp->cb_alloc * 2 : 64;
+		newhandles = zfs_realloc(zhp->zfs_hdl,
+		    cbp->cb_handles, cbp->cb_alloc * sizeof (zfs_handle_t *),
+		    newsz * sizeof (zfs_handle_t *));
+		cbp->cb_handles = newhandles;
 		cbp->cb_alloc = newsz;
 	}
 	cbp->cb_handles[cbp->cb_used++] = zhp;
 }
 
+/*
+ * Recursive helper function used during file system enumeration
+ */
 static int
-mount_cb(zfs_handle_t *zhp, void *data)
+zfs_iter_cb(zfs_handle_t *zhp, void *data)
 {
 	get_all_cb_t *cbp = data;
 
@@ -1121,104 +1132,350 @@ mount_cb(zfs_handle_t *zhp, void *data)
 	}
 
 	libzfs_add_handle(cbp, zhp);
-	if (zfs_iter_filesystems(zhp, mount_cb, cbp) != 0) {
+	if (zfs_iter_filesystems(zhp, zfs_iter_cb, cbp) != 0) {
 		zfs_close(zhp);
 		return (-1);
 	}
 	return (0);
 }
 
+/*
+ * Sort comparator that compares two mountpoint paths. We sort these paths so
+ * that subdirectories immediately follow their parents. This means that we
+ * effectively treat the '/' character as the lowest value non-nul char. An
+ * example sorted list using this comparator would look like:
+ *
+ * /foo
+ * /foo/bar
+ * /foo/bar/baz
+ * /foo/baz
+ * /foo.bar
+ *
+ * The mounting code depends on this ordering to deterministically iterate
+ * over filesystems in order to spawn parallel mount tasks.
+ */
 int
-libzfs_dataset_cmp(const void *a, const void *b)
+mountpoint_cmp(const void *arga, const void *argb)
 {
-	zfs_handle_t **za = (zfs_handle_t **)a;
-	zfs_handle_t **zb = (zfs_handle_t **)b;
+	zfs_handle_t *const *zap = arga;
+	zfs_handle_t *za = *zap;
+	zfs_handle_t *const *zbp = argb;
+	zfs_handle_t *zb = *zbp;
 	char mounta[MAXPATHLEN];
 	char mountb[MAXPATHLEN];
+	const char *a = mounta;
+	const char *b = mountb;
 	boolean_t gota, gotb;
 
-	if ((gota = (zfs_get_type(*za) == ZFS_TYPE_FILESYSTEM)) != 0)
-		verify(zfs_prop_get(*za, ZFS_PROP_MOUNTPOINT, mounta,
+	gota = (zfs_get_type(za) == ZFS_TYPE_FILESYSTEM);
+	if (gota) {
+		verify(zfs_prop_get(za, ZFS_PROP_MOUNTPOINT, mounta,
 		    sizeof (mounta), NULL, NULL, 0, B_FALSE) == 0);
-	if ((gotb = (zfs_get_type(*zb) == ZFS_TYPE_FILESYSTEM)) != 0)
-		verify(zfs_prop_get(*zb, ZFS_PROP_MOUNTPOINT, mountb,
+	}
+	gotb = (zfs_get_type(zb) == ZFS_TYPE_FILESYSTEM);
+	if (gotb) {
+		verify(zfs_prop_get(zb, ZFS_PROP_MOUNTPOINT, mountb,
 		    sizeof (mountb), NULL, NULL, 0, B_FALSE) == 0);
+	}
 
-	if (gota && gotb)
-		return (strcmp(mounta, mountb));
+	if (gota && gotb) {
+		while (*a != '\0' && (*a == *b)) {
+			a++;
+			b++;
+		}
+		if (*a == *b)
+			return (0);
+		if (*a == '\0')
+			return (-1);
+		if (*b == '\0')
+			return (1);
+		if (*a == '/')
+			return (-1);
+		if (*b == '/')
+			return (1);
+		return (*a < *b ? -1 : *a > *b);
+	}
 
 	if (gota)
 		return (-1);
 	if (gotb)
 		return (1);
 
-	return (strcmp(zfs_get_name(a), zfs_get_name(b)));
+	/*
+	 * If neither filesystem has a mountpoint, revert to sorting by
+	 * dataset name.
+	 */
+	return (strcmp(zfs_get_name(za), zfs_get_name(zb)));
+}
+
+/*
+ * Return true if path2 is a child of path1.
+ */
+static boolean_t
+libzfs_path_contains(const char *path1, const char *path2)
+{
+	return (strstr(path2, path1) == path2 && path2[strlen(path1)] == '/');
+}
+
+/*
+ * Given a mountpoint specified by idx in the handles array, find the first
+ * non-descendent of that mountpoint and return its index. Descendant paths
+ * start with the parent's path. This function relies on the ordering
+ * enforced by mountpoint_cmp().
+ */
+static int
+non_descendant_idx(zfs_handle_t **handles, size_t num_handles, int idx)
+{
+	char parent[ZFS_MAXPROPLEN];
+	char child[ZFS_MAXPROPLEN];
+	int i;
+
+	verify(zfs_prop_get(handles[idx], ZFS_PROP_MOUNTPOINT, parent,
+	    sizeof (parent), NULL, NULL, 0, B_FALSE) == 0);
+
+	for (i = idx + 1; i < num_handles; i++) {
+		verify(zfs_prop_get(handles[i], ZFS_PROP_MOUNTPOINT, child,
+		    sizeof (child), NULL, NULL, 0, B_FALSE) == 0);
+		if (!libzfs_path_contains(parent, child))
+			break;
+	}
+	return (i);
+}
+
+typedef struct mnt_param {
+	libzfs_handle_t	*mnt_hdl;
+	zfs_taskq_t	*mnt_tq;
+	zfs_handle_t	**mnt_zhps; /* filesystems to mount */
+	size_t		mnt_num_handles;
+	int		mnt_idx;	/* Index of selected entry to mount */
+	zfs_iter_f	mnt_func;
+	void		*mnt_data;
+} mnt_param_t;
+
+/*
+ * Allocate and populate the parameter struct for mount function, and
+ * schedule mounting of the entry selected by idx.
+ */
+static void
+zfs_dispatch_mount(libzfs_handle_t *hdl, zfs_handle_t **handles,
+    size_t num_handles, int idx, zfs_iter_f func, void *data, zfs_taskq_t *tq)
+{
+	mnt_param_t *mnt_param = zfs_alloc(hdl, sizeof (mnt_param_t));
+
+	mnt_param->mnt_hdl = hdl;
+	mnt_param->mnt_tq = tq;
+	mnt_param->mnt_zhps = handles;
+	mnt_param->mnt_num_handles = num_handles;
+	mnt_param->mnt_idx = idx;
+	mnt_param->mnt_func = func;
+	mnt_param->mnt_data = data;
+
+	(void) zfs_taskq_dispatch(tq, zfs_mount_task, (void*)mnt_param,
+	    ZFS_TQ_SLEEP);
+}
+
+/*
+ * This is the structure used to keep state of mounting or sharing operations
+ * during a call to zpool_enable_datasets().
+ */
+typedef struct mount_state {
+	/*
+	 * ms_mntstatus is set to -1 if any mount fails. While multiple threads
+	 * could update this variable concurrently, no synchronization is
+	 * needed as it's only ever set to -1.
+	 */
+	int		ms_mntstatus;
+	int		ms_mntflags;
+	const char	*ms_mntopts;
+} mount_state_t;
+
+static int
+zfs_mount_one(zfs_handle_t *zhp, void *arg)
+{
+	mount_state_t *ms = arg;
+	int ret = 0;
+
+	if (zfs_mount(zhp, ms->ms_mntopts, ms->ms_mntflags) != 0)
+		ret = ms->ms_mntstatus = -1;
+	return (ret);
+}
+
+static int
+zfs_share_one(zfs_handle_t *zhp, void *arg)
+{
+	mount_state_t *ms = arg;
+	int ret = 0;
+
+	if (zfs_share(zhp) != 0)
+		ret = ms->ms_mntstatus = -1;
+	return (ret);
+}
+
+/*
+ * Task queue function to mount one file system. On completion, it finds and
+ * schedules its children to be mounted. This depends on the sorting done in
+ * zfs_foreach_mountpoint(). Note that the degenerate case (chain of entries
+ * each descending from the previous) will have no parallelism since we always
+ * have to wait for the parent to finish mounting before we can schedule
+ * its children.
+ */
+static void
+zfs_mount_task(void *arg)
+{
+	mnt_param_t *mp = arg;
+	int idx = mp->mnt_idx;
+	zfs_handle_t **handles = mp->mnt_zhps;
+	size_t num_handles = mp->mnt_num_handles;
+	char mountpoint[ZFS_MAXPROPLEN];
+
+	verify(zfs_prop_get(handles[idx], ZFS_PROP_MOUNTPOINT, mountpoint,
+	    sizeof (mountpoint), NULL, NULL, 0, B_FALSE) == 0);
+
+	if (mp->mnt_func(handles[idx], mp->mnt_data) != 0)
+		return;
+
+	/*
+	 * We dispatch tasks to mount filesystems with mountpoints underneath
+	 * this one. We do this by dispatching the next filesystem with a
+	 * descendant mountpoint of the one we just mounted, then skip all of
+	 * its descendants, dispatch the next descendant mountpoint, and so on.
+	 * The non_descendant_idx() function skips over filesystems that are
+	 * descendants of the filesystem we just dispatched.
+	 */
+	for (int i = idx + 1; i < num_handles;
+	    i = non_descendant_idx(handles, num_handles, i)) {
+		char child[ZFS_MAXPROPLEN];
+		verify(zfs_prop_get(handles[i], ZFS_PROP_MOUNTPOINT,
+		    child, sizeof (child), NULL, NULL, 0, B_FALSE) == 0);
+
+		if (!libzfs_path_contains(mountpoint, child))
+			break; /* not a descendant, return */
+		zfs_dispatch_mount(mp->mnt_hdl, handles, num_handles, i,
+		    mp->mnt_func, mp->mnt_data, mp->mnt_tq);
+	}
+	free(mp);
+}
+
+/*
+ * Issue the func callback for each ZFS handle contained in the handles
+ * array. This function is used to mount all datasets, and so this function
+ * guarantees that filesystems for parent mountpoints are called before their
+ * children. As such, before issuing any callbacks, we first sort the array
+ * of handles by mountpoint.
+ *
+ * Callbacks are issued in one of two ways:
+ *
+ * 1. Sequentially: If the parallel argument is B_FALSE or the ZFS_SERIAL_MOUNT
+ *    environment variable is set, then we issue callbacks sequentially.
+ *
+ * 2. In parallel: If the parallel argument is B_TRUE and the ZFS_SERIAL_MOUNT
+ *    environment variable is not set, then we use a taskq to dispatch threads
+ *    to mount filesystems is parallel. This function dispatches tasks to mount
+ *    the filesystems at the top-level mountpoints, and these tasks in turn
+ *    are responsible for recursively mounting filesystems in their children
+ *    mountpoints.
+ */
+void
+zfs_foreach_mountpoint(libzfs_handle_t *hdl, zfs_handle_t **handles,
+    size_t num_handles, zfs_iter_f func, void *data, boolean_t parallel)
+{
+	/*
+	 * The ZFS_SERIAL_MOUNT environment variable is an undocumented
+	 * variable that can be used as a convenience to do a/b comparison
+	 * of serial vs. parallel mounting.
+	 */
+	boolean_t serial_mount = !parallel ||
+	    (getenv("ZFS_SERIAL_MOUNT") != NULL);
+
+	/*
+	 * Sort the datasets by mountpoint. See mountpoint_cmp for details
+	 * of how these are sorted.
+	 */
+	qsort(handles, num_handles, sizeof (zfs_handle_t *), mountpoint_cmp);
+
+	if (serial_mount) {
+		for (int i = 0; i < num_handles; i++) {
+			func(handles[i], data);
+		}
+		return;
+	}
+
+	/*
+	 * Issue the callback function for each dataset using a parallel
+	 * algorithm that uses a taskq to manage threads.
+	 */
+	zfs_taskq_t *tq = zfs_taskq_create("mount_taskq", mount_tq_nthr, 0,
+	    mount_tq_nthr, mount_tq_nthr, ZFS_TASKQ_PREPOPULATE);
+
+	/*
+	 * There may be multiple "top level" mountpoints outside of the pool's
+	 * root mountpoint, e.g.: /foo /bar. Dispatch a mount task for each of
+	 * these.
+	 */
+	for (int i = 0; i < num_handles;
+	    i = non_descendant_idx(handles, num_handles, i)) {
+		zfs_dispatch_mount(hdl, handles, num_handles, i, func, data,
+		    tq);
+	}
+
+	zfs_taskq_wait(tq); /* wait for all scheduled mounts to complete */
+	zfs_taskq_destroy(tq);
 }
 
 /*
  * Mount and share all datasets within the given pool.  This assumes that no
- * datasets within the pool are currently mounted.  Because users can create
- * complicated nested hierarchies of mountpoints, we first gather all the
- * datasets and mountpoints within the pool, and sort them by mountpoint.  Once
- * we have the list of all filesystems, we iterate over them in order and mount
- * and/or share each one.
+ * datasets within the pool are currently mounted.
  */
 #pragma weak zpool_mount_datasets = zpool_enable_datasets
 int
 zpool_enable_datasets(zpool_handle_t *zhp, const char *mntopts, int flags)
 {
 	get_all_cb_t cb = { 0 };
-	libzfs_handle_t *hdl = zhp->zpool_hdl;
+	mount_state_t ms = { 0 };
 	zfs_handle_t *zfsp;
-	int i, ret = -1;
-	int *good;
+	sa_init_selective_arg_t sharearg;
+	int ret = 0;
 
-	/*
-	 * Gather all non-snap datasets within the pool.
-	 */
-	if ((zfsp = zfs_open(hdl, zhp->zpool_name, ZFS_TYPE_DATASET)) == NULL)
+	if ((zfsp = zfs_open(zhp->zpool_hdl, zhp->zpool_name,
+	    ZFS_TYPE_DATASET)) == NULL)
 		goto out;
 
+
+	/*
+	 * Gather all non-snapshot datasets within the pool. Start by adding
+	 * the root filesystem for this pool to the list, and then iterate
+	 * over all child filesystems.
+	 */
 	libzfs_add_handle(&cb, zfsp);
-	if (zfs_iter_filesystems(zfsp, mount_cb, &cb) != 0)
-		goto out;
-	/*
-	 * Sort the datasets by mountpoint.
-	 */
-	qsort(cb.cb_handles, cb.cb_used, sizeof (void *),
-	    libzfs_dataset_cmp);
-
-	/*
-	 * And mount all the datasets, keeping track of which ones
-	 * succeeded or failed.
-	 */
-	if ((good = zfs_alloc(zhp->zpool_hdl,
-	    cb.cb_used * sizeof (int))) == NULL)
+	if (zfs_iter_filesystems(zfsp, zfs_iter_cb, &cb) != 0)
 		goto out;
 
-	ret = 0;
-	for (i = 0; i < cb.cb_used; i++) {
-		if (zfs_mount(cb.cb_handles[i], mntopts, flags) != 0)
-			ret = -1;
-		else
-			good[i] = 1;
-	}
+	ms.ms_mntopts = mntopts;
+	ms.ms_mntflags = flags;
+	zfs_foreach_mountpoint(zhp->zpool_hdl, cb.cb_handles, cb.cb_used,
+	    zfs_mount_one, &ms, B_TRUE);
+	if (ms.ms_mntstatus != 0)
+		ret = ms.ms_mntstatus;
 
 	/*
-	 * Then share all the ones that need to be shared. This needs
-	 * to be a separate pass in order to avoid excessive reloading
-	 * of the configuration. Good should never be NULL since
-	 * zfs_alloc is supposed to exit if memory isn't available.
+	 * Share all filesystems that need to be shared. This needs to be
+	 * a separate pass because libshare is not mt-safe, and so we need
+	 * to share serially.
 	 */
-	for (i = 0; i < cb.cb_used; i++) {
-		if (good[i] && zfs_share(cb.cb_handles[i]) != 0)
-			ret = -1;
-	}
+	sharearg.zhandle_arr = cb.cb_handles;
+	sharearg.zhandle_len = cb.cb_used;
+	if ((ret = zfs_init_libshare_arg(zhp->zpool_hdl,
+	    SA_INIT_SHARE_API_SELECTIVE, &sharearg)) != 0)
+		goto out;
 
-	free(good);
+	ms.ms_mntstatus = 0;
+	zfs_foreach_mountpoint(zhp->zpool_hdl, cb.cb_handles, cb.cb_used,
+	    zfs_share_one, &ms, B_FALSE);
+	if (ms.ms_mntstatus != 0)
+		ret = ms.ms_mntstatus;
 
 out:
-	for (i = 0; i < cb.cb_used; i++)
+	for (int i = 0; i < cb.cb_used; i++)
 		zfs_close(cb.cb_handles[i]);
 	free(cb.cb_handles);
 

--- a/usr/src/lib/libzfs/common/libzfs_taskq.c
+++ b/usr/src/lib/libzfs/common/libzfs_taskq.c
@@ -1,0 +1,297 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright 2012 Garrett D'Amore <garrett@damore.org>.  All rights reserved.
+ * Copyright (c) 2014, 2018 by Delphix. All rights reserved.
+ */
+
+#include <thread.h>
+#include <synch.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/debug.h>
+#include <sys/sysmacros.h>
+
+#include "libzfs_taskq.h"
+
+#define	ZFS_TASKQ_ACTIVE	0x00010000
+#define	ZFS_TASKQ_NAMELEN	31
+
+typedef struct zfs_taskq_ent {
+	struct zfs_taskq_ent	*ztqent_next;
+	struct zfs_taskq_ent	*ztqent_prev;
+	ztask_func_t		*ztqent_func;
+	void			*ztqent_arg;
+	uintptr_t		ztqent_flags;
+} zfs_taskq_ent_t;
+
+struct zfs_taskq {
+	char		ztq_name[ZFS_TASKQ_NAMELEN + 1];
+	mutex_t		ztq_lock;
+	rwlock_t	ztq_threadlock;
+	cond_t		ztq_dispatch_cv;
+	cond_t		ztq_wait_cv;
+	thread_t	*ztq_threadlist;
+	int		ztq_flags;
+	int		ztq_active;
+	int		ztq_nthreads;
+	int		ztq_nalloc;
+	int		ztq_minalloc;
+	int		ztq_maxalloc;
+	cond_t		ztq_maxalloc_cv;
+	int		ztq_maxalloc_wait;
+	zfs_taskq_ent_t	*ztq_freelist;
+	zfs_taskq_ent_t	ztq_task;
+};
+
+static zfs_taskq_ent_t *
+ztask_alloc(zfs_taskq_t *ztq, int ztqflags)
+{
+	zfs_taskq_ent_t *t;
+	timestruc_t ts;
+	int err;
+
+again:	if ((t = ztq->ztq_freelist) != NULL &&
+	    ztq->ztq_nalloc >= ztq->ztq_minalloc) {
+		ztq->ztq_freelist = t->ztqent_next;
+	} else {
+		if (ztq->ztq_nalloc >= ztq->ztq_maxalloc) {
+			if (!(ztqflags & UMEM_NOFAIL))
+				return (NULL);
+
+			/*
+			 * We don't want to exceed ztq_maxalloc, but we can't
+			 * wait for other tasks to complete (and thus free up
+			 * task structures) without risking deadlock with
+			 * the caller.  So, we just delay for one second
+			 * to throttle the allocation rate. If we have tasks
+			 * complete before one second timeout expires then
+			 * zfs_taskq_ent_free will signal us and we will
+			 * immediately retry the allocation.
+			 */
+			ztq->ztq_maxalloc_wait++;
+
+			ts.tv_sec = 1;
+			ts.tv_nsec = 0;
+			err = cond_reltimedwait(&ztq->ztq_maxalloc_cv,
+			    &ztq->ztq_lock, &ts);
+
+			ztq->ztq_maxalloc_wait--;
+			if (err == 0)
+				goto again;		/* signaled */
+		}
+		mutex_exit(&ztq->ztq_lock);
+
+		t = umem_alloc(sizeof (zfs_taskq_ent_t), ztqflags);
+
+		mutex_enter(&ztq->ztq_lock);
+		if (t != NULL)
+			ztq->ztq_nalloc++;
+	}
+	return (t);
+}
+
+static void
+ztask_free(zfs_taskq_t *ztq, zfs_taskq_ent_t *t)
+{
+	if (ztq->ztq_nalloc <= ztq->ztq_minalloc) {
+		t->ztqent_next = ztq->ztq_freelist;
+		ztq->ztq_freelist = t;
+	} else {
+		ztq->ztq_nalloc--;
+		mutex_exit(&ztq->ztq_lock);
+		umem_free(t, sizeof (zfs_taskq_ent_t));
+		mutex_enter(&ztq->ztq_lock);
+	}
+
+	if (ztq->ztq_maxalloc_wait)
+		VERIFY0(cond_signal(&ztq->ztq_maxalloc_cv));
+}
+
+zfs_taskqid_t
+zfs_taskq_dispatch(zfs_taskq_t *ztq, ztask_func_t func, void *arg,
+    uint_t ztqflags)
+{
+	zfs_taskq_ent_t *t;
+
+	mutex_enter(&ztq->ztq_lock);
+	ASSERT(ztq->ztq_flags & ZFS_TASKQ_ACTIVE);
+	if ((t = ztask_alloc(ztq, ztqflags)) == NULL) {
+		mutex_exit(&ztq->ztq_lock);
+		return (0);
+	}
+	if (ztqflags & ZFS_TQ_FRONT) {
+		t->ztqent_next = ztq->ztq_task.ztqent_next;
+		t->ztqent_prev = &ztq->ztq_task;
+	} else {
+		t->ztqent_next = &ztq->ztq_task;
+		t->ztqent_prev = ztq->ztq_task.ztqent_prev;
+	}
+	t->ztqent_next->ztqent_prev = t;
+	t->ztqent_prev->ztqent_next = t;
+	t->ztqent_func = func;
+	t->ztqent_arg = arg;
+	t->ztqent_flags = 0;
+	VERIFY0(cond_signal(&ztq->ztq_dispatch_cv));
+	mutex_exit(&ztq->ztq_lock);
+	return (1);
+}
+
+void
+zfs_taskq_wait(zfs_taskq_t *ztq)
+{
+	mutex_enter(&ztq->ztq_lock);
+	while (ztq->ztq_task.ztqent_next != &ztq->ztq_task ||
+	    ztq->ztq_active != 0) {
+		int ret = cond_wait(&ztq->ztq_wait_cv, &ztq->ztq_lock);
+		VERIFY(ret == 0 || ret == EINTR);
+	}
+	mutex_exit(&ztq->ztq_lock);
+}
+
+static void *
+zfs_taskq_thread(void *arg)
+{
+	zfs_taskq_t *ztq = arg;
+	zfs_taskq_ent_t *t;
+	boolean_t prealloc;
+
+	mutex_enter(&ztq->ztq_lock);
+	while (ztq->ztq_flags & ZFS_TASKQ_ACTIVE) {
+		if ((t = ztq->ztq_task.ztqent_next) == &ztq->ztq_task) {
+			int ret;
+			if (--ztq->ztq_active == 0)
+				VERIFY0(cond_broadcast(&ztq->ztq_wait_cv));
+			ret = cond_wait(&ztq->ztq_dispatch_cv, &ztq->ztq_lock);
+			VERIFY(ret == 0 || ret == EINTR);
+			ztq->ztq_active++;
+			continue;
+		}
+		t->ztqent_prev->ztqent_next = t->ztqent_next;
+		t->ztqent_next->ztqent_prev = t->ztqent_prev;
+		t->ztqent_next = NULL;
+		t->ztqent_prev = NULL;
+		prealloc = t->ztqent_flags & ZFS_TQENT_FLAG_PREALLOC;
+		mutex_exit(&ztq->ztq_lock);
+
+		VERIFY0(rw_rdlock(&ztq->ztq_threadlock));
+		t->ztqent_func(t->ztqent_arg);
+		VERIFY0(rw_unlock(&ztq->ztq_threadlock));
+
+		mutex_enter(&ztq->ztq_lock);
+		if (!prealloc)
+			ztask_free(ztq, t);
+	}
+	ztq->ztq_nthreads--;
+	VERIFY0(cond_broadcast(&ztq->ztq_wait_cv));
+	mutex_exit(&ztq->ztq_lock);
+	return (NULL);
+}
+
+/*ARGSUSED*/
+zfs_taskq_t *
+zfs_taskq_create(const char *name, int nthreads, pri_t pri, int minalloc,
+    int maxalloc, uint_t flags)
+{
+	zfs_taskq_t *ztq = umem_zalloc(sizeof (zfs_taskq_t), UMEM_NOFAIL);
+	int t;
+
+	ASSERT3S(nthreads, >=, 1);
+
+	VERIFY0(rwlock_init(&ztq->ztq_threadlock, USYNC_THREAD, NULL));
+	VERIFY0(cond_init(&ztq->ztq_dispatch_cv, USYNC_THREAD, NULL));
+	VERIFY0(cond_init(&ztq->ztq_wait_cv, USYNC_THREAD, NULL));
+	VERIFY0(cond_init(&ztq->ztq_maxalloc_cv, USYNC_THREAD, NULL));
+	VERIFY0(mutex_init(
+	    &ztq->ztq_lock, LOCK_NORMAL | LOCK_ERRORCHECK, NULL));
+
+	(void) strncpy(ztq->ztq_name, name, ZFS_TASKQ_NAMELEN + 1);
+
+	ztq->ztq_flags = flags | ZFS_TASKQ_ACTIVE;
+	ztq->ztq_active = nthreads;
+	ztq->ztq_nthreads = nthreads;
+	ztq->ztq_minalloc = minalloc;
+	ztq->ztq_maxalloc = maxalloc;
+	ztq->ztq_task.ztqent_next = &ztq->ztq_task;
+	ztq->ztq_task.ztqent_prev = &ztq->ztq_task;
+	ztq->ztq_threadlist =
+	    umem_alloc(nthreads * sizeof (thread_t), UMEM_NOFAIL);
+
+	if (flags & ZFS_TASKQ_PREPOPULATE) {
+		mutex_enter(&ztq->ztq_lock);
+		while (minalloc-- > 0)
+			ztask_free(ztq, ztask_alloc(ztq, UMEM_NOFAIL));
+		mutex_exit(&ztq->ztq_lock);
+	}
+
+	for (t = 0; t < nthreads; t++) {
+		(void) thr_create(0, 0, zfs_taskq_thread,
+		    ztq, THR_BOUND, &ztq->ztq_threadlist[t]);
+	}
+
+	return (ztq);
+}
+
+void
+zfs_taskq_destroy(zfs_taskq_t *ztq)
+{
+	int t;
+	int nthreads = ztq->ztq_nthreads;
+
+	zfs_taskq_wait(ztq);
+
+	mutex_enter(&ztq->ztq_lock);
+
+	ztq->ztq_flags &= ~ZFS_TASKQ_ACTIVE;
+	VERIFY0(cond_broadcast(&ztq->ztq_dispatch_cv));
+
+	while (ztq->ztq_nthreads != 0) {
+		int ret = cond_wait(&ztq->ztq_wait_cv, &ztq->ztq_lock);
+		VERIFY(ret == 0 || ret == EINTR);
+	}
+
+	ztq->ztq_minalloc = 0;
+	while (ztq->ztq_nalloc != 0) {
+		ASSERT(ztq->ztq_freelist != NULL);
+		ztask_free(ztq, ztask_alloc(ztq, UMEM_NOFAIL));
+	}
+
+	mutex_exit(&ztq->ztq_lock);
+
+	for (t = 0; t < nthreads; t++)
+		(void) thr_join(ztq->ztq_threadlist[t], NULL, NULL);
+
+	umem_free(ztq->ztq_threadlist, nthreads * sizeof (thread_t));
+
+	VERIFY0(rwlock_destroy(&ztq->ztq_threadlock));
+	VERIFY0(cond_destroy(&ztq->ztq_dispatch_cv));
+	VERIFY0(cond_destroy(&ztq->ztq_wait_cv));
+	VERIFY0(cond_destroy(&ztq->ztq_maxalloc_cv));
+	VERIFY0(mutex_destroy(&ztq->ztq_lock));
+
+	umem_free(ztq, sizeof (zfs_taskq_t));
+}

--- a/usr/src/lib/libzfs/common/libzfs_taskq.h
+++ b/usr/src/lib/libzfs/common/libzfs_taskq.h
@@ -1,0 +1,63 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2012, Joyent, Inc. All rights reserved.
+ */
+
+#ifndef	_ZFS_TASKQ_H
+#define	_ZFS_TASKQ_H
+
+#include <stdint.h>
+#include <umem.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+typedef struct zfs_taskq zfs_taskq_t;
+typedef uintptr_t zfs_taskqid_t;
+typedef void (ztask_func_t)(void *);
+
+#define	ZFS_TQENT_FLAG_PREALLOC		0x1	/* taskq_dispatch_ent used */
+
+#define	ZFS_TASKQ_PREPOPULATE		0x0001
+
+#define	ZFS_TQ_SLEEP	UMEM_NOFAIL	/* Can block for memory */
+#define	ZFS_TQ_NOSLEEP	UMEM_DEFAULT	/* cannot block for memory; may fail */
+#define	ZFS_TQ_FRONT	0x08		/* Queue in front */
+
+extern zfs_taskq_t	*zfs_taskq_create(const char *, int, pri_t, int,
+	int, uint_t);
+extern void		zfs_taskq_destroy(zfs_taskq_t *);
+
+extern zfs_taskqid_t	zfs_taskq_dispatch(zfs_taskq_t *, ztask_func_t,
+	void *, uint_t);
+
+extern void		zfs_taskq_wait(zfs_taskq_t *);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _ZFS_TASKQ_H */

--- a/usr/src/lib/libzfs/common/mapfile-vers
+++ b/usr/src/lib/libzfs/common/mapfile-vers
@@ -21,7 +21,7 @@
 
 #
 # Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2011, 2015 by Delphix. All rights reserved.
+# Copyright (c) 2011, 2017 by Delphix. All rights reserved.
 # Copyright 2016 Nexenta Systems, Inc.
 #
 
@@ -50,7 +50,6 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	fletcher_4_incremental_native;
 	fletcher_4_incremental_byteswap;
 	libzfs_add_handle;
-	libzfs_dataset_cmp;
 	libzfs_errno;
 	libzfs_error_action;
 	libzfs_error_description;
@@ -77,6 +76,7 @@ SYMBOL_VERSION SUNWprivate_1.1 {
 	zfs_destroy_snaps;
 	zfs_destroy_snaps_nvl;
 	zfs_expand_proplist;
+	zfs_foreach_mountpoint;
 	zfs_get_handle;
 	zfs_get_holds;
 	zfs_get_hole_count;

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -873,6 +873,11 @@ file path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_012_neg \
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_001_pos \
     mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_mountpoints \
+    mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_promote/cleanup \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_promote/setup mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -145,7 +145,7 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_004_pos', 'zfs_mount_005_pos', 'zfs_mount_006_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_012_neg',
-    'zfs_mount_all_001_pos']
+    'zfs_mount_all_001_pos', 'zfs_mount_all_fail', 'zfs_mount_all_mountpoints']
 
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
@@ -25,7 +25,7 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -84,13 +84,11 @@ function setup_filesystem #disklist #pool #fs #mntpoint #type #vdev
 	fi
 
 	case "$type" in
-		'ctr')	log_must zfs create $pool/$fs
-			log_must zfs set mountpoint=$mntpoint $pool/$fs
+		'ctr')	log_must zfs create -o mountpoint=$mntpoint $pool/$fs
 			;;
 		'vol')	log_must zfs create -V $VOLSIZE $pool/$fs
 			;;
-		*)	log_must zfs create $pool/$fs
-			log_must zfs set mountpoint=$mntpoint $pool/$fs
+		*)	log_must zfs create -o mountpoint=$mntpoint $pool/$fs
 			;;
 	esac
 

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail.ksh
@@ -1,0 +1,96 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
+
+# DESCRIPTION:
+#       Verify that if 'zfs mount -a' fails to mount one filesystem,
+#       the command fails with a non-zero error code, but all other
+#       filesystems are mounted.
+#
+# STRATEGY:
+#       1. Create zfs filesystems
+#       2. Unmount a leaf filesystem
+#       3. Create a file in the above filesystem's mountpoint
+#       4. Verify that 'zfs mount -a' fails to mount the above
+#       5. Verify that all other filesystems were mounted
+#
+
+verify_runnable "both"
+
+typeset -a filesystems
+typeset path=${TEST_BASE_DIR%%/}/testroot$$/$TESTPOOL
+typeset fscount=10
+
+function setup_all
+{
+	# Create $fscount filesystems at the top level of $path
+	for ((i=0; i<$fscount; i++)); do
+		setup_filesystem "$DISKS" "$TESTPOOL" $i "$path/$i" ctr
+	done
+
+	zfs list -r $TESTPOOL
+
+	return 0
+}
+
+function cleanup_all
+{
+	export __ZFS_POOL_RESTRICT="$TESTPOOL"
+	log_must zfs $unmountall
+	unset __ZFS_POOL_RESTRICT
+
+	[[ -d ${TEST_BASE_DIR%%/}/testroot$$ ]] && \
+		rm -rf ${TEST_BASE_DIR%%/}/testroot$$
+}
+
+log_onexit cleanup_all
+
+log_must setup_all
+
+#
+# Unmount all of the above so that we can create the stray file
+# in one of the mountpoint directories.
+#
+export __ZFS_POOL_RESTRICT="$TESTPOOL"
+log_must zfs $unmountall
+unset __ZFS_POOL_RESTRICT
+
+# All of our filesystems should be unmounted at this point
+for ((i=0; i<$fscount; i++)); do
+	log_mustnot mounted "$TESTPOOL/$i"
+done
+
+# Create a stray file in one filesystem's mountpoint
+touch $path/0/strayfile
+
+# Verify that zfs mount -a fails
+export __ZFS_POOL_RESTRICT="$TESTPOOL"
+log_mustnot zfs $mountall
+unset __ZFS_POOL_RESTRICT
+
+# All filesystems except for "0" should be mounted
+log_mustnot mounted "$TESTPOOL/0"
+for ((i=1; i<$fscount; i++)); do
+	log_must mounted "$TESTPOOL/$i"
+done
+
+log_pass "'zfs $mountall' failed as expected."

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_mountpoints.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_mountpoints.ksh
@@ -1,0 +1,162 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/cli_root/zfs_mount/zfs_mount.kshlib
+
+# DESCRIPTION:
+#       Verify that 'zfs mount -a' succeeds given a set of filesystems
+#       whose mountpoints have a parent/child relationship which is
+#       counter to the filesystem parent/child relationship.
+#
+# STRATEGY:
+#       1. Create zfs filesystems within the given pool.
+#       2. Unmount all the filesystems.
+#       3. Verify that 'zfs mount -a' command succeed,
+#	   and all available ZFS filesystems are mounted.
+#	4. Verify that 'zfs mount' is identical with 'df -F zfs'
+#
+
+verify_runnable "both"
+
+typeset -a filesystems
+
+function setup_all
+{
+	typeset path=${TEST_BASE_DIR%%/}/testroot$$/$TESTPOOL
+	typeset fscount=10
+
+	#
+	# Generate an array of filesystem names that represent a deep
+	# hierarchy as such:
+	#
+	# 0
+	# 0/1
+	# 0/1/2
+	# 0/1/2/3
+	# 0/1/2/3/4
+	# ...
+	#
+	fs=0
+	for ((i=0; i<$fscount; i++)); do
+		if [[ $i -gt 0 ]]; then
+			fs=$fs/$i
+		fi
+		filesystems+=($fs)
+	done
+
+	# Create all of the above filesystems
+	for ((i=0; i<$fscount; i++)); do
+		fs=${filesystems[$i]}
+		setup_filesystem "$DISKS" "$TESTPOOL" "$fs" "$path/$i" ctr
+	done
+
+	zfs list -r $TESTPOOL
+
+	#
+	# Unmount all of the above so that we can setup our convoluted
+	# mount paths.
+	#
+	export __ZFS_POOL_RESTRICT="$TESTPOOL"
+	log_must zfs $unmountall
+	unset __ZFS_POOL_RESTRICT
+
+	#
+	# Configure the mount paths so that each mountpoint is contained
+	# in a child filesystem. We should end up with something like the
+	# following structure (modulo the number of filesystems):
+	#
+	# NAME                       MOUNTPOINT
+	# testpool                   /testpool
+	# testpool/0                 /testroot25416/testpool/0/1/2/3/4/5/6
+	# testpool/0/1               /testroot25416/testpool/0/1/2/3/4/5
+	# testpool/0/1/2             /testroot25416/testpool/0/1/2/3/4
+	# testpool/0/1/2/3           /testroot25416/testpool/0/1/2/3
+	# testpool/0/1/2/3/4         /testroot25416/testpool/0/1/2
+	# testpool/0/1/2/3/4/5       /testroot25416/testpool/0/1
+	# testpool/0/1/2/3/4/5/6     /testroot25416/testpool/0
+	#
+	for ((i=0; i<$fscount; i++)); do
+		fs=$TESTPOOL/${filesystems[$(($fscount - $i - 1))]}
+		mnt=$path/${filesystems[$i]}
+		zfs set mountpoint=$mnt $fs
+	done
+
+	zfs list -r $TESTPOOL
+
+	return 0
+}
+
+function cleanup_all
+{
+	export __ZFS_POOL_RESTRICT="$TESTPOOL"
+	log_must zfs $unmountall
+	unset __ZFS_POOL_RESTRICT
+
+	for fs in ${filesystems[@]}; do
+		cleanup_filesystem "$TESTPOOL" "$fs"
+	done
+	[[ -d ${TEST_BASE_DIR%%/}/testroot$$ ]] && \
+		rm -rf ${TEST_BASE_DIR%%/}/testroot$$
+}
+
+#
+# This function takes a single true/false argument. If true it will verify that
+# all file systems are mounted. If false it will verify that they are not
+# mounted.
+#
+function verify_all
+{
+	if $1; then
+		logfunc=log_must
+	else
+		logfunc=log_mustnot
+	fi
+
+	for fs in ${filesystems[@]}; do
+		$logfunc mounted "$TESTPOOL/$fs"
+	done
+
+	return 0
+}
+
+log_onexit cleanup_all
+
+log_must setup_all
+
+export __ZFS_POOL_RESTRICT="$TESTPOOL"
+log_must zfs $unmountall
+unset __ZFS_POOL_RESTRICT
+
+verify_all false
+
+export __ZFS_POOL_RESTRICT="$TESTPOOL"
+log_must zfs $mountall
+unset __ZFS_POOL_RESTRICT
+
+verify_all true
+
+log_note "Verify that 'zfs $mountcmd' will display " \
+	"all ZFS filesystems currently mounted."
+
+verify_mount_display
+
+log_pass "'zfs $mountall' succeeds as root, " \
+	"and all available ZFS filesystems are mounted."

--- a/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
+++ b/usr/src/uts/common/fs/zfs/sys/dsl_pool.h
@@ -89,7 +89,7 @@ typedef struct dsl_pool {
 	struct dsl_dir *dp_leak_dir;
 	struct dsl_dataset *dp_origin_snap;
 	uint64_t dp_root_dir_obj;
-	struct taskq *dp_vnrele_taskq;
+	taskq_t *dp_vnrele_taskq;
 
 	/* No lock needed - sync context only */
 	blkptr_t dp_meta_rootbp;


### PR DESCRIPTION
Reviewed by: Matthew Ahrens mahrens@delphix.com
Reviewed by: Pavel Zakharov pavel.zakharov@delphix.com
Reviewed by: Brad Lewis <brad.lewis@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

Overview
========

In analyzing the time it takes for a Delphix Engine to come up following
a planned or unplanned reboot, we've determined that the SMF service
(filesystem/local) that's responsible for mounting all local filesystems
(except for /) is responsible for a significant percentage of the boot
time. The longer it takes for the Delphix Engine to come up, the longer
the Delphix Engine is unavailable during these outages. For example, on
a Delphix Engine with roughly 3000 filesystems, we have the following
breakdown of "filesystem/local" start time for a sample of 74 reboots:

    # NumSamples = 74; Min = 0.00; Max = 782.00
    # Mean = 186.972973; Variance = 17853.891161; SD = 133.618454; Median 156.000000
    # each * represents a count of 1
        0.0000 -    78.2000 [    10]: **********
       78.2000 -   156.4000 [    27]: ***************************
      156.4000 -   234.6000 [    17]: *****************
      234.6000 -   312.8000 [     8]: ********
      312.8000 -   391.0000 [     8]: ********
      391.0000 -   469.2000 [     1]: *
      469.2000 -   547.4000 [     1]: *
      547.4000 -   625.6000 [     1]: *
      625.6000 -   703.8000 [     0]:
      703.8000 -   782.0000 [     1]: *

On average, it takes over 3 minutes to mount local filesystems on that
system. A sampling of 56 reboots on another system which has 9000+
filesystems is below:

    # NumSamples = 56; Min = 0.00; Max = 1377.00
    # Mean = 175.250000; Variance = 54092.223214; SD = 232.577349; Median 118.000000
    # each * represents a count of 1
        0.0000 -   137.7000 [    37]: *************************************
      137.7000 -   275.4000 [    11]: ***********
      275.4000 -   413.1000 [     4]: ****
      413.1000 -   550.8000 [     1]: *
      550.8000 -   688.5000 [     1]: *
      688.5000 -   826.2000 [     0]:
      826.2000 -   963.9000 [     0]:
      963.9000 -  1101.6000 [     1]: *
     1101.6000 -  1239.3000 [     0]:
     1239.3000 -  1377.0000 [     1]: *

Mounting of filesystems in "filesystem/local" is done using `zfs mount -a`,
which mounts each filesystems serially. The bottleneck for each mount is
the I/O done to load metadata for each filesystem. As such, mounting
filesystems using a parallel algorithm should be a big win, and bring down
the runtime of "filesystem/local"'s start method.

Performance Testing: System Configuration
=========================================

To test and verify these changes impacted performance how we expected it
to, we used a VM with:

  - 8 vCPUs
  - zpool with 10 10k-SAS disks
  - filesystem hierarchy like so:

        1 pool     2 groups  100 containers  2 timeflows    5 leaf datasets
                               per group     per container  per timeflow
        ===================================================================
        test-pool-+-group-0-+-container-0-+---timeflow-0---+-ds-0
                  |         |             |                +-ds-1
                  |         |             |                +-ds-2
                  |         |             |                +-ds-3
                  |         |             |                +-ds-4
                  |         |             |
                  |         |             +---timeflow-1---+-ds-0
                  |         |                              +-ds-1
                  |         |                              +-ds-2
                  |         |                              +-ds-3
                  |         |                              +-ds-4
                  |         |
                  |         +-container-1-+---timeflow-0---+-ds-0
                  |         |             |                +-ds-1
                  |         |             |                +-ds-2
                  |         |             |                +-ds-3
                  |         |             |                +-ds-4
                  |         |             |
                  |         |             +---timeflow-1---+-ds-0
                  |         |                              +-ds-1
                  |         |                              +-ds-2
                  |         |                              +-ds-3
                  |         |                              +-ds-4
                  |         + ...
                  |         .
                  |         .
                  |
                  +-group-1 ...

This makes for a total of 2603 filesystems:

    pool + groups + containers + timeflows + leaves
    1    + 2      + 2*100      + 2(2*100)  + 5(2(2*100)) = 2603 filesystems

Additionally, a 1MB file was created in each leaf dataset.

Because this filesystem heirarchy is not very deep, this lends itself
well to the new parallel mounting algorithm implemented.

Performance Testing: Methodology and Results
============================================

The system described above was rebooted 10 times, and the duration of
the start method of "filesystem/local" was measured. Specifically, the
"zfs mount -va" comamnd that it calls was instrumented to break down the
phases of the mounting process into three buckets:

  1. gathering the list of filesystems to mount (aka "load")
  2. mounting all filesystems (aka "mount")
  3. left-over time spent doing anything else (aka "other")

The results of these measurements is below:

           | other (s) | load (s) | mount (s) |
       ----+-----------+----------+-----------+
    Before |    1.5    |    8.1   |    45.5   |
       ----+-------+------+-------+-----------+
     After |    1.7    |    7.9   |    2.1    |
       ----+-----------+----------+-----------+

In summary, for this configuration, the filesystem/local SMF services
goes from taking an average of 55.1 seconds (+/- 1.0s) to an average of
11.7 seconds (+/- 0.8s). The "other" and "load" times remain unchanged
(unsurprising given that this project hasn't touched any code in those
areas).

The big win comes in the "mount" phase, which reduces the time from
roughly 45 seconds to 2 seconds; a 95% decrease in latency.

Using the same zpool as above, "zpool import" performance was also
tested; the mounting done by "zpool import" now uses the same framework
as "zfs mount -a". Performance improvement for this case is unsurprisingly
on par with the "zfs mount -a" improvement documented above.

Upstream bugs: DLPX-46555, DLPX-49847, DLPX-49351, 38457