### PR TITLE
9677 panic from zio_write_gang_block() when creating dump device on f…

### DIFF
--- a/usr/src/uts/common/fs/zfs/zio.c
+++ b/usr/src/uts/common/fs/zfs/zio.c
@@ -2192,7 +2192,13 @@ zio_write_gang_member_ready(zio_t *zio)
 static void
 zio_write_gang_done(zio_t *zio)
 {
-	abd_put(zio->io_abd);
+	/*
+	 * The io_abd field will be NULL for a zio with no data.  The io_flags
+	 * will initially have the ZIO_FLAG_NODATA bit flag set, but we can't
+	 * check for it here as it is cleared in zio_ready.
+	 */
+	if (zio->io_abd != NULL)
+		abd_put(zio->io_abd);
 }
 
 static int
@@ -2213,11 +2219,12 @@ zio_write_gang_block(zio_t *pio)
 	int gbh_copies = MIN(copies + 1, spa_max_replication(spa));
 	zio_prop_t zp;
 	int error;
+	boolean_t has_data = !(pio->io_flags & ZIO_FLAG_NODATA);
 
 	int flags = METASLAB_HINTBP_FAVOR | METASLAB_GANG_HEADER;
 	if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 		ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-		ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+		ASSERT(has_data);
 
 		flags |= METASLAB_ASYNC_ALLOC;
 		VERIFY(refcount_held(&mc->mc_alloc_slots[pio->io_allocator],
@@ -2241,7 +2248,7 @@ zio_write_gang_block(zio_t *pio)
 	if (error) {
 		if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-			ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+			ASSERT(has_data);
 
 			/*
 			 * If we failed to allocate the gang block header then
@@ -2294,14 +2301,15 @@ zio_write_gang_block(zio_t *pio)
 		zp.zp_nopwrite = B_FALSE;
 
 		zio_t *cio = zio_write(zio, spa, txg, &gbh->zg_blkptr[g],
-		    abd_get_offset(pio->io_abd, pio->io_size - resid), lsize,
-		    lsize, &zp, zio_write_gang_member_ready, NULL, NULL,
+		    has_data ? abd_get_offset(pio->io_abd, pio->io_size -
+		    resid) : NULL, lsize, lsize, &zp,
+		    zio_write_gang_member_ready, NULL, NULL,
 		    zio_write_gang_done, &gn->gn_child[g], pio->io_priority,
 		    ZIO_GANG_CHILD_FLAGS(pio), &pio->io_bookmark);
 
 		if (pio->io_flags & ZIO_FLAG_IO_ALLOCATING) {
 			ASSERT(pio->io_priority == ZIO_PRIORITY_ASYNC_WRITE);
-			ASSERT(!(pio->io_flags & ZIO_FLAG_NODATA));
+			ASSERT(has_data);
 
 			/*
 			 * Gang children won't throttle but we should


### PR DESCRIPTION
…ragmented rpool

Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: George Wilson <george.wilson@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>

When the amount of memory in the system changes, we automatically increase the size of the dump device.
The dump device is allocated with ZIO_FLAG_NODATA, so that we just allocate the space and don't write
to it (yet - we'll write when the system dumps). If the rpool is fragmented, then we may end up trying
to create gang blocks for the dump device. What should happen is that we allocate the gang blocks, and
then the zvol_dumpify() code will notice that there are gang blocks in the dump device, and fail to
activate it for dump (since we don't have code to support this).

However, when we create the gang block for the dump device (with ZIO_FLAG_NODATA), we get a panic from
zio_write_gang_block(), because pio->io_abd is NULL. It should be fine for this to be NULL, since we have
ZIO_FLAG_NODATA we should not be touching it. However, with the ABD changes we are now doing
"abd_get_offset(pio->io_abd, ...)" which will panic since the io_abd is NULL.

The solution is for zio_write_gang_block() to pass a NULL abd to zio_write() instead of calling
abd_get_offset(pio->io_abd == NULL), when ZIO_FLAG_NODATA is set.

Upstream bug: DLPX-57429