### PR TITLE
9678 ZFS panic when cancelling removal with Log Spacemap feature enabled

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -2367,6 +2367,7 @@ file path=opt/zfs-tests/tests/functional/refreserv/setup mode=0555
 file path=opt/zfs-tests/tests/functional/removal/cleanup mode=0555
 file path=opt/zfs-tests/tests/functional/removal/removal.kshlib mode=0444
 file path=opt/zfs-tests/tests/functional/removal/removal_all_vdev mode=0555
+file path=opt/zfs-tests/tests/functional/removal/removal_cancel mode=0555
 file path=opt/zfs-tests/tests/functional/removal/removal_check_space mode=0555
 file path=opt/zfs-tests/tests/functional/removal/removal_condense_export \
     mode=0555

--- a/usr/src/test/zfs-tests/tests/functional/removal/removal_cancel.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/removal/removal_cancel.ksh
@@ -1,0 +1,105 @@
+#! /bin/ksh -p
+#
+# CDDL HEADER START
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+# CDDL HEADER END
+#
+
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+
+. $STF_SUITE/include/libtest.shlib
+. $STF_SUITE/tests/functional/removal/removal.kshlib
+
+#
+# DESCRIPTION:
+#
+# Ensure that cancelling a removal midway does not panic the
+# system for whatever reason. [The original issue was a
+# regression due to the Log Space Map feature]
+#
+# STRATEGY:
+#
+# 1. Create a pool with one vdev and do some writes on it.
+# 2. Add a new vdev to the pool and start the removal of
+#    the first vdev.
+# 3. Cancel the removal after some segments have been copied
+#    over to the new vdev.
+# 4. Run zdb to ensure the on-disk state of the pool is ok.
+#
+
+
+function cleanup
+{
+	#
+	# Reset tunable.
+	#
+	mdb_ctf_set_int zfs_remove_max_bytes_pause -0t1
+	default_cleanup_noexit
+}
+
+log_onexit cleanup
+
+SAMPLEFILE=/$TESTDIR/00
+
+#
+# Create pool with one disk.
+#
+log_must default_setup_noexit "$REMOVEDISK"
+
+#
+# Create a file of size 1GB and then do some random writes.
+# Since randwritecomp does 8K writes we do 12500 writes
+# which means we write ~100MB to the vdev.
+#
+log_must mkfile -n 1g $SAMPLEFILE
+log_must randwritecomp $SAMPLEFILE 12500
+
+#
+# Add second device where all the data will be evacuated.
+#
+log_must zpool add -f $TESTPOOL $NOTREMOVEDISK
+
+#
+# Set maximum bytes to be transfered by removal to be 20MB.
+# The idea is to make sure that it stops at some point after
+# it has copied over some data but not all of them (100MB).
+#
+mdb_ctf_set_int zfs_remove_max_bytes_pause 1400000
+
+#
+# Start removal.
+#
+log_must zpool remove $TESTPOOL $REMOVEDISK
+
+#
+# Sleep a bit to allow removal to copy some data.
+#
+log_must sleep 10
+
+#
+# Only for debugging purposes in test logs.
+#
+log_must zpool status $TESTPOOL
+
+#
+# Cancel removal.
+#
+log_must zpool remove -s $TESTPOOL
+
+#
+# Verify on-disk state.
+#
+log_must zdb $TESTPOOL
+
+log_pass "Device removal thread cancelled successfully."

--- a/usr/src/test/zfs-tests/tests/functional/removal/removal_resume_export.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/removal/removal_resume_export.ksh
@@ -15,7 +15,7 @@
 #
 
 #
-# Copyright (c) 2017 by Delphix. All rights reserved.
+# Copyright (c) 2018 by Delphix. All rights reserved.
 #
 
 . $STF_SUITE/include/libtest.shlib

--- a/usr/src/uts/common/fs/zfs/vdev_removal.c
+++ b/usr/src/uts/common/fs/zfs/vdev_removal.c
@@ -1621,6 +1621,11 @@ spa_vdev_remove_cancel_sync(void *arg, dmu_tx_t *tx)
 			mutex_enter(&svr->svr_lock);
 			VERIFY0(space_map_load(msp->ms_sm,
 			    svr->svr_allocd_segs, SM_ALLOC));
+
+			range_tree_walk(msp->ms_unflushed_allocs,
+			    range_tree_add, svr->svr_allocd_segs);
+			range_tree_walk(msp->ms_unflushed_frees,
+			    range_tree_remove, svr->svr_allocd_segs);
 			range_tree_walk(msp->ms_freeing,
 			    range_tree_remove, svr->svr_allocd_segs);
 


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Prashanth Sreenivasa <pks@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>

This panic was hit three times during device removal tests:

vdev_indirect_mark_obsolete+0xc8(ffffff03885a6000, 20003000, 800)
free_mapped_segment_cb+0x2e(ffffff03885a6000, 20003000, 800)
range_tree_vacate+0x65(ffffff0377aca2c0, fffffffff7a6ec10, ffffff03885a6000)
spa_vdev_remove_cancel_sync+0x110(0, ffffff0376a27d00)
dsl_sync_task_sync+0xda(ffffff00103c1a70, ffffff0376a27d00)
dsl_pool_sync+0x2a5(ffffff03b1d80240, be)
spa_sync_iterate_to_convergence+0xf7(ffffff039a7b8000, ffffff03bfe7a1c0)
spa_sync+0x2b9(ffffff039a7b8000, be)
txg_sync_thread+0x23f(ffffff03b1d80240)
thread_start+8

The sync task that cancels the removal must know about unflushed allocs and frees in the metaslabs
of the device being removed.

Upstream bug: DLPX-57783