### PR TITLE
9647 Introduce ZFS Read/Write kstats

### DIFF
--- a/usr/src/common/zfs/zpool_prop.c
+++ b/usr/src/common/zfs/zpool_prop.c
@@ -21,7 +21,7 @@
 /*
  * Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2011 Nexenta Systems, Inc. All rights reserved.
- * Copyright (c) 2012, 2017 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  */
 
@@ -96,6 +96,8 @@ zpool_prop_init(void)
 	    ZFS_TYPE_POOL, "<size>", "CAP");
 	zprop_register_number(ZPOOL_PROP_GUID, "guid", 0, PROP_READONLY,
 	    ZFS_TYPE_POOL, "<guid>", "GUID");
+	zprop_register_number(ZPOOL_PROP_LOAD_GUID, "load_guid", 0,
+	    PROP_READONLY, ZFS_TYPE_POOL, "<load_guid>", "LOAD_GUID");
 	zprop_register_number(ZPOOL_PROP_HEALTH, "health", 0, PROP_READONLY,
 	    ZFS_TYPE_POOL, "<state>", "HEALTH");
 	zprop_register_number(ZPOOL_PROP_DEDUPRATIO, "dedupratio", 0,

--- a/usr/src/man/man1m/zpool.1m
+++ b/usr/src/man/man1m/zpool.1m
@@ -554,6 +554,15 @@ Health can be one of
 .Sy ONLINE , DEGRADED , FAULTED , OFFLINE, REMOVED , UNAVAIL .
 .It Sy guid
 A unique identifier for the pool.
+.It Sy load_guid
+A unique identifier for the pool.
+Unlike the
+.Sy guid
+property, this identifier is generated every time we load the pool (e.g. does
+not persist across imports/exports) and never changes while the pool is loaded
+(even if a
+.Sy reguid
+operation takes place).
 .It Sy size
 Total size of the storage pool.
 .It Sy unsupported@ Ns Em feature_guid

--- a/usr/src/uts/common/fs/zfs/spa.c
+++ b/usr/src/uts/common/fs/zfs/spa.c
@@ -305,6 +305,8 @@ spa_prop_get_config(spa_t *spa, nvlist_t **nvp)
 		else
 			src = ZPROP_SRC_LOCAL;
 		spa_prop_add_list(*nvp, ZPOOL_PROP_VERSION, NULL, version, src);
+		spa_prop_add_list(*nvp, ZPOOL_PROP_LOAD_GUID,
+		    NULL, spa_load_guid(spa), src);
 	}
 
 	if (pool != NULL) {

--- a/usr/src/uts/common/fs/zfs/sys/zvol.h
+++ b/usr/src/uts/common/fs/zfs/sys/zvol.h
@@ -23,6 +23,10 @@
  * Copyright (c) 2006, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 
+/*
+ * Copyright (c) 2018 by Delphix. All rights reserved.
+ */
+
 #ifndef	_SYS_ZVOL_H
 #define	_SYS_ZVOL_H
 
@@ -66,6 +70,9 @@ extern uint64_t zvol_get_volume_size(void *minor_hdl);
 extern int zvol_get_volume_wce(void *minor_hdl);
 extern void zvol_log_write_minor(void *minor_hdl, dmu_tx_t *tx, offset_t off,
     ssize_t resid, boolean_t sync);
+
+extern void zvol_update_read_kstats(void *minor_hdl, int64_t nread);
+extern void zvol_update_write_kstats(void *minor_hdl, int64_t nwritten);
 
 #endif
 

--- a/usr/src/uts/common/fs/zfs/zfs_vfsops.c
+++ b/usr/src/uts/common/fs/zfs/zfs_vfsops.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2015 by Delphix. All rights reserved.
+ * Copyright (c) 2012, 2018 by Delphix. All rights reserved.
  * Copyright (c) 2014 Integros [integros.com]
  * Copyright 2016 Nexenta Systems, Inc. All rights reserved.
  */
@@ -848,6 +848,148 @@ zfs_owner_overquota(zfsvfs_t *zfsvfs, znode_t *zp, boolean_t isgroup)
 	return (zfs_fuid_overquota(zfsvfs, isgroup, fuid));
 }
 
+static zfsvfs_kstats_t empty_zfsvfs_kstats = {
+	{ "writes",	KSTAT_DATA_UINT64 },
+	{ "nwritten",	KSTAT_DATA_UINT64 },
+	{ "reads",	KSTAT_DATA_UINT64 },
+	{ "nread",	KSTAT_DATA_UINT64 },
+};
+
+static int
+zfsvfs_kstats_update(kstat_t *ksp, int rw)
+{
+	zfsvfs_t *zfsvfs = ksp->ks_private;
+	zfsvfs_kstats_t *zs = ksp->ks_data;
+
+	ASSERT3P(zfsvfs->z_iokstat, ==, ksp);
+
+	if (rw == KSTAT_WRITE)
+		return (EACCES);
+
+	zs->zk_writes.value.ui64 =
+	    aggsum_value(&zfsvfs->z_aggsum_stats.zas_writes);
+	zs->zk_nwritten.value.ui64 =
+	    aggsum_value(&zfsvfs->z_aggsum_stats.zas_nwritten);
+	zs->zk_reads.value.ui64 =
+	    aggsum_value(&zfsvfs->z_aggsum_stats.zas_reads);
+	zs->zk_nread.value.ui64 =
+	    aggsum_value(&zfsvfs->z_aggsum_stats.zas_nread);
+
+	return (0);
+}
+
+static void
+zfsvfs_kstats_create(zfsvfs_t *zfsvfs)
+{
+	ASSERT3P(zfsvfs->z_iokstat, ==, NULL);
+
+	/*
+	 * There should not be anything wrong with having kstats for
+	 * snapshots. Since we are not sure how useful they would be
+	 * though nor how much their memory overhead would matter in
+	 * a filesystem with many snapshots, we skip them for now.
+	 */
+	if (zfsvfs->z_issnap)
+		return;
+
+	/*
+	 * We are limited by KSTAT_STRLEN for the kstat's name here
+	 * which is a lot less that the string length of a dataset's
+	 * path. Thus, we distinguish handles by their objset IDs
+	 * prepended by the pool's load_guid. Note that both numbers
+	 * are formatted in hex. See breakdown in comment below.
+	 *
+	 * We use the pool's load_guid because it is guaranteed to
+	 * not change as long as the machine is running (unlike the
+	 * current GUID from the pool's config which could change upon
+	 * a reguid).
+	 */
+	char kstat_name[KSTAT_STRLEN];
+	int n = snprintf(kstat_name, sizeof (kstat_name), "%llx-%llx",
+	    (unsigned long long)spa_load_guid(dmu_objset_spa(zfsvfs->z_os)),
+	    (unsigned long long)dmu_objset_id(zfsvfs->z_os));
+
+	/*
+	 * At the time of this writing, KSTAT_STRLEN is 31, the pool GUID
+	 * is 64 bits and object IDs use 48 bits maximum. Separated by a
+	 * dash and formatted in hex the pool guid and the object ID should
+	 * take 29 characters in total:
+	 * - pool GUID (64 bits - 16 chars in hex - 16 total chars)
+	 * - dash      ( 8 bits -  1 char         - 17 total chars)
+	 * - object id (48 bits - 12 chars in hex - 29 total chars)
+	 *
+	 * We place the assertion below to hopefully raise an issue when
+	 * and if one of the above assumptions is wrong in the future. If
+	 * there is still an issue and an assertion is not hit (e.g. we
+	 * don't have DEBUG enabled), we skip creating the kstat as an
+	 * indicator that something is going on and potentially to avoid
+	 * any weird situations like a naming conflict due to truncation.
+	 */
+	ASSERT3U(n, <, KSTAT_STRLEN);
+	if (n >= KSTAT_STRLEN)
+		return;
+
+	kstat_t *iokstat = kstat_create("zfs", 0, kstat_name, "zfsvfs",
+	    KSTAT_TYPE_NAMED,
+	    sizeof (empty_zfsvfs_kstats) / sizeof (kstat_named_t),
+	    KSTAT_FLAG_VIRTUAL);
+	if (iokstat == NULL)
+		return;
+
+	iokstat->ks_data = kmem_alloc(sizeof (empty_zfsvfs_kstats), KM_SLEEP);
+	bcopy(&empty_zfsvfs_kstats, iokstat->ks_data,
+	    sizeof (empty_zfsvfs_kstats));
+	iokstat->ks_update = zfsvfs_kstats_update;
+	iokstat->ks_private = zfsvfs;
+	zfsvfs->z_iokstat = iokstat;
+	kstat_install(zfsvfs->z_iokstat);
+
+	aggsum_init(&zfsvfs->z_aggsum_stats.zas_writes, 0);
+	aggsum_init(&zfsvfs->z_aggsum_stats.zas_nwritten, 0);
+	aggsum_init(&zfsvfs->z_aggsum_stats.zas_reads, 0);
+	aggsum_init(&zfsvfs->z_aggsum_stats.zas_nread, 0);
+}
+
+static void
+zfsvfs_kstats_destroy(zfsvfs_t *zfsvfs)
+{
+	if (zfsvfs->z_iokstat == NULL)
+		return;
+
+	kmem_free(zfsvfs->z_iokstat->ks_data, sizeof (empty_zfsvfs_kstats));
+	kstat_delete(zfsvfs->z_iokstat);
+	zfsvfs->z_iokstat = NULL;
+
+	aggsum_fini(&zfsvfs->z_aggsum_stats.zas_writes);
+	aggsum_fini(&zfsvfs->z_aggsum_stats.zas_nwritten);
+	aggsum_fini(&zfsvfs->z_aggsum_stats.zas_reads);
+	aggsum_fini(&zfsvfs->z_aggsum_stats.zas_nread);
+}
+
+void
+zfsvfs_update_write_kstats(zfsvfs_t *zfsvfs, int64_t nwritten)
+{
+	ASSERT3S(nwritten, >=, 0);
+
+	if (zfsvfs->z_iokstat == NULL)
+		return;
+
+	aggsum_add(&zfsvfs->z_aggsum_stats.zas_writes, 1);
+	aggsum_add(&zfsvfs->z_aggsum_stats.zas_nwritten, nwritten);
+}
+
+void
+zfsvfs_update_read_kstats(zfsvfs_t *zfsvfs, int64_t nread)
+{
+	ASSERT3S(nread, >=, 0);
+
+	if (zfsvfs->z_iokstat == NULL)
+		return;
+
+	aggsum_add(&zfsvfs->z_aggsum_stats.zas_reads, 1);
+	aggsum_add(&zfsvfs->z_aggsum_stats.zas_nread, nread);
+}
+
 /*
  * Associate this zfsvfs with the given objset, which must be owned.
  * This will cache a bunch of on-disk state from the objset in the
@@ -1122,6 +1264,7 @@ zfsvfs_free(zfsvfs_t *zfsvfs)
 	rw_destroy(&zfsvfs->z_fuid_lock);
 	for (i = 0; i != ZFS_OBJ_MTX_SZ; i++)
 		mutex_destroy(&zfsvfs->z_hold_mtx[i]);
+	zfsvfs_kstats_destroy(zfsvfs);
 	kmem_free(zfsvfs, sizeof (zfsvfs_t));
 }
 
@@ -1239,6 +1382,16 @@ out:
 		zfsvfs_free(zfsvfs);
 	} else {
 		atomic_inc_32(&zfs_active_fs_count);
+
+		/*
+		 * Note: Since zfsvfs kstats are created and detroyed
+		 * during mounting/unmounting, the behavior is uniform
+		 * even when datasets are renamed (e.g. kstats of the
+		 * old mount are destroyed and new ones are created for
+		 * the new mount, as renaming unmounts and mounts the
+		 * dataset).
+		 */
+		zfsvfs_kstats_create(zfsvfs);
 	}
 
 	return (error);
@@ -1912,6 +2065,7 @@ zfs_umount(vfs_t *vfsp, int fflag, cred_t *cr)
 	if (zfsvfs->z_ctldir != NULL)
 		zfsctl_destroy(zfsvfs);
 
+	zfsvfs_kstats_destroy(zfsvfs);
 	return (0);
 }
 
@@ -1924,7 +2078,7 @@ zfs_vget(vfs_t *vfsp, vnode_t **vpp, fid_t *fidp)
 	uint64_t	fid_gen = 0;
 	uint64_t	gen_mask;
 	uint64_t	zp_gen;
-	int 		i, err;
+	int		i, err;
 
 	*vpp = NULL;
 

--- a/usr/src/uts/common/sys/fs/zfs.h
+++ b/usr/src/uts/common/sys/fs/zfs.h
@@ -210,6 +210,7 @@ typedef enum {
 	ZPOOL_PROP_MAXBLOCKSIZE,
 	ZPOOL_PROP_BOOTSIZE,
 	ZPOOL_PROP_CHECKPOINT,
+	ZPOOL_PROP_LOAD_GUID,
 	ZPOOL_NUM_PROPS
 } zpool_prop_t;
 
@@ -855,7 +856,7 @@ typedef struct vdev_stat {
  * is passed between kernel and userland as an nvlist uint64 array.
  */
 typedef struct ddt_object {
-	uint64_t	ddo_count;	/* number of elments in ddt 	*/
+	uint64_t	ddo_count;	/* number of elments in ddt	*/
 	uint64_t	ddo_dspace;	/* size of ddt on disk		*/
 	uint64_t	ddo_mspace;	/* size of ddt in-core		*/
 } ddt_object_t;


### PR DESCRIPTION
Reviewed by: Sara Hartse <sara.hartse@delphix.com>
Reviewed by: Sebastien Roy <sebastien.roy@delphix.com>
Reviewed by: Matthew Ahrens <mahrens@delphix.com>
Reviewed by: George Wilson <gwilson@zfsmail.com>

There are use-cases when we want to look into dataset performance
(reads/writes) in ZFS and create high-level tooling for it.

In illumos we already have some of these kstats already in the VFS
layer (module:unix - name:vopstats_<fs_id of dataset here>). That
said we want to introduce kstats specific to ZFS for the following
reasons:
[1] The current kstats don't support R/W to ZVOL's as these code
    paths don't go through VFS.
[2] The VFS version of these statistics are not surrounded by locks
    on purpose so performance of this hot paths doesn't take a hit.
    That's generally fine but it also means that the values are not
    fully accurate. In this new version of kstats we can take
    advantage of the aggsum_t counters (already used for ARC related
    kstats) which would take care of most of that overhead.
[3] Linux does not have the VFS kstats of illumos in its own VFS
    layer, and they would have to implement this feature anyway. Thus
    it would be nice to have the codebase being consistent among
    variants.

Upstream Bugs: DLPX-58996, DLPX-59190

Closes XXX