### PR TITLE
9456 ztest failure in zil_commit_waiter_timeout

### DIFF
--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -2290,7 +2290,7 @@ zil_commit_waiter_timeout(zilog_t *zilog, zil_commit_waiter_t *zcw)
 	 */
 	lwb_t *nlwb = zil_lwb_write_issue(zilog, lwb);
 
-	ASSERT3S(lwb->lwb_state, !=, LWB_STATE_OPENED);
+	IMPLY(nlwb != NULL, lwb->lwb_state != LWB_STATE_OPENED);
 
 	/*
 	 * Since the lwb's zio hadn't been issued by the time this thread


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim.dimitro@delphix.com>

Problem
Illumos bug 8373 was integrated, which now presents a code path where "dmu_tx_assign" can fail.
When "dmu_tx_assign" fails, it will not issue the lwb that was passed in to "zil_lwb_write_issue".
As a result, when "zil_lwb_write_issue" returns, the lwb will still be in the "opened" state, just as it
was when "zil_lwb_write_issue" was originally called.

Solution
As a result of this new call path, the failed assertion needs to be modified to be aware of this new
possibility. Thus, we can only assert that the lwb is no longer in the "opened" state if the returned
lwb is non-null, since we cannot differentiate between the case of "dmu_tx_assign" failing or
"zio_alloc_zil" failing within the call to "zil_lwb_write_issue".

Upstream bug: DLPX-54539