### PR TITLE
6037 zfs(1M) needs to handle unknown uid/gid in context of allow/unallow more gracefully

### DIFF
--- a/usr/src/cmd/zfs/zfs_main.c
+++ b/usr/src/cmd/zfs/zfs_main.c
@@ -4613,6 +4613,14 @@ parse_fs_perm(fs_perm_t *fsperm, nvlist_t *nvl)
 						(void) strlcpy(
 						    node->who_perm.who_ug_name,
 						    nice_name, 256);
+					else {
+						/* User or group unknown */
+						(void) snprintf(
+						    node->who_perm.who_ug_name,
+						    sizeof (
+						    node->who_perm.who_ug_name),
+						    "(unknown: %d)", rid);
+					}
 				}
 
 				uu_avl_insert(avl, node, idx);
@@ -5111,9 +5119,9 @@ construct_fsacl_list(boolean_t un, struct allow_opts *opts, nvlist_t **nvlp)
 
 				if (p != NULL)
 					rid = p->pw_uid;
-				else {
+				else if (*endch != '\0') {
 					(void) snprintf(errbuf, 256, gettext(
-					    "invalid user %s"), curr);
+					    "invalid user %s\n"), curr);
 					allow_usage(un, B_TRUE, errbuf);
 				}
 			} else if (opts->group) {
@@ -5125,9 +5133,9 @@ construct_fsacl_list(boolean_t un, struct allow_opts *opts, nvlist_t **nvlp)
 
 				if (g != NULL)
 					rid = g->gr_gid;
-				else {
+				else if (*endch != '\0') {
 					(void) snprintf(errbuf, 256, gettext(
-					    "invalid group %s"),  curr);
+					    "invalid group %s\n"),  curr);
 					allow_usage(un, B_TRUE, errbuf);
 				}
 			} else {
@@ -5153,7 +5161,7 @@ construct_fsacl_list(boolean_t un, struct allow_opts *opts, nvlist_t **nvlp)
 					rid = g->gr_gid;
 				} else {
 					(void) snprintf(errbuf, 256, gettext(
-					    "invalid user/group %s"), curr);
+					    "invalid user/group %s\n"), curr);
 					allow_usage(un, B_TRUE, errbuf);
 				}
 			}


### PR DESCRIPTION
Fix by @delphij

Currently, if a uid/gid is unknown to the system, zfs(1M) would say nothing on the unknown user/group. For instance, after a user which owns uid=1002 is removed, we would have something like this, if 'destroy' is previously granted:

```
$ zfs allow zeta/test                   
---- Permissions on zeta/test ----------------------------------------
Local+Descendent permissions:
    user  destroy
```

With the attached patch applied, it would become:

```
$ zfs allow zeta/test                   
---- Permissions on zeta/test ----------------------------------------
Local+Descendent permissions:
    user (unknown: 1002) destroy
```

The proposed patch also allows 'allow' and 'unallow' to accept numerical IDs, even when they are not known to the system, when -u or -g is explicitly specified. Without the change there would be no way other than recreating a user/group that occupies the same UID/GID to revoke a granted permission to unknown user.
