### PR TITLE
9559 zfs diff handles files on delete queue in fromsnap poorly

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_diff.c
+++ b/usr/src/lib/libzfs/common/libzfs_diff.c
@@ -22,7 +22,7 @@
 /*
  * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2015 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2015, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2015, 2018 by Delphix. All rights reserved.
  * Copyright 2016 Joyent, Inc.
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  */
@@ -49,7 +49,7 @@
 #include "libzfs_impl.h"
 
 #define	ZDIFF_SNAPDIR		"/.zfs/snapshot/"
-#define	ZDIFF_SHARESDIR 	"/.zfs/shares/"
+#define	ZDIFF_SHARESDIR		"/.zfs/shares/"
 #define	ZDIFF_PREFIX		"zfs-diff-%d"
 
 #define	ZDIFF_ADDED	'+'
@@ -359,12 +359,12 @@ describe_free(FILE *fp, differ_info_t *di, uint64_t object, char *namebuf,
 
 	if (get_stats_for_obj(di, di->fromsnap, object, namebuf,
 	    maxlen, &sb) != 0) {
-		/* Let it slide, if in the delete queue on from side */
-		if (di->zerr == ENOENT && sb.zs_links == 0) {
-			di->zerr = 0;
-			return (0);
-		}
 		return (-1);
+	}
+	/* Don't print if in the delete queue on from side */
+	if (di->zerr == ESTALE) {
+		di->zerr = 0;
+		return (0);
 	}
 
 	print_file(fp, di, ZDIFF_REMOVED, namebuf, &sb);


### PR DESCRIPTION
The issue is that the error handling in zfs diff was not updated to reflect that files on the delete queue no longer trigger a non-zero return value.  As a result, delete-queue files in the from snapshot are no longer ignored by zfs diff, which results in misleading and incorrect behavior. The fix is to reinstate the error handling logic and tweak it to work appropriately with the new behavior.

Reviewed-by: Matthew Ahrens mahrens@delphix.com
Reviewed-by: George Wilson gwilson@delphix.com

External Issue: DLPX-58635