### PR TITLE
Update libzfs_util.c

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_util.c
+++ b/usr/src/lib/libzfs/common/libzfs_util.c
@@ -787,9 +787,9 @@ zcmd_free_nvlists(zfs_cmd_t *zc)
 	free((void *)(uintptr_t)zc->zc_nvlist_conf);
 	free((void *)(uintptr_t)zc->zc_nvlist_src);
 	free((void *)(uintptr_t)zc->zc_nvlist_dst);
-	zc->zc_nvlist_conf = NULL;
-	zc->zc_nvlist_src = NULL;
-	zc->zc_nvlist_dst = NULL;
+	zc->zc_nvlist_conf = (uintptr_t)NULL;
+	zc->zc_nvlist_src = (uintptr_t)NULL;
+	zc->zc_nvlist_dst = (uintptr_t)NULL;
 }
 
 static int


### PR DESCRIPTION
Clang warnings are generated on these initializers on 32bit builds.  This update silences the warning and DTRT.

```
cc -DCOMPAT_32BIT -march=i686 -mmmx -msse -msse2 -m32  -L/var/tmp/home/sbruno/bsd/fbsd_head/amd64.amd64/obj-lib32/tmp/usr/lib32  --sysroot=/var/tmp/home/sbruno/bsd/fbsd_head/amd64.amd64/obj-lib32/tmp  -B/var/tmp/home/sbruno/bsd/fbsd_head/amd64.amd64/tmp/usr/bin -B/var/tmp/home/sbruno/bsd/fbsd_head/amd64.amd64/obj-lib32/tmp/usr/lib32 -pg  -O2 -pipe -DZFS_NO_ACL -I/home/sbruno/bsd/fbsd_head/sbin/mount -I/home/sbruno/bsd/fbsd_head/sys/cddl/compat/opensolaris -I/home/sbruno/bsd/fbsd_head/cddl/compat/opensolaris/include -I/home/sbruno/bsd/fbsd_head/cddl/compat/opensolaris/lib/libumem -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzpool/common -I/home/sbruno/bsd/fbsd_head/sys/cddl/contrib/opensolaris/common/zfs -I/home/sbruno/bsd/fbsd_head/sys/cddl/contrib/opensolaris/uts/common/fs/zfs -I/home/sbruno/bsd/fbsd_head/sys/cddl/contrib/opensolaris/uts/common/sys -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/head -I/home/sbruno/bsd/fbsd_head/sys/cddl/contrib/opensolaris/uts/common -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libnvpair -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libuutil/common -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs_core/common -I/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libcmdutils  -DNEED_SOLARIS_BOOLEAN -g -MD  -MF.depend.libzfs_util.po -MTlibzfs_util.po -std=iso9899:1999 -fstack-protector-strong -Wno-pointer-sign -Wno-unknown-pragmas -Wno-empty-body -Wno-string-plus-int -Wno-unused-const-variable -Wno-tautological-compare -Wno-unused-value -Wno-parentheses-equality -Wno-unused-function -Wno-enum-conversion -Wno-unused-local-typedef -Wno-address-of-packed-member -Wno-switch -Wno-switch-enum -Wno-knr-promoted-parameter -Wno-parentheses  -Qunused-arguments  -c /home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_util.c -o libzfs_util.po
/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_util.c:826:21: warning: incompatible pointer to integer conversion assigning to 'uint64_t' (aka 'unsigned long long') from 'void *' [-Wint-conversion]
        zc->zc_nvlist_conf = NULL;
                           ^ ~~~~
/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_util.c:827:20: warning: incompatible pointer to integer conversion assigning to 'uint64_t' (aka 'unsigned long long') from 'void *' [-Wint-conversion]
        zc->zc_nvlist_src = NULL;
                          ^ ~~~~
/home/sbruno/bsd/fbsd_head/cddl/contrib/opensolaris/lib/libzfs/common/libzfs_util.c:828:20: warning: incompatible pointer to integer conversion assigning to 'uint64_t' (aka 'unsigned long long') from 'void *' [-Wint-conversion]
        zc->zc_nvlist_dst = NULL;
                          ^ ~~~~
3 warnings generated.
```