### PR TITLE
9963 Seperate tunable for disabling ZIL vdev flush

### DIFF
--- a/usr/src/uts/common/fs/zfs/vdev_disk.c
+++ b/usr/src/uts/common/fs/zfs/vdev_disk.c
@@ -38,6 +38,13 @@
 #include <sys/fm/fs/zfs.h>
 
 /*
+ * Tunable parameter for debugging or performance analysis. Setting this
+ * will cause pool corruption on power loss if a volatile out-of-order
+ * write cache is enabled.
+ */
+boolean_t zfs_nocacheflush = B_FALSE;
+
+/*
  * Virtual device vector for disks.
  */
 

--- a/usr/src/uts/common/fs/zfs/zil.c
+++ b/usr/src/uts/common/fs/zfs/zil.c
@@ -95,11 +95,12 @@ int zfs_commit_timeout_pct = 5;
 int zil_replay_disable = 0;
 
 /*
- * Tunable parameter for debugging or performance analysis.  Setting
- * zfs_nocacheflush will cause corruption on power loss if a volatile
- * out-of-order write cache is enabled.
+ * Disable the DKIOCFLUSHWRITECACHE commands that are normally sent to
+ * the disk(s) by the ZIL after an LWB write has completed. Setting this
+ * will cause ZIL corruption on power loss if a volatile out-of-order
+ * write cache is enabled.
  */
-boolean_t zfs_nocacheflush = B_FALSE;
+boolean_t zil_nocacheflush = B_FALSE;
 
 /*
  * Limit SLOG write size per commit executed with synchronous priority.
@@ -991,7 +992,7 @@ zil_lwb_add_block(lwb_t *lwb, const blkptr_t *bp)
 	int ndvas = BP_GET_NDVAS(bp);
 	int i;
 
-	if (zfs_nocacheflush)
+	if (zil_nocacheflush)
 		return;
 
 	mutex_enter(&lwb->lwb_vdev_lock);
@@ -1015,7 +1016,7 @@ zil_lwb_add_txg(lwb_t *lwb, uint64_t txg)
 /*
  * This function is a called after all VDEVs associated with a given lwb
  * write have completed their DKIOCFLUSHWRITECACHE command; or as soon
- * as the lwb write completes, if "zfs_nocacheflush" is set.
+ * as the lwb write completes, if "zil_nocacheflush" is set.
  *
  * The intention is for this function to be called as soon as the
  * contents of an lwb are considered "stable" on disk, and will survive


### PR DESCRIPTION
Reviewed by: Matt Ahrens <matt@delphix.com>
Reviewed by: Brad Lewis <brad.lewis@delphix.com>
Reviewed by: Patrick Mooney <patrick.mooney@joyent.com>

This change adds a new tunable, "zil_nocacheflush", which can be used to
disable the vdev flush command that's issued by the ZIL. Previously,
this was controlled by the "zfs_nocacheflush" tunable, but the drawback
of that tunable is it also disables the vdev flush command issued by SPA
sync, which raises serious data integrity concerns for the whole pool.

Now, one can set the new "zil_nocacheflush" tunable, and this will
disable the vdev flush commands issued by the ZIL, while having no
impact on the vdev flush commands issued by SPA sync. Further, setting
the "zfs_nocacheflush" command will continue to disable the vdev flush
commands issued by both the ZIL and SPA sync.