### PR TITLE
9184 Add ZFS performance test for fixed blocksize random read/write IO

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -2719,12 +2719,14 @@ file path=opt/zfs-tests/tests/longevity/slop_space_test mode=0555
 file path=opt/zfs-tests/tests/perf/fio/mkfiles.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/random_reads.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/random_readwrite.fio mode=0444
+file path=opt/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/random_writes.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/sequential_reads.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/sequential_writes.fio mode=0444
 file path=opt/zfs-tests/tests/perf/perf.shlib mode=0444
 file path=opt/zfs-tests/tests/perf/regression/random_reads mode=0555
 file path=opt/zfs-tests/tests/perf/regression/random_readwrite mode=0555
+file path=opt/zfs-tests/tests/perf/regression/random_readwrite_fixed mode=0555
 file path=opt/zfs-tests/tests/perf/regression/random_writes mode=0555
 file path=opt/zfs-tests/tests/perf/regression/random_writes_zil mode=0555
 file path=opt/zfs-tests/tests/perf/regression/sequential_reads mode=0555

--- a/usr/src/test/zfs-tests/runfiles/perf-regression.run
+++ b/usr/src/test/zfs-tests/runfiles/perf-regression.run
@@ -26,5 +26,6 @@ outputdir = /var/tmp/test_results
 [/opt/zfs-tests/tests/perf/regression]
 tests = ['sequential_writes', 'sequential_reads', 'sequential_reads_arc_cached',
     'sequential_reads_arc_cached_clone', 'sequential_reads_dbuf_cached',
-    'random_reads', 'random_writes', 'random_readwrite', 'random_writes_zil']
+    'random_reads', 'random_writes', 'random_readwrite', 'random_writes_zil',
+    'random_readwrite_fixed']
 post =

--- a/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio
@@ -1,0 +1,35 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2017 by Delphix. All rights reserved.
+#
+
+[global]
+filename_format=file$jobnum
+nrfiles=16
+group_reporting=1
+fallocate=0
+overwrite=0
+thread=1
+rw=randrw
+rwmixread=70
+time_based=1
+directory=${DIRECTORY}
+runtime=${RUNTIME}
+bs=${BLOCKSIZE}
+ioengine=psync
+sync=${SYNC_TYPE}
+numjobs=${NUMJOBS}
+buffer_compress_percentage=66
+buffer_compress_chunk=4096
+
+[job]

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_reads.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_reads.ksh
@@ -58,7 +58,7 @@ if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 128k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -81,9 +81,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"
 )

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_readwrite_fixed.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_readwrite_fixed.ksh
@@ -1,7 +1,5 @@
 #!/usr/bin/ksh
-
-#
-# This file and its contents are supplied under the terms of the
+# file and its contents are supplied under the terms of the
 # Common Development and Distribution License ("CDDL"), version 1.0.
 # You may only use this file in accordance with the terms of version
 # 1.0 of the CDDL.
@@ -12,21 +10,18 @@
 #
 
 #
-# Copyright (c) 2016 by Delphix. All rights reserved.
+# Copyright (c) 2017 by Delphix. All rights reserved.
 #
 
 #
 # Description:
-# Trigger fio runs using the sequential_reads job file. The number of runs and
+# Trigger fio runs using the random_readwrite_fixed job file. The number of runs and
 # data collected is determined by the PERF_* variables. See do_fio_run for
 # details about these variables.
 #
-# The files to read from are created prior to the first fio run, and used
-# for all fio runs. The ARC is not cleared to ensure that all data is cached.
-#
-# This is basically a copy of the sequential_reads_cached test case, but with
-# a smaller dateset so that we can fit everything into the decompressed, linear
-# space in the dbuf cache.
+# The files to read and write from are created prior to the first fio run,
+# and used for all fio runs. The ARC is cleared with `zinject -a` prior to
+# each run so reads will go to disk.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -34,7 +29,7 @@
 
 function cleanup
 {
-	recreate_perf_pool
+        recreate_perf_pool
 }
 
 log_onexit cleanup
@@ -42,8 +37,8 @@ log_onexit cleanup
 recreate_perf_pool
 populate_perf_filesystems
 
-# Ensure the working set can be cached in the dbuf cache.
-export TOTAL_SIZE=$(($(get_max_dbuf_cache_size) * 3 / 4))
+# Aim to fill the pool to 50% capacity while accounting for a 3x compressratio.
+export TOTAL_SIZE=$(($(get_prop avail $PERFPOOL) * 3 / 2))
 
 # Variables for use by fio.
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
@@ -51,20 +46,20 @@ if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
 	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
-	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 128k'}
+	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
+	export PERF_IOSIZES='8k 64k'
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'64 128'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'64k'}
+	export PERF_IOSIZES='8k'
 fi
 
-# Layout the files to be used by the read tests. Create as many files as the
-# largest number of threads. An fio run with fewer threads will use a subset
-# of the available files.
+# Layout the files to be used by the readwrite tests. Create as many files
+# as the largest number of threads. An fio run with fewer threads will use
+# a subset of the available files.
 export NUMJOBS=$(get_max $PERF_NTHREADS)
 export FILE_SIZE=$((TOTAL_SIZE / NUMJOBS))
 export DIRECTORY=$(get_directory)
@@ -75,14 +70,13 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
-    "dtrace -Cs $PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1"  "prefetch"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"
 )
 
-log_note "Sequential cached reads with $PERF_RUNTYPE settings"
-do_fio_run sequential_reads.fio false false
-log_pass "Measure IO stats during sequential cached read load"
+log_note "Random reads and writes with $PERF_RUNTYPE settings"
+do_fio_run random_readwrite_fixed.fio false true
+log_pass "Measure IO stats during random read and write load"

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_writes.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_writes.ksh
@@ -57,7 +57,7 @@ if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_NTHREADS=${PERF_NTHREADS:-'1 4 8 16 32 64 128'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 256k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -72,9 +72,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"
 )

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads.ksh
@@ -58,7 +58,7 @@ if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'64k 128k 1m'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 128k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -81,9 +81,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace -Cs $PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1"  "prefetch"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads_arc_cached.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads_arc_cached.ksh
@@ -45,10 +45,10 @@ export TOTAL_SIZE=$(($(get_max_arc_size) / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'64k 128k 1m'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 128k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -71,9 +71,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace -Cs $PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1"  "prefetch"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads_arc_cached_clone.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_reads_arc_cached_clone.ksh
@@ -51,10 +51,10 @@ export TOTAL_SIZE=$(($(get_max_arc_size) / 2))
 if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_WEEKLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'weekly'}
-	export PERF_NTHREADS=${PERF_NTHREADS:-'16 64'}
+	export PERF_NTHREADS=${PERF_NTHREADS:-'8 16 32 64'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'64k 128k 1m'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 128k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -97,9 +97,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace -Cs $PERF_SCRIPTS/prefetch_io.d $PERFPOOL 1"  "prefetch"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"

--- a/usr/src/test/zfs-tests/tests/perf/regression/sequential_writes.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/sequential_writes.ksh
@@ -57,7 +57,7 @@ if [[ -n $PERF_REGRESSION_WEEKLY ]]; then
 	export PERF_NTHREADS=${PERF_NTHREADS:-'1 4 8 16 32 64 128'}
 	export PERF_NTHREADS_PER_FS=${PERF_NTHREADS_PER_FS:-'0'}
 	export PERF_SYNC_TYPES=${PERF_SYNC_TYPES:-'0 1'}
-	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 128k 1m'}
+	export PERF_IOSIZES=${PERF_IOSIZES:-'8k 64k 256k'}
 elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_RUNTIME=${PERF_RUNTIME:-$PERF_RUNTIME_NIGHTLY}
 	export PERF_RUNTYPE=${PERF_RUNTYPE:-'nightly'}
@@ -72,9 +72,9 @@ lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(
     "kstat zfs:0 1"  "kstat"
-    "vmstat 1"       "vmstat"
-    "mpstat 1"       "mpstat"
-    "iostat -xcnz 1" "iostat"
+    "vmstat -T d 1"       "vmstat"
+    "mpstat -T d 1"       "mpstat"
+    "iostat -T d -xcnz 1" "iostat"
     "dtrace -Cs $PERF_SCRIPTS/io.d $PERFPOOL $lun_list 1" "io"
     "dtrace  -s $PERF_SCRIPTS/profile.d"                  "profile"
 )


### PR DESCRIPTION
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

Work by Ahmed Gahnem

This change introduces a new performance test which does random reads
and writes, but instead of using `bssplit` to determine the block size,
it uses a fixed blocksize. Additionally, some new IO sizes are added to
other tests and timestamp data is recorded with the performance data.