### PR TITLE
9466 add JSON output support to channel programs

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -29,6 +29,7 @@
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright (c) 2018 Datto Inc.
  */
 
 #include <assert.h>
@@ -335,7 +336,7 @@ get_usage(zfs_help_t idx)
 	case HELP_BOOKMARK:
 		return (gettext("\tbookmark <snapshot> <bookmark>\n"));
 	case HELP_CHANNEL_PROGRAM:
-		return (gettext("\tprogram [-n] [-t <instruction limit>] "
+		return (gettext("\tprogram [-jn] [-t <instruction limit>] "
 		    "[-m <memory limit (b)>] <pool> <program file> "
 		    "[lua args...]\n"));
 	}
@@ -7099,12 +7100,12 @@ zfs_do_channel_program(int argc, char **argv)
 	nvlist_t *outnvl;
 	uint64_t instrlimit = ZCP_DEFAULT_INSTRLIMIT;
 	uint64_t memlimit = ZCP_DEFAULT_MEMLIMIT;
-	boolean_t sync_flag = B_TRUE;
+	boolean_t sync_flag = B_TRUE, json_output = B_FALSE;
 	zpool_handle_t *zhp;
 
 	/* check options */
 	while (-1 !=
-	    (c = getopt(argc, argv, "nt:(instr-limit)m:(memory-limit)"))) {
+	    (c = getopt(argc, argv, "jnt:(instr-limit)m:(memory-limit)"))) {
 		switch (c) {
 		case 't':
 		case 'm': {
@@ -7144,6 +7145,10 @@ zfs_do_channel_program(int argc, char **argv)
 		}
 		case 'n': {
 			sync_flag = B_FALSE;
+			break;
+		}
+		case 'j': {
+			json_output = B_TRUE;
 			break;
 		}
 		case '?':
@@ -7264,11 +7269,14 @@ zfs_do_channel_program(int argc, char **argv)
 		    gettext("Channel program execution failed:\n%s\n"),
 		    errstring);
 	} else {
-		(void) printf("Channel program fully executed ");
-		if (nvlist_empty(outnvl)) {
-			(void) printf("with no return value.\n");
+		if (json_output) {
+			(void) nvlist_print_json(stdout, outnvl);
+		} else if (nvlist_empty(outnvl)) {
+			(void) fprintf(stdout, gettext("Channel program fully "
+			    "executed and did not produce output.\n"));
 		} else {
-			(void) printf("with return value:\n");
+			(void) fprintf(stdout, gettext("Channel program fully "
+			    "executed and produced output:\n"));
 			dump_nvlist(outnvl, 4);
 		}
 	}

--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -9,6 +9,7 @@
 .\"
 .\"
 .\" Copyright (c) 2016, 2017 by Delphix. All rights reserved.
+.\" Copyright (c) 2018 Datto Inc.
 .\"
 .Dd January 21, 2016
 .Dt ZFS-PROGRAM 1M
@@ -18,7 +19,7 @@
 .Nd executes ZFS channel programs
 .Sh SYNOPSIS
 .Cm "zfs program"
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar instruction-limit
 .Op Fl m Ar memory-limit
 .Ar pool
@@ -46,6 +47,11 @@ will be run on
 and any attempts to access or modify other pools will cause an error.
 .Sh OPTIONS
 .Bl -tag -width "-t"
+.It Fl j
+Display channel program output in JSON format.
+When this flag is specified and standard output is empty -
+channel program encountered an error.
+The details of such an error will be printed to standard error in plain text.
 .It Fl n
 Executes a read-only channel program, which runs faster.
 The program cannot change on-disk state by calling functions from the

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -28,6 +28,7 @@
 .\" Copyright (c) 2014 Integros [integros.com]
 .\" Copyright 2018 Nexenta Systems, Inc.
 .\" Copyright 2018 Joyent, Inc.
+.\" Copyright (c) 2018 Datto Inc.
 .\"
 .Dd Feb 10, 2018
 .Dt ZFS 1M
@@ -271,7 +272,7 @@
 .Ar snapshot Ar snapshot Ns | Ns Ar filesystem
 .Nm
 .Cm program
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar timeout
 .Op Fl m Ar memory_limit
 .Ar pool script
@@ -3475,7 +3476,7 @@ Display the path's inode change time as the first column of output.
 .It Xo
 .Nm
 .Cm program
-.Op Fl n
+.Op Fl jn
 .Op Fl t Ar timeout
 .Op Fl m Ar memory_limit
 .Ar pool script
@@ -3496,6 +3497,11 @@ Channel programs may only be run with root privileges.
 For full documentation of the ZFS channel program interface, see the manual
 page for
 .Bl -tag -width ""
+.It Fl j
+Display channel program output in JSON format.
+When this flag is specified and standard output is empty -
+channel program encountered an error.
+The details of such an error will be printed to standard error in plain text.
 .It Fl n
 Executes a read-only channel program, which runs faster.
 The program cannot change on-disk state by calling functions from

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -14,6 +14,7 @@
 # Copyright 2015, 2016 Nexenta Systems, Inc.  All rights reserved.
 # Copyright 2016, OmniTI Computer Consulting, Inc. All rights reserved.
 # Copyright 2018 Joyent, Inc.
+# Copyright (c) 2018 Datto Inc.
 #
 
 set name=pkg.fmri value=pkg:/system/test/zfstest@$(PKGVERS)
@@ -53,6 +54,7 @@ dir path=opt/zfs-tests/tests/functional/cli_root/zfs_destroy
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_get
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_inherit
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_mount
+dir path=opt/zfs-tests/tests/functional/cli_root/zfs_program
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_promote
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_property
 dir path=opt/zfs-tests/tests/functional/cli_root/zfs_receive
@@ -878,6 +880,11 @@ file path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_fail \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/cli_root/zfs_mount/zfs_mount_all_mountpoints \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/cleanup \
+    mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/setup mode=0555
+file path=opt/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json \
     mode=0555
 file path=opt/zfs-tests/tests/functional/cli_root/zfs_promote/cleanup \
     mode=0555

--- a/usr/src/test/zfs-tests/runfiles/delphix.run
+++ b/usr/src/test/zfs-tests/runfiles/delphix.run
@@ -147,6 +147,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_012_neg',
     'zfs_mount_all_001_pos', 'zfs_mount_all_fail', 'zfs_mount_all_mountpoints']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/runfiles/omnios.run
+++ b/usr/src/test/zfs-tests/runfiles/omnios.run
@@ -140,6 +140,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_all_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/runfiles/openindiana.run
+++ b/usr/src/test/zfs-tests/runfiles/openindiana.run
@@ -140,6 +140,9 @@ tests = ['zfs_mount_001_pos', 'zfs_mount_002_pos', 'zfs_mount_003_pos',
     'zfs_mount_007_pos', 'zfs_mount_008_pos', 'zfs_mount_009_neg',
     'zfs_mount_010_neg', 'zfs_mount_011_neg', 'zfs_mount_all_001_pos']
 
+[/opt/zfs-tests/tests/functional/cli_root/zfs_program]
+tests = ['zfs_program_json']
+
 [/opt/zfs-tests/tests/functional/cli_root/zfs_promote]
 tests = ['zfs_promote_001_pos', 'zfs_promote_002_pos', 'zfs_promote_003_pos',
     'zfs_promote_004_pos', 'zfs_promote_005_pos', 'zfs_promote_006_neg',

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/Makefile
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/Makefile
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2018 Datto Inc.
+#
+
+include $(SRC)/Makefile.master
+
+ROOTOPTPKG = $(ROOT)/opt/zfs-tests
+TARGETDIR = $(ROOTOPTPKG)/tests/functional/cli_root/zfs_program
+
+include $(SRC)/test/zfs-tests/Makefile.com

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/cleanup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/cleanup.ksh
@@ -1,0 +1,30 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, usr/src/common/zfs this CDDL HEADER in each
+# file and usr/src/common/zfs the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+default_cleanup

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/setup.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/setup.ksh
@@ -1,0 +1,32 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or https://opensource.org/licenses/CDDL-1.0
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, usr/src/common/zfs this CDDL HEADER in each
+# file and usr/src/common/zfs the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+DISK=${DISKS%% *}
+
+default_setup $DISK

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs_program/zfs_program_json.ksh
@@ -1,0 +1,161 @@
+#!/bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy is of the CDDL is also available via the Internet
+# at http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 Datto Inc.
+#
+
+. $STF_SUITE/include/libtest.shlib
+
+#
+# DESCRIPTION:
+#
+# STRATEGY:
+#	1. Ensure empty JSON is printed when there is no channel program output
+#	2. Compare JSON output formatting for a channel program to template
+#	3. Using bad command line option (-Z) gives correct error output
+#
+
+verify_runnable "both"
+
+function cleanup
+{
+	log_must zfs destroy -r $TESTDS
+	return 0
+}
+log_onexit cleanup
+
+log_assert "Channel programs output valid JSON"
+
+TESTDS="$TESTPOOL/zcp-json"
+TESTSNAP="$TESTDS@snap0"
+log_must zfs create $TESTDS
+
+# 1. Ensure empty JSON is printed when there is no channel program output
+TESTZCP="/$TESTDS/zfs_destroy.zcp"
+cat > "$TESTZCP" << EOF
+       args = ...
+       argv = args["argv"]
+       zfs.sync.destroy(argv[1])
+EOF
+
+EMPTY_OUTPUT=("{}")
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+log_must zfs program $TESTPOOL $TESTZCP $TESTSNAP 2>&1
+log_mustnot zfs list $TESTSNAP 2>&1
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+log_must zfs program -j $TESTPOOL $TESTZCP $TESTSNAP 2>&1
+log_mustnot zfs list $TESTSNAP 2>&1
+log_must zfs snap $TESTSNAP 2>&1
+log_must zfs list $TESTSNAP 2>&1
+OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTSNAP 2>&1)
+if [ "$OUTPUT" != "$EMPTY_OUTPUT" ]; then
+       log_note "Got     :$OUTPUT"
+       log_note "Expected:$EMPTY_OUTPUT"
+       log_fail "Channel program output not empty";
+fi
+log_mustnot zfs list $TESTSNAP 2>&1
+
+# 2. Compare JSON output formatting for a channel program to template
+TESTZCP="/$TESTDS/zfs_rlist.zcp"
+cat > "$TESTZCP" << EOF
+	succeeded = {}
+	failed = {}
+
+	function list_recursive(root, prop)
+		for child in zfs.list.children(root) do
+			list_recursive(child, prop)
+		end
+		val, src  = zfs.get_prop(root, prop)
+		if (val == nil) then
+			failed[root] = val
+		else
+			succeeded[root] = val
+		end
+	end
+
+	args = ...
+
+	argv = args["argv"]
+
+	list_recursive(argv[1], argv[2])
+
+	results = {}
+	results["succeeded"] = succeeded
+	results["failed"] = failed
+	return results
+EOF
+
+typeset -a pos_cmds=("recordsize" "type")
+typeset -a pos_cmds_out=(
+"{
+    \"return\": {
+        \"failed\": {},
+        \"succeeded\": {
+            \"$TESTDS\": 131072
+        }
+    }
+}"
+"{
+    \"return\": {
+        \"failed\": {},
+        \"succeeded\": {
+            \"$TESTDS\": \"filesystem\"
+        }
+    }
+}")
+typeset -i cnt=0
+typeset cmd
+for cmd in ${pos_cmds[@]}; do
+	log_must zfs program $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
+	log_must zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1
+	# json.tool is needed to guarantee consistent ordering of fields
+	# sed is needed to trim trailing space in CentOS 6's json.tool output
+	OUTPUT=$(zfs program -j $TESTPOOL $TESTZCP $TESTDS $cmd 2>&1 | python -m json.tool | sed 's/[[:space:]]*$//')
+	if [ "$OUTPUT" != "${pos_cmds_out[$cnt]}" ]; then
+		log_note "Got     :$OUTPUT"
+		log_note "Expected:${pos_cmds_out[$cnt]}"
+		log_fail "Unexpected channel program output";
+	fi
+	cnt=$((cnt + 1))
+done
+
+# 3. Using bad command line option (-Z) gives correct error output
+typeset -a neg_cmds=("-Z")
+typeset -a neg_cmds_out=(
+"invalid option 'Z'
+usage:
+	program [-jn] [-t <instruction limit>] [-m <memory limit (b)>] <pool> <program file> [lua args...]
+
+For the property list, run: zfs set|get
+
+For the delegated permission list, run: zfs allow|unallow")
+cnt=0
+for cmd in ${neg_cmds[@]}; do
+	log_mustnot zfs program $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	log_mustnot zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1
+	OUTPUT=$(zfs program -j $cmd $TESTPOOL $TESTZCP $TESTDS 2>&1)
+	if [ "$OUTPUT" != "${neg_cmds_out[$cnt]}" ]; then
+		log_note "Got     :$OUTPUT"
+		log_note "Expected:${neg_cmds_out[$cnt]}"
+		log_fail "Unexpected channel program error output";
+	fi
+	cnt=$((cnt + 1))
+done
+
+log_pass "Channel programs output valid JSON"


### PR DESCRIPTION
This is an upstream attempt for a relatively simple ZoL patch that adds JSON output to channel programs (see https://github.com/zfsonlinux/zfs/pull/7281).

By piggybacking JSON output on top of channel programs we ensure that JSON output support is targeted to scripting use cases and is easily maintainable since it really only touches one function (`zfs_do_channel_program()`).
