### PR TITLE
9880 Race in ZFS parallel mount

### DIFF
--- a/usr/src/lib/libzfs/common/libzfs_mount.c
+++ b/usr/src/lib/libzfs/common/libzfs_mount.c
@@ -26,6 +26,7 @@
  * Copyright 2016 Igor Kozhukhov <ikozhukhov@gmail.com>
  * Copyright 2017 Joyent, Inc.
  * Copyright 2017 RackTop Systems.
+ * Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
  */
 
 /*
@@ -1142,19 +1143,28 @@ zfs_iter_cb(zfs_handle_t *zhp, void *data)
 /*
  * Sort comparator that compares two mountpoint paths. We sort these paths so
  * that subdirectories immediately follow their parents. This means that we
- * effectively treat the '/' character as the lowest value non-nul char. An
- * example sorted list using this comparator would look like:
+ * effectively treat the '/' character as the lowest value non-nul char.
+ * Since filesystems from non-global zones can have the same mountpoint
+ * as other filesystems, the comparator sorts global zone filesystems to
+ * the top of the list. This means that the global zone will traverse the
+ * filesystem list in the correct order and can stop when it sees the
+ * first zoned filesystem. In a non-global zone, only the delegated
+ * filesystems are seen.
+ *
+ * An example sorted list using this comparator would look like:
  *
  * /foo
  * /foo/bar
  * /foo/bar/baz
  * /foo/baz
  * /foo.bar
+ * /foo (NGZ1)
+ * /foo (NGZ2)
  *
  * The mounting code depends on this ordering to deterministically iterate
  * over filesystems in order to spawn parallel mount tasks.
  */
-int
+static int
 mountpoint_cmp(const void *arga, const void *argb)
 {
 	zfs_handle_t *const *zap = arga;
@@ -1166,6 +1176,14 @@ mountpoint_cmp(const void *arga, const void *argb)
 	const char *a = mounta;
 	const char *b = mountb;
 	boolean_t gota, gotb;
+	uint64_t zoneda, zonedb;
+
+	zoneda = zfs_prop_get_int(za, ZFS_PROP_ZONED);
+	zonedb = zfs_prop_get_int(zb, ZFS_PROP_ZONED);
+	if (zoneda && !zonedb)
+		return (1);
+	if (!zoneda && zonedb)
+		return (-1);
 
 	gota = (zfs_get_type(za) == ZFS_TYPE_FILESYSTEM);
 	if (gota) {
@@ -1379,6 +1397,8 @@ void
 zfs_foreach_mountpoint(libzfs_handle_t *hdl, zfs_handle_t **handles,
     size_t num_handles, zfs_iter_f func, void *data, boolean_t parallel)
 {
+	zoneid_t zoneid = getzoneid();
+
 	/*
 	 * The ZFS_SERIAL_MOUNT environment variable is an undocumented
 	 * variable that can be used as a convenience to do a/b comparison
@@ -1414,6 +1434,14 @@ zfs_foreach_mountpoint(libzfs_handle_t *hdl, zfs_handle_t **handles,
 	 */
 	for (int i = 0; i < num_handles;
 	    i = non_descendant_idx(handles, num_handles, i)) {
+		/*
+		 * Since the mountpoints have been sorted so that the zoned
+		 * filesystems are at the end, a zoned filesystem seen from
+		 * the global zone means that we're done.
+		 */
+		if (zoneid == GLOBAL_ZONEID &&
+		    zfs_prop_get_int(handles[i], ZFS_PROP_ZONED))
+			break;
 		zfs_dispatch_mount(hdl, handles, num_handles, i, func, data,
 		    tq);
 	}


### PR DESCRIPTION
There is a race condition in the ZFS parallel mount code which shows up if you have zoned datasets with the same mountpoint as those in the global zone. The code makes the incorrect assumption that mount points are globally unique. This results in mount failures during boot or pool import.

Take the following set of filesystems which have been sorted by mountpoint by the existing code - mountpoints followed by the dataset in brackets. The letters at the left are my annotations.

With this set of filesystems, `zfs_foreach_mountpoint()` will create tasks _a-h_, task _g_ will create _A-D_ and _D_ will create _s-z_. The problem is that, for example, _t_ can run before _B_.

```
a   / (rpool/ROOT/r151024l)
b   / (rpool/ROOT/r151028.pre2)
c   / (rpool/ROOT/r151026.l1tf)
d   /data (data/zone/build/export)
e   /data (data/zone/reci/export)
f   /data (data)
g   /data (data/zone/ns1/export)
 A  /data/sendmail (data/zone/build/export/sendmail)
 B  /data/sendmail (data/sendmail)
 C  /data/sendmail (data/zone/ns1/export/sendmail)
 D  /data/sendmail (data/zone/reci/export/sendmail)
  s /data/sendmail/clientmqueue (data/zone/reci/export/sendmail/clientmqueue)
  t /data/sendmail/clientmqueue (data/sendmail/clientmqueue)
  u /data/sendmail/clientmqueue (data/zone/ns1/export/sendmail/clientmqueue)
  v /data/sendmail/clientmqueue (data/zone/build/export/sendmail/clientmqueue)
  w /data/sendmail/mqueue (data/zone/ns1/export/sendmail/mqueue)
  x /data/sendmail/mqueue (data/zone/build/export/sendmail/mqueue)
  y /data/sendmail/mqueue (data/sendmail/mqueue)
  z /data/sendmail/mqueue (data/zone/reci/export/sendmail/mqueue)
h   /home (data/home)
 Z  /home/af (data/home/af)
```

The fix I've gone for at the moment is to change the sort so that filesystems with the `zoned` attribute are sorted to the bottom. In the global zone, that results in the expected sorted list of filesystems and has the additional benefit that we can stop creating tasks once we see a zoned filesystem in the list. In a non-global zone, only the delegated filesystems are seen so the list is just traversed as normal.