### PR TITLE
9463 zloop warns that "sudo: command not found"

### DIFF
--- a/usr/src/cmd/ztest/zloop.bash
+++ b/usr/src/cmd/ztest/zloop.bash
@@ -147,7 +147,7 @@ or_die /bin/rm -f ztest.history
 or_die /bin/rm -f ztest.cores
 
 # Allow core files to be written to cwd if that's currently disabled.
-sudo coreadm -e process
+/bin/sudo /bin/coreadm -e process
 
 ztrc=0		# ztest return value
 foundcrashes=0	# number of crashes found so far


### PR DESCRIPTION
At the start of the zloop logs we find a warning that states "/bin/zloop: line 150: sudo: command not found".
/bin/zloop: line 150: sudo: command not found

Upstream bug: DLPX-52252