### PR TITLE
9457 libzfs_import.c:add_config() has a memory leak

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_import.c
+++ b/usr/src/lib/libzfs/common/libzfs_import.c
@@ -217,7 +217,6 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 		ne->ne_next = pl->names;
 		pl->names = ne;
 
-		nvlist_free(config);
 		return (0);
 	}
 
@@ -237,7 +236,6 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 	    &top_guid) != 0 ||
 	    nvlist_lookup_uint64(config, ZPOOL_CONFIG_POOL_TXG,
 	    &txg) != 0 || txg == 0) {
-		nvlist_free(config);
 		return (0);
 	}
 
@@ -252,7 +250,6 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 
 	if (pe == NULL) {
 		if ((pe = zfs_alloc(hdl, sizeof (pool_entry_t))) == NULL) {
-			nvlist_free(config);
 			return (-1);
 		}
 		pe->pe_guid = pool_guid;
@@ -271,7 +268,6 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 
 	if (ve == NULL) {
 		if ((ve = zfs_alloc(hdl, sizeof (vdev_entry_t))) == NULL) {
-			nvlist_free(config);
 			return (-1);
 		}
 		ve->ve_guid = top_guid;
@@ -291,15 +287,12 @@ add_config(libzfs_handle_t *hdl, pool_list_t *pl, const char *path,
 
 	if (ce == NULL) {
 		if ((ce = zfs_alloc(hdl, sizeof (config_entry_t))) == NULL) {
-			nvlist_free(config);
 			return (-1);
 		}
 		ce->ce_txg = txg;
-		ce->ce_config = config;
+		ce->ce_config = fnvlist_dup(config);
 		ce->ce_next = ve->ve_configs;
 		ve->ve_configs = ce;
-	} else {
-		nvlist_free(config);
 	}
 
 	/*
@@ -1234,9 +1227,7 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 					    &this_guid) == 0 &&
 					    iarg->guid == this_guid;
 				}
-				if (!matched) {
-					nvlist_free(config);
-				} else {
+				if (matched) {
 					/*
 					 * use the non-raw path for the config
 					 */
@@ -1246,6 +1237,7 @@ zpool_find_import_impl(libzfs_handle_t *hdl, importargs_t *iarg)
 					    config) != 0)
 						config_failed = B_TRUE;
 				}
+				nvlist_free(config);
 			}
 			free(slice->rn_name);
 			free(slice);


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim.dimitro@delphix.com>

A memory leak occurs on lines 209 and 213 because the config is not freed in the error case.
The interface to add_config() seems less than ideal - it would be better if it copied any data
necessary from the config and the caller freed it.

Upstream bug: DLPX-49583