### PR TITLE
Reserve DMU_BACKUP_FEATURE for ZSTD

### DIFF
--- a/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
+++ b/usr/src/uts/common/fs/zfs/sys/zfs_ioctl.h
@@ -94,6 +94,8 @@ typedef enum drr_headertype {
 /* flag #21 is reserved for a Delphix feature */
 #define	DMU_BACKUP_FEATURE_COMPRESSED		(1 << 22)
 /* flag #23 is reserved for the large dnode feature */
+/* flag #24 is reserved for the raw send feature */
+/* flag #25 is reserved for the ZSTD compression feature */
 
 /*
  * Mask of all supported backup features


### PR DESCRIPTION
Reserve #25 for the ZSTD compression feature from FreeBSD.
Also note that #24 is reserved for 'raw send', part of the zfs encryption patch from ZoL.