### PR TITLE
9690 metaslab of vdev with no space maps was flushed during removal

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev.c
+++ b/usr/src/uts/common/fs/zfs/vdev.c
@@ -2823,11 +2823,11 @@ vdev_destroy_spacemaps(vdev_t *vd, dmu_tx_t *tx)
 }
 
 static void
-vdev_remove_empty(vdev_t *vd, uint64_t txg)
+vdev_remove_empty_log(vdev_t *vd, uint64_t txg)
 {
 	spa_t *spa = vd->vdev_spa;
-	dmu_tx_t *tx;
 
+	ASSERT(vd->vdev_islog);
 	ASSERT(vd == vd->vdev_top);
 	ASSERT3U(txg, ==, spa_syncing_txg(spa));
 
@@ -2871,13 +2871,14 @@ vdev_remove_empty(vdev_t *vd, uint64_t txg)
 			ASSERT0(mg->mg_histogram[i]);
 	}
 
-	tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);
-	vdev_destroy_spacemaps(vd, tx);
+	dmu_tx_t *tx = dmu_tx_create_assigned(spa_get_dsl(spa), txg);
 
-	if (vd->vdev_islog && vd->vdev_top_zap != 0) {
+	vdev_destroy_spacemaps(vd, tx);
+	if (vd->vdev_top_zap != 0) {
 		vdev_destroy_unlink_zap(vd, vd->vdev_top_zap, tx);
 		vd->vdev_top_zap = 0;
 	}
+
 	dmu_tx_commit(tx);
 }
 
@@ -2949,14 +2950,11 @@ vdev_sync(vdev_t *vd, uint64_t txg)
 		vdev_dtl_sync(lvd, txg);
 
 	/*
-	 * Remove the metadata associated with this vdev once it's empty.
-	 * Note that this is typically used for log/cache device removal;
-	 * we don't empty toplevel vdevs when removing them.  But if
-	 * a toplevel happens to be emptied, this is not harmful.
+	 * If this is an empty log device being removed, destroy the
+	 * metadata associated with it.
 	 */
-	if (vd->vdev_stat.vs_alloc == 0 && vd->vdev_removing) {
-		vdev_remove_empty(vd, txg);
-	}
+	if (vd->vdev_islog && vd->vdev_stat.vs_alloc == 0 && vd->vdev_removing)
+		vdev_remove_empty_log(vd, txg);
 
 	(void) txg_list_add(&spa->spa_vdev_txg_list, vd, TXG_CLEAN(txg));
 }


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Brad Lewis <brad.lewis@delphix.com>

While running zloop, this assertion was hit:

assertion failed for thread 0xfffffd7ffe64a240,
thread-id 334: dn->dn_phys->dn_type || dn->dn_allocated_txg, file ../../../uts/common/fs/zfs/dnode.c, line 1327

libc.so.1`_lwp_kill+0xa()
libc.so.1`_assfail+0x182(fffffd7ff9d4b970, fffffd7ff9d4ad20, 52f)
libc.so.1`assfail+0x19(fffffd7ff9d4b970, fffffd7ff9d4ad20, 52f)
libzpool.so.1`dnode_setdirty+0x1ce(f36a5d0, 157b5d00)
libzpool.so.1`dbuf_dirty+0x63a(1065e200, 157b5d00)
libzpool.so.1`dmu_buf_will_dirty+0xfc(1065e200, 157b5d00)
libzpool.so.1`space_map_write+0x75(a578880, 170eba00, 0, 1000000, 157b5d00)
libzpool.so.1`metaslab_flush+0x173(2215940, 157b5d00)
libzpool.so.1`spa_flush_metaslabs+0x1a5(1d3c000, 157b5d00)
libzpool.so.1`spa_sync_iterate_to_convergence+0x170(1d3c000, 157b5d00)
libzpool.so.1`spa_sync+0x26a(1d3c000, 11a)
libzpool.so.1`txg_sync_thread+0x2ab(2096740)
libc.so.1`_thrp_setup+0x8a(fffffd7ffe64a240)
libc.so.1`_lwp_start()
The immediate problem is that this spacemap's dnode doesn't appear to be allocated.

> ::status
debugging core file of ztest (64-bit) from install-os-2074-bc7947b1-0.dcenter
initial argv: /usr/bin/amd64/ztest
threading model: native threads
status: process terminated by SIGABRT (Abort), pid=106523 uid=1025 code=-1
panic message:
assertion failed for thread 0xfffffd7ffe64a240, thread-id 334: dn->dn_phys->dn_type || dn->dn_allocated_txg,
 file ../../../uts/common/fs/zfs/dnode.c, line 1
327

> $C
fffffd7fd7e9d730 libc.so.1`_lwp_kill+0xa()
fffffd7fd7e9dac0 libc.so.1`_assfail+0x182(fffffd7ff9d4b970, fffffd7ff9d4ad20, 52f)
fffffd7fd7e9daf0 libc.so.1`assfail+0x19(fffffd7ff9d4b970, fffffd7ff9d4ad20, 52f)
fffffd7fd7e9db60 libzpool.so.1`dnode_setdirty+0x1ce(f36a5d0, 157b5d00)
fffffd7fd7e9dc20 libzpool.so.1`dbuf_dirty+0x63a(1065e200, 157b5d00)
fffffd7fd7e9dc60 libzpool.so.1`dmu_buf_will_dirty+0xfc(1065e200, 157b5d00)
fffffd7fd7e9dce0 libzpool.so.1`space_map_write+0x75(a578880, 170eba00, 0, 1000000, 157b5d00)
fffffd7fd7e9dd70 libzpool.so.1`metaslab_flush+0x173(2215940, 157b5d00)
fffffd7fd7e9ddf0 libzpool.so.1`spa_flush_metaslabs+0x1a5(1d3c000, 157b5d00)
fffffd7fd7e9de70 libzpool.so.1`spa_sync_iterate_to_convergence+0x170(1d3c000, 157b5d00)
fffffd7fd7e9def0 libzpool.so.1`spa_sync+0x26a(1d3c000, 11a)
fffffd7fd7e9dfb0 libzpool.so.1`txg_sync_thread+0x2ab(2096740)
fffffd7fd7e9dfe0 libc.so.1`_thrp_setup+0x8a(fffffd7ffe64a240)
fffffd7fd7e9dff0 libc.so.1`_lwp_start()

> f36a5d0::print dnode_t dn_phys->dn_type dn_allocated_txg dn_free_txg
dn_phys->dn_type = 0
dn_allocated_txg = 0
dn_free_txg = 0

This seems to point that the space map's dnode has been freed probably through dnode_sync_free() as this
is the function that actually frees the dnode and zeroes out all the above fields.

The failure occurs while we were trying to flush a metaslab in spa_sync() and these code paths have
assertions everywhere that we only flush metaslabs that have a space map (e.g. went through metaslab_sync()
at least once since the creation of the pool). There is a contradiction then where the metaslab's spacemap
information in memory (ms_sm data) exist but the actual space map on-disk have been freed.

To fix this, we first want to try calling vdev_remove_empty() only for log devices in vdev_sync().

Upstream bug: DLPX-58198