### PR TITLE
Limit testing to zloop and zfstest; remove others.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,19 +163,7 @@ node('master') {
         }
 
         stage('run tests') {
-            parallel('run libc-tests': {
-                run_test('run-libc-tests', 'm4.large', '0.100', 1, 'none', [
-                    ['RUNFILE', '/opt/libc-tests/runfiles/default.run']
-                ])
-            }, 'run os-tests': {
-                run_test('run-os-tests', 'm4.large', '0.100', 1, 'none', [
-                    ['RUNFILE', '/opt/os-tests/runfiles/default.run']
-                ])
-            }, 'run util-tests': {
-                run_test('run-util-tests', 'm4.large', '0.100', 1, 'none', [
-                    ['RUNFILE', '/opt/util-tests/runfiles/default.run']
-                ])
-            }, 'run zfs-tests': {
+            parallel('run zfs-tests': {
                 run_test('run-zfs-tests', 'm4.large', '0.100', 8, 'run-zfs-tests', [
                     ['RUNFILE', '/opt/zfs-tests/runfiles/delphix.run']
                 ])


### PR DESCRIPTION
This change stops running libc-tests, os-tests, and utils-tests. This is
done for a few different reasons:

 1. These test suites are not specific to the OpenZFS distribution.
 2. They sometimes cause flaky failures, due to test infrastructure issues.
 3. Their pass/fail status is ignored in context of OpenZFS PRs.

Thus, we might as well remove them to try and improve reliability of the
test automation, while also cutting EC2 costs by using fewer instances.