### PR TITLE
add missing dmu_zfetch_fini() in dnode_move_impl()

### DIFF
--- a/usr/src/uts/common/fs/zfs/dnode.c
+++ b/usr/src/uts/common/fs/zfs/dnode.c
@@ -799,6 +799,7 @@ dnode_move_impl(dnode_t *odn, dnode_t *ndn)
 	odn->dn_dbufs_count = 0;
 	odn->dn_bonus = NULL;
 	odn->dn_zfetch.zf_dnode = NULL;
+	dmu_zfetch_fini(&odn->dn_zfetch);
 
 	/*
 	 * Set the low bit of the objset pointer to ensure that dnode_move()


### PR DESCRIPTION
As it turns out, on the Windows platform when rw_init() is called (rather
its bedrock call ExInitializeResourceLite) it is placed on an active-list
of locks, and is removed at rw_destroy() time.

dnode_move() has logic to copy over the old-dnode to new-dnode,
including calling dmu_zfetch_init(new-dnode). But due to the missing
dmu_zfetch_fini(old-dnode), kmem will call dnode_dest() to release the
memory (and in debug builds fill pattern 0xdeadbeef) over the Windows
active-lock's prev/next list pointers, making Windows sad.

But on other platforms, the contents of dmu_zfetch_fini() is one
call to list_destroy() and one to rw_destroy(), which is effectively a
no-op call and is not required. This commit is mostly for
"correctness" and can be skipped there.

Signed-off-by: Jorgen Lundman <lundman@lundman.net>