### PR TITLE
Update libzfs_sendrecv.c

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_sendrecv.c
+++ b/usr/src/lib/libzfs/common/libzfs_sendrecv.c
@@ -3593,7 +3593,7 @@ zfs_receive_one(libzfs_handle_t *hdl, int infd, const char *tosnap,
 		zfs_nicenum(bytes, buf1, sizeof (buf1));
 		zfs_nicenum(bytes/delta, buf2, sizeof (buf1));
 
-		(void) printf("received %sB stream in %lu seconds (%sB/sec)\n",
+		(void) printf("received %sB stream in %zd seconds (%sB/sec)\n",
 		    buf1, delta, buf2);
 	}
 


### PR DESCRIPTION
Use a printf() format string that is more compatible with time_t for 32bit and 64bit compilation.

Fixes clang warnings:
```
/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_sendrecv.c:3645:13: warning: format specifies type 'unsigned long' but the argument has type 'time_t' (aka 'int') [-Wformat]
buf1, delta, buf2);
```