### PR TITLE
8601 memory leak in get_special_prop()

### DIFF
--- a/usr/src/uts/common/fs/zfs/zcp_get.c
+++ b/usr/src/uts/common/fs/zfs/zcp_get.c
@@ -14,7 +14,7 @@
  */
 
 /*
- * Copyright (c) 2016 by Delphix. All rights reserved.
+ * Copyright (c) 2016, 2017 by Delphix. All rights reserved.
  */
 
 #include "lua.h"
@@ -422,16 +422,21 @@ get_special_prop(lua_State *state, dsl_dataset_t *ds, const char *dsname,
 	case ZFS_PROP_INCONSISTENT:
 		numval = dsl_get_inconsistent(ds);
 		break;
-	case ZFS_PROP_RECEIVE_RESUME_TOKEN:
-		VERIFY3U(strlcpy(strval, get_receive_resume_stats_impl(ds),
-		    ZAP_MAXVALUELEN), <, ZAP_MAXVALUELEN);
+	case ZFS_PROP_RECEIVE_RESUME_TOKEN: {
+		char *token = get_receive_resume_stats_impl(ds);
+		VERIFY3U(strlcpy(strval, token, ZAP_MAXVALUELEN), <,
+		    ZAP_MAXVALUELEN);
+		strfree(token);
 		if (strcmp(strval, "") == 0) {
-			VERIFY3U(strlcpy(strval, get_child_receive_stats(ds),
-			    ZAP_MAXVALUELEN), <, ZAP_MAXVALUELEN);
+			token = get_child_receive_stats(ds);
+			VERIFY3U(strlcpy(strval, token, ZAP_MAXVALUELEN), <,
+			    ZAP_MAXVALUELEN);
+			strfree(token);
 			if (strcmp(strval, "") == 0)
 				error = ENOENT;
 		}
 		break;
+	}
 	case ZFS_PROP_VOLSIZE:
 		ASSERT(ds_type == ZFS_TYPE_VOLUME);
 		error = dmu_objset_from_ds(ds, &os);


### PR DESCRIPTION
Reviewed by: Serapheim Dimitropoulos <serapheim.dimitro@delphix.com>
Reviewed by: Sara Hartse <sara.hartse@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>
Reviewed by: Matt Ahrens <matt@delphix.com>

after running "zfstest" and then using "reboot -d" and "::findleaks", there's a couple of leaks like the following:

kmem_alloc_8 leak: 2 buffers, 8 bytes each, 16 bytes total
ADDR BUFADDR TIMESTAMP THREAD
CACHE LASTLOG CONTENTS
ffffff071a067978 ffffff071a0416c0 9b097add290 ffffff002126fc40
ffffff06e1628888 ffffff06f0e0b440 ffffff06f7592ea0
kmem_cache_alloc_debug+0x2e0
kmem_cache_alloc+0xdd
kmem_alloc+0x4b
ddi_strdup+0x5f
strdup+0x13
get_receive_resume_stats_impl+0x31c
get_special_prop+0x192
zcp_get_system_prop+0x79
zcp_get_prop+0xab
luaD_precall+0x1fd
luaV_execute+0x355
luaD_call+0x88
f_call+0x1d
luaD_rawrunprotected+0x69
luaD_pcall+0x55

Upstream bug: DLPX-47891