### PR TITLE
9465 ARC check for 'anon_size > arc_c/2' can stall the system

### DIFF
--- a/usr/src/uts/common/fs/zfs/dsl_dir.c
+++ b/usr/src/uts/common/fs/zfs/dsl_dir.c
@@ -1379,7 +1379,7 @@ dsl_dir_tempreserve_space(dsl_dir_t *dd, uint64_t lsize, uint64_t asize,
 	    offsetof(struct tempreserve, tr_node));
 	ASSERT3S(asize, >, 0);
 
-	err = arc_tempreserve_space(lsize, tx->tx_txg);
+	err = arc_tempreserve_space(dd->dd_pool->dp_spa, lsize, tx->tx_txg);
 	if (err == 0) {
 		struct tempreserve *tr;
 

--- a/usr/src/uts/common/fs/zfs/spa_misc.c
+++ b/usr/src/uts/common/fs/zfs/spa_misc.c
@@ -1910,6 +1910,12 @@ bp_get_dsize(spa_t *spa, const blkptr_t *bp)
 	return (dsize);
 }
 
+uint64_t
+spa_dirty_data(spa_t *spa)
+{
+	return (spa->spa_dsl_pool->dp_dirty_total);
+}
+
 /*
  * ==========================================================================
  * Initialization and Termination

--- a/usr/src/uts/common/fs/zfs/sys/arc.h
+++ b/usr/src/uts/common/fs/zfs/sys/arc.h
@@ -190,7 +190,7 @@ void arc_freed(spa_t *spa, const blkptr_t *bp);
 
 void arc_flush(spa_t *spa, boolean_t retry);
 void arc_tempreserve_clear(uint64_t reserve);
-int arc_tempreserve_space(uint64_t reserve, uint64_t txg);
+int arc_tempreserve_space(spa_t *spa, uint64_t reserve, uint64_t txg);
 
 uint64_t arc_max_bytes(void);
 void arc_init(void);

--- a/usr/src/uts/common/fs/zfs/sys/spa.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa.h
@@ -813,6 +813,7 @@ extern uint64_t spa_bootfs(spa_t *spa);
 extern uint64_t spa_delegation(spa_t *spa);
 extern objset_t *spa_meta_objset(spa_t *spa);
 extern uint64_t spa_deadman_synctime(spa_t *spa);
+extern uint64_t spa_dirty_data(spa_t *spa);
 
 /* Miscellaneous support routines */
 extern void spa_load_failed(spa_t *spa, const char *fmt, ...);

--- a/usr/src/uts/common/fs/zfs/sys/spa_impl.h
+++ b/usr/src/uts/common/fs/zfs/sys/spa_impl.h
@@ -373,6 +373,10 @@ struct spa {
 		int spa_queued;
 	} spa_queue_stats[ZIO_PRIORITY_NUM_QUEUEABLE];
 
+	/* arc_memory_throttle() parameters during low memory condition */
+	uint64_t	spa_lowmem_page_load;	/* memory load during txg */
+	uint64_t	spa_lowmem_last_txg;	/* txg window start */
+
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
 
 	/*


### PR DESCRIPTION
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

Seen in a test suite run of checkpoint_big_rewind which uses a nested pool.
Does not appear to reproduce easily.

Current theory is that the upper pool’s dirty/anon data is preventing the
lower pool from adding writes into its open context.
The upper pool cannot make progress (and clear its dirty data) until its
write I/O sent to lower pool completes.

nestedpool (upper)
waiting for I/O to a vdev in testpool
lots of dirty/anon data but syncing I stalled
spa_syncing_txg is 162
vdev io is getting throttled
Stack:

swtch+0x141()
cv_wait+0x70(ffffff03385afb78, ffffff03385afb70)
zio_wait+0xbb(ffffff03385af800)
dsl_pool_sync+0xf9(ffffff033df2cb00, a2)
spa_sync+0x456(ffffff0342c18000, a2)
txg_sync_thread+0x260(ffffff033df2cb00)
thread_start+8()
testpool (lower)
stalled in dmu_tx_assign
waiting for anon_size to shrink

spa_syncing_txg is 11,800,157 (in less than 30 minutes!)
  typically a run of this test completes in under 200 TXGs
  Stacks (per each file vdev used by upper):
swtch+0x141()
cv_wait+0x70(ffffff035368549e, ffffff0353685458)
txg_wait_open+0xcb(ffffff0353685280, b40e5f)
dmu_tx_wait+0x1d8(ffffff0328bc87c0)
dmu_tx_assign+0x8a(ffffff0328bc87c0, 1)
zfs_write+0x561(ffffff0527861980, ffffff000cdf1a80, 0, ffffff0310e98db0, 0)
fop_write+0x5b(ffffff0527861980, ffffff000cdf1a80, 0, ffffff0310e98db0, 0)
vn_rdwr+0x27a(1, ffffff0527861980, ffffff032dfdc000, 800, ec0000, 1)
vdev_file_io_strategy+0x65(ffffff033fd71380)
taskq_d_thread+0xb7(ffffff0322000568)
thread_start+8()

Upstream bug: DLPX-53592