### PR TITLE
Make createtxg and guid properties public

### DIFF
--- a/usr/src/common/zfs/zfs_prop.c
+++ b/usr/src/common/zfs/zfs_prop.c
@@ -391,6 +391,10 @@ zfs_prop_init(void)
 	zprop_register_number(ZFS_PROP_SNAPSHOT_COUNT, "snapshot_count",
 	    UINT64_MAX, PROP_READONLY, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
 	    "<count>", "SSCOUNT");
+	zprop_register_number(ZFS_PROP_GUID, "guid", 0, PROP_READONLY,
+	    ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "<uint64>", "GUID");
+	zprop_register_number(ZFS_PROP_CREATETXG, "createtxg", 0, PROP_READONLY,
+	    ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "<uint64>", "CREATETXG");
 
 	/* default number properties */
 	zprop_register_number(ZFS_PROP_QUOTA, "quota", 0, PROP_DEFAULT,
@@ -418,8 +422,6 @@ zfs_prop_init(void)
 	    ZFS_TYPE_FILESYSTEM, "512 to 1M, power of 2", "RECSIZE");
 
 	/* hidden properties */
-	zprop_register_hidden(ZFS_PROP_CREATETXG, "createtxg", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "CREATETXG");
 	zprop_register_hidden(ZFS_PROP_REMAPTXG, "remaptxg", PROP_TYPE_NUMBER,
 	    PROP_READONLY, ZFS_TYPE_DATASET, "REMAPTXG");
 	zprop_register_hidden(ZFS_PROP_NUMCLONES, "numclones", PROP_TYPE_NUMBER,
@@ -431,8 +433,6 @@ zfs_prop_init(void)
 	zprop_register_hidden(ZFS_PROP_STMF_SHAREINFO, "stmf_sbd_lu",
 	    PROP_TYPE_STRING, PROP_INHERIT, ZFS_TYPE_VOLUME,
 	    "STMF_SBD_LU");
-	zprop_register_hidden(ZFS_PROP_GUID, "guid", PROP_TYPE_NUMBER,
-	    PROP_READONLY, ZFS_TYPE_DATASET | ZFS_TYPE_BOOKMARK, "GUID");
 	zprop_register_hidden(ZFS_PROP_USERACCOUNTING, "useraccounting",
 	    PROP_TYPE_NUMBER, PROP_READONLY, ZFS_TYPE_DATASET,
 	    "USERACCOUNTING");

--- a/usr/src/lib/libzfs/common/libzfs_dataset.c
+++ b/usr/src/lib/libzfs/common/libzfs_dataset.c
@@ -2753,6 +2753,7 @@ zfs_prop_get(zfs_handle_t *zhp, zfs_prop_t prop, char *propbuf, size_t proplen,
 		break;
 
 	case ZFS_PROP_GUID:
+	case ZFS_PROP_CREATETXG:
 		/*
 		 * GUIDs are stored as numbers, but they are identifiers.
 		 * We don't want them to be pretty printed, because pretty

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -550,6 +550,12 @@ Compression can be turned on by running:
 .Nm zfs Cm set Sy compression Ns = Ns Sy on Ar dataset .
 The default value is
 .Sy off .
+.It Sy createtxg
+The transaction group (txg) in which the dataset was created. Bookmarks have
+the same
+.Sy createtxg
+as the snapshot they are initially tied to. This property is suitable for
+ordering a list of snapshots, e.g. for incremental send and receive.
 .It Sy creation
 The time this dataset was created.
 .It Sy clones
@@ -581,6 +587,12 @@ the dataset tree.
 This value is only available when a
 .Sy filesystem_limit
 has been set somewhere in the tree under which the dataset resides.
+.It Sy guid
+The 64 bit GUID of this dataset or bookmark which does not change over its
+entire lifetime. When a snapshot is sent to another pool, the received
+snapshot has the same GUID. Thus, the
+.Sy guid
+is suitable to identify a snapshot across pools.
 .It Sy logicalreferenced
 The amount of space that is
 .Qq logically

--- a/usr/src/man/man1m/zfs.1m
+++ b/usr/src/man/man1m/zfs.1m
@@ -551,11 +551,12 @@ Compression can be turned on by running:
 The default value is
 .Sy off .
 .It Sy createtxg
-The transaction group (txg) in which the dataset was created. Bookmarks have
-the same
+The transaction group (txg) in which the dataset was created.
+Bookmarks have the same
 .Sy createtxg
-as the snapshot they are initially tied to. This property is suitable for
-ordering a list of snapshots, e.g. for incremental send and receive.
+as the snapshot they are initially tied to.
+This property is suitable for ordering a list of snapshots,
+e.g. for incremental send and receive.
 .It Sy creation
 The time this dataset was created.
 .It Sy clones
@@ -589,8 +590,10 @@ This value is only available when a
 has been set somewhere in the tree under which the dataset resides.
 .It Sy guid
 The 64 bit GUID of this dataset or bookmark which does not change over its
-entire lifetime. When a snapshot is sent to another pool, the received
-snapshot has the same GUID. Thus, the
+entire lifetime.
+When a snapshot is sent to another pool, the received snapshot has the same
+GUID.
+Thus, the
 .Sy guid
 is suitable to identify a snapshot across pools.
 .It Sy logicalreferenced

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -115,7 +115,7 @@ typedef enum {
 	ZFS_PROP_SNAPDIR,
 	ZFS_PROP_ACLMODE,
 	ZFS_PROP_ACLINHERIT,
-	ZFS_PROP_CREATETXG,		/* not exposed to the user */
+	ZFS_PROP_CREATETXG,
 	ZFS_PROP_NAME,			/* not exposed to the user */
 	ZFS_PROP_CANMOUNT,
 	ZFS_PROP_ISCSIOPTIONS,		/* not exposed to the user */


### PR DESCRIPTION
This change is taken from ZoL

    commit 305bc4b370b20de81eaf10a1cf724374258b74d1
    Author: Christian Schwarz <me@cschwarz.com>
    Date:   Wed May 10 00:36:53 2017 +0200

    Document the existence of `createtxg` and `guid` native properties
    in man pages and zfs command output.

    One of the great features of ZFS is incremental replication of
    snapshots, possibly between pools on different machines.

    Shell scripts are commonly used to auomate this procedure. They have to
    find the most recent common snapshot between both sides and then
    perform incremental send & recv.
    Currently, scripts rely on the sorting order of `zfs list`, which
    defaults to `createtxg`, and the assumption that snapshot names on
    either side do not change.

    By making `createtxg` and `guid` part of the public ZFS interface,
    scripts are enabled to use

      a) `createtxg` to determine the logical & temporal order of snapshots
         (the creation property is not an equivalent substitute since
          multiple snapshots may be created within one second)
      b) `guid` to uniquely identify a snapshot, independent of its current
          display name

    This has the potential of making scripts safer and correct.

    Reviewed-by: George Melikov <mail@gmelikov.ru>
    Reviewed-by: Brian Behlendorf <behlendorf1@llnl.gov>
    Reviewed-by: DHE <git@dehacked.net>
    Reviewed-by: Richard Laager <rlaager@wiktel.com>
    Signed-off-by: Christian Schwarz <me@cschwarz.com>
    Closes #6102

https://www.illumos.org/issues/9621