### PR TITLE
8589 zfs send | recv crashes receiving system

### DIFF
--- a/usr/src/uts/common/fs/zfs/dmu_send.c
+++ b/usr/src/uts/common/fs/zfs/dmu_send.c
@@ -392,6 +392,22 @@ static int
 dump_freeobjects(dmu_sendarg_t *dsp, uint64_t firstobj, uint64_t numobjs)
 {
 	struct drr_freeobjects *drrfo = &(dsp->dsa_drr->drr_u.drr_freeobjects);
+	uint64_t maxobj = DNODES_PER_BLOCK *
+	    (DMU_META_DNODE(dsp->dsa_os)->dn_maxblkid + 1);
+
+	/*
+	 * Versions of OpenZFS less than 7104 does not handle large
+	 * FREEOBJECTS records correctly, leading to zfs recv never completing.
+	 * To avoid this issue, don't send FREEOBJECTS records for object
+	 * IDs which cannot exist on the receiving side.
+	 */
+	if (maxobj > 0) {
+		if (maxobj < firstobj)
+			return (0);
+
+		if (maxobj < firstobj + numobjs)
+			numobjs = maxobj - firstobj;
+	}
 
 	/*
 	 * If there is a pending op, but it's not PENDING_FREEOBJECTS,


### PR DESCRIPTION
The code is the same as the one on https://github.com/zfsonlinux/zfs/pull/6616. I just included the missing part.