### PR TITLE
9403 assertion failed in arc_buf_destroy() when concurrently reading …

### DIFF
--- a/usr/src/uts/common/fs/zfs/dbuf.c
+++ b/usr/src/uts/common/fs/zfs/dbuf.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
- * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
  * Copyright (c) 2013, Joyent, Inc. All rights reserved.
  * Copyright (c) 2014 Spectra Logic Corporation, All rights reserved.
@@ -904,22 +904,26 @@ dbuf_read_done(zio_t *zio, arc_buf_t *buf, void *vdb)
 	ASSERT(refcount_count(&db->db_holds) > 0);
 	ASSERT(db->db_buf == NULL);
 	ASSERT(db->db.db_data == NULL);
-	if (db->db_level == 0 && db->db_freed_in_flight) {
-		/* we were freed in flight; disregard any error */
+	if (buf == NULL) {
+		/* i/o error */
+		ASSERT(zio == NULL || zio->io_error != 0);
+		ASSERT(db->db_blkid != DMU_BONUS_BLKID);
+		ASSERT3P(db->db_buf, ==, NULL);
+		db->db_state = DB_UNCACHED;
+	} else if (db->db_level == 0 && db->db_freed_in_flight) {
+		/* freed in flight */
+		ASSERT(zio == NULL || zio->io_error == 0);
 		arc_release(buf, db);
 		bzero(buf->b_data, db->db.db_size);
 		arc_buf_freeze(buf);
 		db->db_freed_in_flight = FALSE;
 		dbuf_set_data(db, buf);
 		db->db_state = DB_CACHED;
-	} else if (zio == NULL || zio->io_error == 0) {
+	} else {
+		/* success */
+		ASSERT(zio == NULL || zio->io_error == 0);
 		dbuf_set_data(db, buf);
 		db->db_state = DB_CACHED;
-	} else {
-		ASSERT(db->db_blkid != DMU_BONUS_BLKID);
-		ASSERT3P(db->db_buf, ==, NULL);
-		arc_buf_destroy(buf, db);
-		db->db_state = DB_UNCACHED;
 	}
 	cv_broadcast(&db->db_changed);
 	dbuf_rele_and_unlock(db, NULL);
@@ -2323,6 +2327,13 @@ dbuf_prefetch_indirect_done(zio_t *zio, arc_buf_t *abuf, void *private)
 	ASSERT3S(dpa->dpa_zb.zb_level, <, dpa->dpa_curlevel);
 	ASSERT3S(dpa->dpa_curlevel, >, 0);
 
+	if (abuf == NULL) {
+		ASSERT(zio == NULL || zio->io_error != 0);
+		kmem_free(dpa, sizeof (*dpa));
+		return;
+	}
+	ASSERT(zio == NULL || zio->io_error == 0);
+
 	/*
 	 * The dpa_dnode is only valid if we are called with a NULL
 	 * zio. This indicates that the arc_read() returned without
@@ -2361,7 +2372,7 @@ dbuf_prefetch_indirect_done(zio_t *zio, arc_buf_t *abuf, void *private)
 	    (dpa->dpa_epbs * (dpa->dpa_curlevel - dpa->dpa_zb.zb_level));
 	blkptr_t *bp = ((blkptr_t *)abuf->b_data) +
 	    P2PHASE(nextblkid, 1ULL << dpa->dpa_epbs);
-	if (BP_IS_HOLE(bp) || (zio != NULL && zio->io_error != 0)) {
+	if (BP_IS_HOLE(bp)) {
 		kmem_free(dpa, sizeof (*dpa));
 	} else if (dpa->dpa_curlevel == dpa->dpa_zb.zb_level) {
 		ASSERT3U(nextblkid, ==, dpa->dpa_zb.zb_blkid);

--- a/usr/src/uts/common/fs/zfs/zio_compress.c
+++ b/usr/src/uts/common/fs/zfs/zio_compress.c
@@ -25,7 +25,7 @@
  */
 /*
  * Copyright (c) 2013 by Saso Kiselkov. All rights reserved.
- * Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2013, 2018 by Delphix. All rights reserved.
  */
 
 #include <sys/zfs_context.h>
@@ -34,6 +34,12 @@
 #include <sys/zfeature.h>
 #include <sys/zio.h>
 #include <sys/zio_compress.h>
+
+/*
+ * If nonzero, every 1/X decompression attempts will fail, simulating
+ * an undetected memory error.
+ */
+uint64_t zio_decompress_fail_fraction = 0;
 
 /*
  * Compression vectors.
@@ -145,6 +151,16 @@ zio_decompress_data(enum zio_compress c, abd_t *src, void *dst,
 	void *tmp = abd_borrow_buf_copy(src, s_len);
 	int ret = zio_decompress_data_buf(c, tmp, dst, s_len, d_len);
 	abd_return_buf(src, tmp, s_len);
+
+	/*
+	 * Decompression shouldn't fail, because we've already verifyied
+	 * the checksum.  However, for extra protection (e.g. against bitflips
+	 * in non-ECC RAM), we handle this error (and test it).
+	 */
+	ASSERT0(ret);
+	if (zio_decompress_fail_fraction != 0 &&
+	    spa_get_random(zio_decompress_fail_fraction) == 0)
+		ret = SET_ERROR(EINVAL);
 
 	return (ret);
 }


### PR DESCRIPTION
…block with checksum error

Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Paul Dagnelie <pcd@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

This assertion (VERIFY) failure was reported when reading a block. Turns out the problem is that if
we get an i/o error (ECKSUM in this case), and there are multiple concurrent ARC reads of the same
block (from different clones), then the ARC will put multiple buf's on the same ANON hdr, which
isn't supposed to happen, and then causes a panic when we try to arc_buf_destroy() the buf.

```
Jan 12 18:39:29 TFGELSVMLXDEL01 ^Mpanic[cpu12]/thread=fffffe4229738c40:
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 603766 kern.notice] assertion failed: remove_reference(hdr, 0L, tag) 0 (0x2 0x0), file: ../../common/fs/zfs/arc.c, line: 3125
Jan 12 18:39:29 TFGELSVMLXDEL01 unix: [ID 100000 kern.notice]
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe42297388b0 genunix:strlog+0 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe42297388f0 zfs:arc_buf_destroy+d7 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe4229738940 zfs:dbuf_read_done+93 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe42297389a0 zfs:arc_read_done+198 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe4229738a40 zfs:zio_done+3f2 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe4229738a70 zfs:zio_execute+7f ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe4229738b30 genunix:taskq_thread+2d0 ()
Jan 12 18:39:29 TFGELSVMLXDEL01 genunix: [ID 655072 kern.notice] fffffe4229738b40 unix:thread_start+8 ()

fffffe422a5b2c40::findstack -v

stack pointer for thread fffffe422a5b2c40: fffffe422a5b24f0
[ fffffe422a5b24f0 _resume_from_idle+0xf4() ]
fffffe422a5b2520 swtch+0x141()
fffffe422a5b2560 cv_wait+0x70(fffffea8a7bc13e0, fffffea8a7bc13d8)
fffffe422a5b25a0 zio_wait+0x6b(fffffea8a7bc1068)
fffffe422a5b2650 dmu_buf_hold_array_by_dnode+0x163(fffffeaac781a780, 853d5dc0000, 2000, 1, fffffffff7ac7650, fffffe422a5b269c, fffffe422a5b2690, 0)
fffffe422a5b26f0 dmu_read_uio_dnode+0x5a(fffffeaac781a780, fffffe422a5b2940, 2000)
fffffe422a5b2750 dmu_read_uio+0x5b(fffffea4cd1f0ac0, 1, fffffe422a5b2940, 2000)
fffffe422a5b27c0 zvol_read+0x10a(1130000016e, fffffe422a5b2940, fffffea323cacdb0)
fffffe422a5b27f0 cdev_read+0x2d(1130000016e, fffffe422a5b2940, fffffea323cacdb0)
fffffe422a5b2890 spec_read+0x2b9(fffffea4d53a6580, fffffe422a5b2940, 0, fffffea323cacdb0, 0)
fffffe422a5b2910 fop_read+0x5b(fffffea4d53a6580, fffffe422a5b2940, 0, fffffea323cacdb0, 0)
fffffe422a5b29f0 vn_rdwr+0x10a(0, fffffea4d53a6580, fffffea4cccb6000, 2000, 853d5dc0000, 1, 0, fffffffffffffffd, fffffea323cacdb0, fffffe422a5b2a48)
fffffe422a5b2ab0 sbd_data_read+0x153(fffffeab1ea9d998, fffffea3ca9fc800, 853d5dc0000, 2000, fffffea4cccb6000)
fffffe422a5b2b20 sbd_handle_read+0x1ce(fffffea3ca9fc800, 0)
fffffe422a5b2b80 sbd_new_task+0x60b(fffffea3ca9fc800, 0)
fffffe422a5b2c20 stmf_worker_task+0x2fd(fffffea43f5d80f0)
fffffe422a5b2c30 thread_start+8()

fffffe422ce63c40::findstack -v

stack pointer for thread fffffe422ce63c40: fffffe422ce634f0
[ fffffe422ce634f0 _resume_from_idle+0xf4() ]
fffffe422ce63520 swtch+0x141()
fffffe422ce63560 cv_wait+0x70(fffffea8ad269f00, fffffea8ad269ef8)
fffffe422ce635a0 zio_wait+0x6b(fffffea8ad269b88)
fffffe422ce63650 dmu_buf_hold_array_by_dnode+0x163(fffffeaac666ac50, 853d5dc0000, 2000, 1, fffffffff7ac7650, fffffe422ce6369c, fffffe422ce63690, 0)
fffffe422ce636f0 dmu_read_uio_dnode+0x5a(fffffeaac666ac50, fffffe422ce63940, 2000)
fffffe422ce63750 dmu_read_uio+0x5b(fffffea4cd07ae00, 1, fffffe422ce63940, 2000)
fffffe422ce637c0 zvol_read+0x10a(11300000162, fffffe422ce63940, fffffea323cacdb0)
fffffe422ce637f0 cdev_read+0x2d(11300000162, fffffe422ce63940, fffffea323cacdb0)
fffffe422ce63890 spec_read+0x2b9(fffffea3616f9e80, fffffe422ce63940, 0, fffffea323cacdb0, 0)
fffffe422ce63910 fop_read+0x5b(fffffea3616f9e80, fffffe422ce63940, 0, fffffea323cacdb0, 0)
fffffe422ce639f0 vn_rdwr+0x10a(0, fffffea3616f9e80, fffffea4c9c9d000, 2000, 853d5dc0000, 1, 0, fffffffffffffffd, fffffea323cacdb0, fffffe422ce63a48)
fffffe422ce63ab0 sbd_data_read+0x153(fffffea4c1af5998, fffffea52401f000, 853d5dc0000, 2000, fffffea4c9c9d000)
fffffe422ce63b20 sbd_handle_read+0x1ce(fffffea52401f000, 0)
fffffe422ce63b80 sbd_new_task+0x60b(fffffea52401f000, 0)
fffffe422ce63c20 stmf_worker_task+0x2fd(fffffea43f5d8230)
fffffe422ce63c30 thread_start+8()
```

Note that both threads are reading the same offset (0x853d5dc0000) of different dnodes (both object #1 of different ZVOLs).

The typical code path is that the 2nd arc_read() of this BP will go through:
```
if (hdr != NULL && HDR_HAS_L1HDR(hdr) && hdr->b_l1hdr.b_pabd != NULL) {
...
        if (HDR_IO_IN_PROGRESS(hdr)) {
...
            if (done) {
... add new acb to existing hdr
                hdr->b_l1hdr.b_acb = acb;
and then when the i/o completes, arc_read_done() will do:
for (acb = callback_list; acb != NULL; acb = acb->acb_next) {
...
        int error = arc_buf_alloc_impl(hdr, acb->acb_private,
            acb->acb_compressed, no_zio_error, &acb->acb_buf);
...
    if (no_zio_error) {
...
    } else {
...
            arc_change_state(arc_anon, hdr, hash_lock);
...
    while ((acb = callback_list) != NULL) {
        if (acb->acb_done)
            acb->acb_done(zio, acb->acb_buf, acb->acb_private);
The acb_done() is dbuf_read_done() which calls arc_buf_destroy() if there was an i/o error.
There is also a similar code path in arc_read() that should also be able to hit this, but is a
narrower race. In arc_read_done(), we do

arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
...
    cv_broadcast(&hdr->b_l1hdr.b_cv);
if (hash_lock != NULL) {
        mutex_exit(hash_lock);
So a concurrent
arc_read() can see the hdr as not IO_IN_PROGRESS, but the hdr is still ANON. arc_read() can do:
if (hdr != NULL && HDR_HAS_L1HDR(hdr) && hdr->b_l1hdr.b_pabd != NULL) {
...
        if (HDR_IO_IN_PROGRESS(hdr)) { - FALSE
...
        if (done) {
...
            VERIFY0(arc_buf_alloc_impl(hdr, private,
                compressed_read, B_TRUE, &buf));
```
And then arc_read_done() calls acb_done() which is dbuf_read_done() which calls arc_buf_destroy() if there was an i/o error - but now there are 2 bufs and it would panic.

Possible ways to address this:

1. pass another flag to `arc_buf_alloc_impl` to indicate if there’s an error or not

2. have arc_read / arc_read_done allocate a whole new anon hdr if there was an error

3. change the interface to not pass a buf to the callback (to the DMU) when there’s an i/o error

Upstream bug: DLPX-56684 assertion failed in arc_buf_destroy() when concurrently reading block with checksum error