### PR TITLE
Add SIGINFO feature to zfs send

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -3869,6 +3869,9 @@ zfs_do_send(int argc, char **argv)
 		return (1);
 	}
 
+	/* Always enable siginfo from 'zfs' command */
+	flags.siginfo = B_TRUE;
+
 	if (resume_token != NULL) {
 		return (zfs_send_resume(g_zfs, &flags, STDOUT_FILENO,
 		    resume_token));

--- a/usr/src/lib/libzfs/common/libzfs.h
+++ b/usr/src/lib/libzfs/common/libzfs.h
@@ -635,6 +635,9 @@ typedef struct sendflags {
 
 	/* compressed WRITE records are permitted */
 	boolean_t compress;
+
+	/* signal handling for SIGINFO are permitted */
+	boolean_t siginfo;
 } sendflags_t;
 
 typedef boolean_t (snapfilter_cb_t)(zfs_handle_t *, void *);


### PR DESCRIPTION
Change the send_progress_thread() to always be started, both for one-second
progress, and to idle for SIGINFO signal when not. Uses pthread_sigmask() to
control which thread receives the signal, or the "main" thread sitting
in ioctl(IOC_SEND) will abort. Signal handling is only enabled if
flag_siginfo is set (always done in zfs cmd) so that other users of
libzfs can avoid it.

Currently both shell and zfs send status is printed.

 load: 0.51  cmd: zfs 1523 waiting 0.04u 0.35s
 16:29:07   26.5M   BOOM@send
 load: 0.82  cmd: zfs 1523 waiting 0.04u 1.17s
 16:29:18    206M   BOOM@send
 load: 1.15  cmd: zfs 1523 waiting 0.04u 2.05s
 16:29:30    948M   BOOM@send

Signed-off-by: Jorgen Lundman <lundman@lundman.net>