### PR TITLE
9675 memory leak from cpupart_create

### DIFF
--- a/usr/src/uts/common/disp/cpupart.c
+++ b/usr/src/uts/common/disp/cpupart.c
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright (c) 1996, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017 by Delphix. All rights reserved.
  */
 
 #include <sys/types.h>
@@ -821,15 +822,10 @@ cpupart_create(psetid_t *psid)
 	ASSERT(pool_lock_held());
 
 	pp = kmem_zalloc(sizeof (cpupart_t), KM_SLEEP);
-	pp->cp_nlgrploads = lgrp_plat_max_lgrps();
-	pp->cp_lgrploads = kmem_zalloc(sizeof (lpl_t) * pp->cp_nlgrploads,
-	    KM_SLEEP);
 
 	mutex_enter(&cpu_lock);
 	if (cp_numparts == cp_max_numparts) {
 		mutex_exit(&cpu_lock);
-		kmem_free(pp->cp_lgrploads, sizeof (lpl_t) * pp->cp_nlgrploads);
-		pp->cp_lgrploads = NULL;
 		kmem_free(pp, sizeof (cpupart_t));
 		return (ENOMEM);
 	}


### PR DESCRIPTION
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Pavel Zakharov <pavel.zakharov@delphix.com>

In usr/src/uts/common/disp/cpupart.c, cpupart_create() allocates a buffer and assigns it to the
cp_lgrploads member of a cpupart_t struct:

pp->cp_nlgrploads = lgrp_plat_max_lgrps();
    pp->cp_lgrploads = kmem_zalloc(sizeof (lpl_t) * pp->cp_nlgrploads,
        KM_SLEEP);

The function then goes on to call cpupart_lpl_initialize(), which allocates an identical buffer and
assigns it to the same field, leaking the original buffer:

sz = cp->cp_nlgrploads = lgrp_plat_max_lgrps();
    cp->cp_lgrploads = kmem_zalloc(sizeof (lpl_t) * sz, KM_SLEEP);

We should be able to just remove the initial allocation.

Upstream bug: DLPX-56280