### PR TITLE
8862 ZFS Channel Programs - List Bookmarks & Holds

### DIFF
--- a/usr/src/man/man1m/zfs-program.1m
+++ b/usr/src/man/man1m/zfs-program.1m
@@ -453,8 +453,29 @@ dataset (string)
 .Bd -ragged -compact -offset "xxxx"
 Must be a valid filesystem or volume.
 .Ed
-.It Em zfs.list.properties(dataset)
+.It Em zfs.list.bookmarks(dataset)
+Iterate through all bookmarks of the given dataset.
+Each bookmark is returned as a string containing the full dataset name, e.g.
+"pool/fs#bookmark".
+.Pp
+dataset (string)
+.Bd -ragged -compact -offset "xxxx"
+Must be a valid filesystem or volume.
+.Ed
+.It Em zfs.list.holds(snapshot)
+Iterate through all user holds on the given snapshot.
+Each hold is returned as a pair of the hold's tag and the timestamp
+(in seconds since the epoch) at which it was created.
+.Pp
+snapshot (string)
+.Bd -ragged -compact -offset "xxxx"
+Must be a valid snapshot.
+.Ed
+.It Em zfs.list.user_properties(dataset)
 Iterate through all user properties for the given dataset.
+For each step of the iteration, output the property name, its value,
+and its source.
+Throws a Lua error if the dataset is invalid.
 .Pp
 dataset (string)
 .Bd -ragged -compact -offset "xxxx"

--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -546,10 +546,16 @@ file \
     path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.get_written \
     mode=0555
 file \
+    path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_bookmarks \
+    mode=0555
+file \
     path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_children \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_clones \
+    mode=0555
+file \
+    path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_holds \
     mode=0555
 file \
     path=opt/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_snapshots \

--- a/usr/src/test/zfs-tests/include/libtest.shlib
+++ b/usr/src/test/zfs-tests/include/libtest.shlib
@@ -616,6 +616,18 @@ function bkmarkexists
 }
 
 #
+# Return 0 if a hold exists; $? otherwise
+#
+# $1 - hold tag
+# $2 - snapshot name
+#
+function holdexists
+{
+	zfs holds "$2" | awk '{ print $2 }' | grep "$1" > /dev/null 2>&1
+	return $?
+}
+
+#
 # Set a property to a certain value on a dataset.
 # Sets a property of the dataset to the value as passed in.
 # @param:

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_bookmarks.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_bookmarks.ksh
@@ -1,0 +1,120 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION:
+#       Listing zfs bookmarks should work correctly.
+#
+
+verify_runnable "global"
+
+TESTBOOK=$TESTPOOL/$TESTFS#testbook
+TESTBOOK1=$TESTBOOK-1
+TESTBOOK2=$TESTBOOK-2
+TESTBOOK3=$TESTBOOK-3
+
+function cleanup
+{
+	bkmarkexists $TESTBOOK && log_must zfs destroy $TESTBOOK
+	bkmarkexists $TESTBOOK1 && log_must zfs destroy $TESTBOOK1
+	bkmarkexists $TESTBOOK2 && log_must zfs destroy $TESTBOOK2
+	bkmarkexists $TESTBOOK3 && log_must zfs destroy $TESTBOOK3
+	destroy_snapshot
+}
+
+log_onexit cleanup
+
+create_snapshot
+
+# 0 bookmarks handled correctly
+log_must_program $TESTPOOL - <<-EOF
+	n = 0
+	for s in zfs.list.bookmarks("$TESTPOOL/$TESTFS") do
+		n = n + 1
+	end
+	assert(n == 0)
+	return 0
+EOF
+
+# Create a bookmark
+log_must zfs bookmark $TESTPOOL/$TESTFS@$TESTSNAP $TESTBOOK
+
+log_must_program $TESTPOOL - <<-EOF
+	n = 0
+	for s in zfs.list.bookmarks("$TESTPOOL/$TESTFS") do
+		assert(s == "$TESTBOOK")
+		n = n + 1
+	end
+	assert(n == 1)
+	return 0
+EOF
+
+log_must zfs bookmark $TESTPOOL/$TESTFS@$TESTSNAP $TESTBOOK1
+log_must zfs bookmark $TESTPOOL/$TESTFS@$TESTSNAP $TESTBOOK2
+log_must zfs bookmark $TESTPOOL/$TESTFS@$TESTSNAP $TESTBOOK3
+
+# All bookmarks appear exactly once
+log_must_program $TESTPOOL - <<-EOF
+	a = {}
+	a["$TESTBOOK"] = false
+	a["$TESTBOOK1"] = false
+	a["$TESTBOOK2"] = false
+	a["$TESTBOOK3"] = false
+	n = 0
+	for s in zfs.list.bookmarks("$TESTPOOL/$TESTFS") do
+		assert(not a[s])
+		a[s] = true
+		n = n + 1
+	end
+	assert(n == 4)
+	assert(a["$TESTBOOK"] and
+	    a["$TESTBOOK1"] and
+	    a["$TESTBOOK2"] and
+	    a["$TESTBOOK3"])
+	return 0
+EOF
+
+# Nonexistent input
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.bookmarks("$TESTPOOL/nonexistent-fs")
+	return 0
+EOF
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.bookmarks("nonexistent-pool/$TESTFS")
+	return 0
+EOF
+
+# Can't look in a different pool than the one specified on command line
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.bookmarks("rpool")
+	return 0
+EOF
+
+# Can't have bookmarks on snapshots, only on filesystems
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.bookmarks("$TESTPOOL/$TESTFS@$TESTSNAP")
+	return 0
+EOF
+
+# Can't have bookmarks on bookmarks, only on filesystems
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.bookmarks("$TESTBOOK")
+	return 0
+EOF
+
+log_pass "Listing zfs bookmarks should work correctly."

--- a/usr/src/test/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_holds.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/channel_program/synctask_core/tst.list_holds.ksh
@@ -1,0 +1,121 @@
+#!/bin/ksh -p
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/tests/functional/channel_program/channel_common.kshlib
+
+#
+# DESCRIPTION:
+#       Listing zfs holds should work correctly.
+#
+
+verify_runnable "global"
+
+TESTHOLD=testhold-tag
+TESTHOLD1=$TESTHOLD-1
+TESTHOLD2=$TESTHOLD-2
+TESTHOLD3=$TESTHOLD-3
+SNAP=$TESTPOOL/$TESTFS@$TESTSNAP
+
+function cleanup
+{
+	holdexists $TESTHOLD $SNAP && log_must zfs release $TESTHOLD $SNAP
+	holdexists $TESTHOLD1 $SNAP && log_must zfs release $TESTHOLD1 $SNAP
+	holdexists $TESTHOLD2 $SNAP && log_must zfs release $TESTHOLD2 $SNAP
+	holdexists $TESTHOLD3 $SNAP && log_must zfs release $TESTHOLD3 $SNAP
+	destroy_snapshot
+}
+
+log_onexit cleanup
+
+create_snapshot
+
+# 0 holds handled correctly
+log_must_program $TESTPOOL - <<-EOF
+	n = 0
+	for s in zfs.list.holds("$SNAP") do
+		n = n + 1
+	end
+	assert(n == 0)
+	return 0
+EOF
+
+# Create a hold
+log_must zfs hold $TESTHOLD $SNAP
+
+log_must_program $TESTPOOL - <<-EOF
+	n = 0
+	for s in zfs.list.holds("$SNAP") do
+		assert(s == "$TESTHOLD")
+		n = n + 1
+	end
+	assert(n == 1)
+	return 0
+EOF
+
+log_must zfs hold $TESTHOLD1 $SNAP
+log_must zfs hold $TESTHOLD2 $SNAP
+log_must zfs hold $TESTHOLD3 $SNAP
+
+# All holds appear exactly once
+log_must_program $TESTPOOL - <<-EOF
+	a = {}
+	a["$TESTHOLD"] = false
+	a["$TESTHOLD1"] = false
+	a["$TESTHOLD2"] = false
+	a["$TESTHOLD3"] = false
+	n = 0
+	for s in zfs.list.holds("$SNAP") do
+		assert(not a[s])
+		a[s] = true
+		n = n + 1
+	end
+	assert(n == 4)
+	assert(a["$TESTHOLD"] and
+	    a["$TESTHOLD1"] and
+	    a["$TESTHOLD2"] and
+	    a["$TESTHOLD3"])
+	return 0
+EOF
+
+# Nonexistent input
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.holds("$TESTPOOL/nonexistent-fs@nonexistent-snap")
+	return 0
+EOF
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.holds("nonexistent-pool/$TESTFS")
+	return 0
+EOF
+
+# Can't look in a different pool than the one specified on command line
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.holds("rpool")
+	return 0
+EOF
+
+# Can't have holds on filesystems
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.holds("$TESTPOOL/$TESTFS")
+	return 0
+EOF
+
+# Can't have holds on bookmarks
+log_mustnot_program $TESTPOOL - <<-EOF
+	zfs.list.holds("$TESTPOOL/$TESTFS#bookmark")
+	return 0
+EOF
+
+log_pass "Listing zfs holds should work correctly."

--- a/usr/src/uts/common/fs/zfs/zcp_iter.c
+++ b/usr/src/uts/common/fs/zfs/zcp_iter.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  */
 
 #include "lua.h"
@@ -23,6 +23,7 @@
 #include <sys/dmu.h>
 #include <sys/dsl_prop.h>
 #include <sys/dsl_synctask.h>
+#include <sys/dsl_bookmark.h>
 #include <sys/dsl_dataset.h>
 #include <sys/dsl_pool.h>
 #include <sys/dmu_tx.h>
@@ -122,8 +123,6 @@ zcp_clones_list(lua_State *state)
 {
 	const char *snapname = lua_tostring(state, 1);
 	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
-	boolean_t issnap;
-	uint64_t dsobj, cursor;
 
 	/*
 	 * zcp_dataset_hold will either successfully return the requested
@@ -133,9 +132,9 @@ zcp_clones_list(lua_State *state)
 	dsl_dataset_t *ds = zcp_dataset_hold(state, dp, snapname, FTAG);
 	if (ds == NULL)
 		return (1); /* not reached; zcp_dataset_hold() longjmp'd */
-	cursor = 0;
-	issnap = ds->ds_is_snapshot;
-	dsobj = ds->ds_object;
+	boolean_t issnap = ds->ds_is_snapshot;
+	uint64_t cursor = 0;
+	uint64_t dsobj = ds->ds_object;
 	dsl_dataset_rele(ds, FTAG);
 
 	if (!issnap) {
@@ -335,7 +334,7 @@ zcp_children_list(lua_State *state)
 }
 
 static int
-zcp_props_list_gc(lua_State *state)
+zcp_user_props_list_gc(lua_State *state)
 {
 	nvlist_t **props = lua_touserdata(state, 1);
 	if (*props != NULL)
@@ -344,7 +343,7 @@ zcp_props_list_gc(lua_State *state)
 }
 
 static int
-zcp_props_iter(lua_State *state)
+zcp_user_props_iter(lua_State *state)
 {
 	char *source, *val;
 	nvlist_t *nvprop;
@@ -373,11 +372,11 @@ zcp_props_iter(lua_State *state)
 	return (3);
 }
 
-static int zcp_props_list(lua_State *);
-static zcp_list_info_t zcp_props_list_info = {
-	.name = "properties",
-	.func = zcp_props_list,
-	.gc = zcp_props_list_gc,
+static int zcp_user_props_list(lua_State *);
+static zcp_list_info_t zcp_user_props_list_info = {
+	.name = "user_properties",
+	.func = zcp_user_props_list,
+	.gc = zcp_user_props_list_gc,
 	.pargs = {
 	    { .za_name = "filesystem | snapshot | volume",
 	    .za_lua_type = LUA_TSTRING},
@@ -389,7 +388,7 @@ static zcp_list_info_t zcp_props_list_info = {
 };
 
 static int
-zcp_props_list(lua_State *state)
+zcp_user_props_list(lua_State *state)
 {
 	const char *dsname = lua_tostring(state, 1);
 	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
@@ -404,23 +403,24 @@ zcp_props_list(lua_State *state)
 	dsl_dataset_rele(ds, FTAG);
 
 	/*
-	 * Set the metatable for the properties list to free it on completion.
+	 * Set the metatable for the user properties list to free it on
+	 * completion.
 	 */
-	luaL_getmetatable(state, zcp_props_list_info.name);
+	luaL_getmetatable(state, zcp_user_props_list_info.name);
 	(void) lua_setmetatable(state, -2);
 
 	lua_pushlightuserdata(state, NULL);
-	lua_pushcclosure(state, &zcp_props_iter, 2);
+	lua_pushcclosure(state, &zcp_user_props_iter, 2);
 	return (1);
 }
 
 
 /*
- * Populate nv with all valid properties and their values for the given
+ * Populate nv with all valid system properties and their values for the given
  * dataset.
  */
 static void
-zcp_dataset_props(dsl_dataset_t *ds, nvlist_t *nv)
+zcp_dataset_system_props(dsl_dataset_t *ds, nvlist_t *nv)
 {
 	for (int prop = ZFS_PROP_TYPE; prop < ZFS_NUM_PROPS; prop++) {
 		/* Do not display hidden props */
@@ -447,8 +447,8 @@ static zcp_list_info_t zcp_system_props_list_info = {
 };
 
 /*
- * Get a list of all visble properties and their values for a given dataset.
- * Returned on the stack as a Lua table.
+ * Get a list of all visble system properties and their values for a given
+ * dataset. Returned on the stack as a Lua table.
  */
 static int
 zcp_system_props_list(lua_State *state)
@@ -466,8 +466,8 @@ zcp_system_props_list(lua_State *state)
 	if (ds == NULL)
 		return (1); /* not reached; zcp_dataset_hold() longjmp'd */
 
-	/* Get the names of all valid properties for this dataset */
-	zcp_dataset_props(ds, nv);
+	/* Get the names of all valid system properties for this dataset */
+	zcp_dataset_system_props(ds, nv);
 	dsl_dataset_rele(ds, FTAG);
 
 	/* push list as lua table */
@@ -477,6 +477,209 @@ zcp_system_props_list(lua_State *state)
 		return (luaL_error(state,
 		    "Error returning nvlist: %s", errbuf));
 	}
+	return (1);
+}
+
+static int
+zcp_bookmarks_iter(lua_State *state)
+{
+	char ds_name[ZFS_MAX_DATASET_NAME_LEN];
+	char bookmark_name[ZFS_MAX_DATASET_NAME_LEN];
+	uint64_t dsobj = lua_tonumber(state, lua_upvalueindex(1));
+	uint64_t cursor = lua_tonumber(state, lua_upvalueindex(2));
+	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
+	dsl_dataset_t *ds;
+	zap_attribute_t za;
+	zap_cursor_t zc;
+
+	int err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err == ENOENT) {
+		return (0);
+	} else if (err != 0) {
+		return (luaL_error(state,
+		    "unexpected error %d from dsl_dataset_hold_obj(dsobj)",
+		    err));
+	}
+
+	if (!dsl_dataset_is_zapified(ds)) {
+		dsl_dataset_rele(ds, FTAG);
+		return (0);
+	}
+
+	err = zap_lookup(dp->dp_meta_objset, ds->ds_object,
+	    DS_FIELD_BOOKMARK_NAMES, sizeof (ds->ds_bookmarks_obj), 1,
+	    &ds->ds_bookmarks_obj);
+	if (err != 0 && err != ENOENT) {
+		dsl_dataset_rele(ds, FTAG);
+		return (luaL_error(state,
+		    "unexpected error %d from zap_lookup()", err));
+	}
+	if (ds->ds_bookmarks_obj == 0) {
+		dsl_dataset_rele(ds, FTAG);
+		return (0);
+	}
+
+	/* Store the dataset's name so we can append the bookmark's name */
+	dsl_dataset_name(ds, ds_name);
+
+	zap_cursor_init_serialized(&zc, ds->ds_dir->dd_pool->dp_meta_objset,
+	    ds->ds_bookmarks_obj, cursor);
+	dsl_dataset_rele(ds, FTAG);
+
+	err = zap_cursor_retrieve(&zc, &za);
+	if (err != 0) {
+		zap_cursor_fini(&zc);
+		if (err != ENOENT) {
+			return (luaL_error(state,
+			    "unexpected error %d from zap_cursor_retrieve()",
+			    err));
+		}
+		return (0);
+	}
+	zap_cursor_advance(&zc);
+	cursor = zap_cursor_serialize(&zc);
+	zap_cursor_fini(&zc);
+
+	/* Create the full "pool/fs#bookmark" string to return */
+	(void) snprintf(bookmark_name, ZFS_MAX_DATASET_NAME_LEN, "%s#%s",
+	    ds_name, za.za_name);
+
+	lua_pushnumber(state, cursor);
+	lua_replace(state, lua_upvalueindex(2));
+
+	(void) lua_pushstring(state, bookmark_name);
+	return (1);
+}
+
+static int zcp_bookmarks_list(lua_State *);
+static zcp_list_info_t zcp_bookmarks_list_info = {
+	.name = "bookmarks",
+	.func = zcp_bookmarks_list,
+	.pargs = {
+	    { .za_name = "dataset", .za_lua_type = LUA_TSTRING},
+	    {NULL, NULL}
+	},
+	.kwargs = {
+	    {NULL, NULL}
+	}
+};
+
+static int
+zcp_bookmarks_list(lua_State *state)
+{
+	const char *dsname = lua_tostring(state, 1);
+	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
+
+	dsl_dataset_t *ds = zcp_dataset_hold(state, dp, dsname, FTAG);
+	if (ds == NULL)
+		return (1); /* not reached; zcp_dataset_hold() longjmp'd */
+
+	boolean_t issnap = ds->ds_is_snapshot;
+	uint64_t dsobj = ds->ds_object;
+	uint64_t cursor = 0;
+	dsl_dataset_rele(ds, FTAG);
+
+	if (issnap) {
+		return (zcp_argerror(state, 1, "%s is a snapshot", dsname));
+	}
+
+	lua_pushnumber(state, dsobj);
+	lua_pushnumber(state, cursor);
+	lua_pushcclosure(state, &zcp_bookmarks_iter, 2);
+	return (1);
+}
+
+static int
+zcp_holds_iter(lua_State *state)
+{
+	uint64_t dsobj = lua_tonumber(state, lua_upvalueindex(1));
+	uint64_t cursor = lua_tonumber(state, lua_upvalueindex(2));
+	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
+	dsl_dataset_t *ds;
+	zap_attribute_t za;
+	zap_cursor_t zc;
+
+	int err = dsl_dataset_hold_obj(dp, dsobj, FTAG, &ds);
+	if (err == ENOENT) {
+		return (0);
+	} else if (err != 0) {
+		return (luaL_error(state,
+		    "unexpected error %d from dsl_dataset_hold_obj(dsobj)",
+		    err));
+	}
+
+	if (dsl_dataset_phys(ds)->ds_userrefs_obj == 0) {
+		dsl_dataset_rele(ds, FTAG);
+		return (0);
+	}
+
+	zap_cursor_init_serialized(&zc, ds->ds_dir->dd_pool->dp_meta_objset,
+	    dsl_dataset_phys(ds)->ds_userrefs_obj, cursor);
+	dsl_dataset_rele(ds, FTAG);
+
+	err = zap_cursor_retrieve(&zc, &za);
+	if (err != 0) {
+		zap_cursor_fini(&zc);
+		if (err != ENOENT) {
+			return (luaL_error(state,
+			    "unexpected error %d from zap_cursor_retrieve()",
+			    err));
+		}
+		return (0);
+	}
+	zap_cursor_advance(&zc);
+	cursor = zap_cursor_serialize(&zc);
+	zap_cursor_fini(&zc);
+
+	lua_pushnumber(state, cursor);
+	lua_replace(state, lua_upvalueindex(2));
+
+	(void) lua_pushstring(state, za.za_name);
+	(void) lua_pushnumber(state, za.za_first_integer);
+	return (2);
+}
+
+static int zcp_holds_list(lua_State *);
+static zcp_list_info_t zcp_holds_list_info = {
+	.name = "holds",
+	.func = zcp_holds_list,
+	.gc = NULL,
+	.pargs = {
+	    { .za_name = "snapshot", .za_lua_type = LUA_TSTRING},
+	    {NULL, NULL}
+	},
+	.kwargs = {
+	    {NULL, NULL}
+	}
+};
+
+/*
+ * Iterate over all the holds for a given dataset. Each iteration returns
+ * a hold's tag and its timestamp as an integer.
+ */
+static int
+zcp_holds_list(lua_State *state)
+{
+	const char *snapname = lua_tostring(state, 1);
+	dsl_pool_t *dp = zcp_run_info(state)->zri_pool;
+
+	dsl_dataset_t *ds = zcp_dataset_hold(state, dp, snapname, FTAG);
+	if (ds == NULL)
+		return (1); /* not reached; zcp_dataset_hold() longjmp'd */
+
+	boolean_t issnap = ds->ds_is_snapshot;
+	uint64_t dsobj = ds->ds_object;
+	uint64_t cursor = 0;
+	dsl_dataset_rele(ds, FTAG);
+
+	if (!issnap) {
+		return (zcp_argerror(state, 1, "%s is not a snapshot",
+		    snapname));
+	}
+
+	lua_pushnumber(state, dsobj);
+	lua_pushnumber(state, cursor);
+	lua_pushcclosure(state, &zcp_holds_iter, 2);
 	return (1);
 }
 
@@ -497,9 +700,11 @@ zcp_load_list_lib(lua_State *state)
 	zcp_list_info_t *zcp_list_funcs[] = {
 		&zcp_children_list_info,
 		&zcp_snapshots_list_info,
-		&zcp_props_list_info,
+		&zcp_user_props_list_info,
 		&zcp_clones_list_info,
 		&zcp_system_props_list_info,
+		&zcp_bookmarks_list_info,
+		&zcp_holds_list_info,
 		NULL
 	};
 


### PR DESCRIPTION
This adds two new features to channel programs --
listing bookmarks on a filesystem and listing holds on a snapshot.

The man page of channel programs has also been updated to explain
why zfs.list.properties() returns 3 items (the property name, its value,
and its source) for each iteration, rather than just the property name
as the current version of the docs might make you expect.

One final code cleanup/sidefix is the renaming zfs.list.properties to
zfs.list.user_properties to make the operation more like its sibling
zfs.list.system_properties.

Reviewed by: Matt Ahrens <mahrens@delphix.com>
Reviewed by: Serapheim Dimitropoulos <serapheim@delphix.com>

Upstream Bugs: DLPX-50618, DLPX-50362, DLPX-52112, DLPX-52115