### PR TITLE
Use "latest" symlink to archive build artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,14 +116,14 @@ node('master') {
                 stage('archive build artifacts') {
                     shscript('download-remote-file', false, [
                         ['INSTANCE_ID', env.BUILD_INSTANCE_ID],
-                        ['REMOTE_FILE', "${build_workspace}/log/*/nightly.log"],
+                        ['REMOTE_FILE', "${build_workspace}/log/latest/nightly.log"],
                         ['LOCAL_FILE', 'nightly.log']
                     ])
                     archive(includes: 'nightly.log')
 
                     shscript('download-remote-file', false, [
                         ['INSTANCE_ID', env.BUILD_INSTANCE_ID],
-                        ['REMOTE_FILE', "${build_workspace}/log/*/mail_msg"],
+                        ['REMOTE_FILE', "${build_workspace}/log/latest/mail_msg"],
                         ['LOCAL_FILE', 'nightly-mail.log']
                     ])
                     archive(includes: 'nightly-mail.log')


### PR DESCRIPTION
Since pulling in this illumos commit:

    commit  810d639eb61bde114845e4c7852b983d06536b8b
    Author: John Levon <john.levon@joyent.com>
    Date:   2018-03-10T22:07:10.000Z

        9231 nightly should create a log/latest/ symlink

the automation used to upload the nightly build artifacts has been
broken. This change attempts to reconcile the situation, by using this
new "latest" symlink when archiving the build logs.
