### PR TITLE
9185 Enable testing over NFS in ZFS performance tests

### DIFF
--- a/usr/src/pkg/manifests/system-test-zfstest.mf
+++ b/usr/src/pkg/manifests/system-test-zfstest.mf
@@ -2731,6 +2731,7 @@ file path=opt/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/random_writes.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/sequential_reads.fio mode=0444
 file path=opt/zfs-tests/tests/perf/fio/sequential_writes.fio mode=0444
+file path=opt/zfs-tests/tests/perf/nfs-sample.cfg mode=0444
 file path=opt/zfs-tests/tests/perf/perf.shlib mode=0444
 file path=opt/zfs-tests/tests/perf/regression/random_reads mode=0555
 file path=opt/zfs-tests/tests/perf/regression/random_readwrite mode=0555

--- a/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
+++ b/usr/src/test/zfs-tests/cmd/scripts/zfstest.ksh
@@ -132,7 +132,7 @@ constrain_path
 export PATH=$PATHDIR
 
 verify_id
-while getopts ac:q c; do
+while getopts ac:n:q c; do
 	case $c in
 	'a')
 		auto_detect=true
@@ -141,6 +141,12 @@ while getopts ac:q c; do
 		runfile=$OPTARG
 		[[ -f $runfile ]] || fail "Cannot read file: $runfile"
 		;;
+	'n')
+		nfsfile=$OPTARG
+		[[ -f $nfsfile ]] || fail "Cannot read file: $nfsfile"
+		export NFS=1
+		. "$nfsfile"
+		 ;;
 	'q')
 		quiet='-q'
 		;;

--- a/usr/src/test/zfs-tests/include/commands.cfg
+++ b/usr/src/test/zfs-tests/include/commands.cfg
@@ -92,11 +92,13 @@ export USR_BIN_FILES='awk
     rmdir
     rsh
     runat
+    scp
     sed
     seq
     shuf
     sleep
     sort
+    ssh
     stat
     strings
     su

--- a/usr/src/test/zfs-tests/tests/perf/fio/random_reads.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/random_reads.fio
@@ -26,6 +26,7 @@ runtime=${RUNTIME}
 bs=${BLOCKSIZE}
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 
 [job]

--- a/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite.fio
@@ -28,6 +28,7 @@ runtime=${RUNTIME}
 bssplit=4k/50:8k/30:128k/10:1m/10
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 buffer_compress_percentage=66
 buffer_compress_chunk=4096

--- a/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/random_readwrite_fixed.fio
@@ -28,6 +28,7 @@ runtime=${RUNTIME}
 bs=${BLOCKSIZE}
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 buffer_compress_percentage=66
 buffer_compress_chunk=4096

--- a/usr/src/test/zfs-tests/tests/perf/fio/random_writes.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/random_writes.fio
@@ -25,6 +25,7 @@ runtime=${RUNTIME}
 bs=${BLOCKSIZE}
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 filesize=${FILESIZE}
 buffer_compress_percentage=66

--- a/usr/src/test/zfs-tests/tests/perf/fio/sequential_reads.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/sequential_reads.fio
@@ -26,6 +26,7 @@ runtime=${RUNTIME}
 bs=${BLOCKSIZE}
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 
 [job]

--- a/usr/src/test/zfs-tests/tests/perf/fio/sequential_writes.fio
+++ b/usr/src/test/zfs-tests/tests/perf/fio/sequential_writes.fio
@@ -25,6 +25,7 @@ runtime=${RUNTIME}
 bs=${BLOCKSIZE}
 ioengine=psync
 sync=${SYNC_TYPE}
+direct=${DIRECT}
 numjobs=${NUMJOBS}
 filesize=${FILESIZE}
 buffer_compress_percentage=66

--- a/usr/src/test/zfs-tests/tests/perf/nfs-sample.cfg
+++ b/usr/src/test/zfs-tests/tests/perf/nfs-sample.cfg
@@ -1,0 +1,47 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright (c) 2016 by Delphix. All rights reserved.
+#
+
+#
+# This file is a sample NFS configuration for the performance tests. To use the
+# performance tests over NFS you must have:
+#   - a client machine with fio and sudo installed
+#   - passwordless SSH set up from this host
+#     for delphix and root users to the client
+#   - passwordless sudo for the user on the client
+#
+
+
+# The IP address for the DE, this should be the 10 GbE connection IP
+export NFS_SERVER=127.0.0.1
+
+# The IP address for the client, this should be the 10 GbE
+# connection IP
+export NFS_CLIENT=127.0.0.1
+
+# The mountpoint to use inside the client
+export NFS_MOUNT=/var/tmp/nfs
+
+# The user to run the tests as on the client
+export NFS_USER=delphix
+
+# Common NFS client mount options
+export NFS_OPTIONS="-o rw,nosuid,bg,hard,rsize=1048576,wsize=1048576,"
+NFS_OPTIONS+="nointr,timeo=600,proto=tcp,actimeo=0,port=2049"
+
+# illumos NFS client mount options
+# export NFS_OPTIONS="$NFS_OPTIONS,vers=3"
+
+# Linux NFS client mount options
+export NFS_OPTIONS="-t nfs $NFS_OPTIONS,noacl,nfsvers=3"

--- a/usr/src/test/zfs-tests/tests/perf/perf.shlib
+++ b/usr/src/test/zfs-tests/tests/perf/perf.shlib
@@ -111,6 +111,16 @@ function do_fio_run_impl
 	export BLOCKSIZE=$iosize
 	sync
 
+	# When running locally, we want to keep the default behavior of
+	# DIRECT == 0, so only set it when we're running over NFS to
+	# disable client cache for reads.
+	if [[ $NFS -eq 1 ]]; then
+		export DIRECT=1
+		do_setup_nfs $script
+	else
+		export DIRECT=0
+	fi
+
 	# This will be part of the output filename.
 	typeset suffix=$(get_suffix $threads $sync $iosize)
 
@@ -123,7 +133,14 @@ function do_fio_run_impl
 	typeset outfile="$logbase.fio.$suffix"
 
 	# Start the load
-	log_must fio --output $outfile $FIO_SCRIPTS/$script
+	if [[ $NFS -eq 1 ]]; then
+		log_must ssh -t $NFS_USER@$NFS_CLIENT "
+			fio --output /tmp/fio.out /tmp/test.fio
+		"
+		log_must scp $NFS_USER@$NFS_CLIENT:/tmp/fio.out $outfile
+	else
+		log_must fio --output $outfile $FIO_SCRIPTS/$script
+	fi
 }
 
 #
@@ -163,6 +180,34 @@ function do_fio_run
 			done
 		done
 	done
+}
+
+# This function sets NFS mount on the client and make sure all correct
+# permissions are in place
+#
+function do_setup_nfs
+{
+	typeset script=$1
+	zfs  set sharenfs=on $TESTFS
+	log_must chmod  -R 777 /$TESTFS
+
+	ssh -t $NFS_USER@$NFS_CLIENT "mkdir -m 777 -p $NFS_MOUNT"
+	ssh -t $NFS_USER@$NFS_CLIENT "sudo -S umount $NFS_MOUNT"
+	log_must ssh -t $NFS_USER@$NFS_CLIENT "
+		sudo -S mount $NFS_OPTIONS $NFS_SERVER:/$TESTFS $NFS_MOUNT
+	"
+	#
+	# The variables in the fio script are only available in our current
+	# shell session, so we have to evaluate them here before copying
+	# the resulting script over to the target machine.
+	#
+	export jobnum='$jobnum'
+	while read line; do
+		eval echo "$line"
+	done < $FIO_SCRIPTS/$script > /tmp/test.fio
+	log_must sed -i -e "s%directory.*%directory=$NFS_MOUNT%" /tmp/test.fio
+	log_must scp /tmp/test.fio $NFS_USER@$NFS_CLIENT:/tmp
+	log_must rm /tmp/test.fio
 }
 
 #

--- a/usr/src/test/zfs-tests/tests/perf/regression/random_writes_zil.ksh
+++ b/usr/src/test/zfs-tests/tests/perf/regression/random_writes_zil.ksh
@@ -55,6 +55,10 @@ elif [[ -n $PERF_REGRESSION_NIGHTLY ]]; then
 	export PERF_IOSIZES=${PERF_IOSIZES:-'8k'}
 fi
 
+# Until the performance tests over NFS can deal with multiple file systems,
+# force the use of only one file system when testing over NFS.
+[[ $NFS -eq 1 ]] && PERF_NTHREADS_PER_FS='0'
+
 lun_list=$(pool_to_lun_list $PERFPOOL)
 log_note "Collecting backend IO stats with lun list $lun_list"
 export collect_scripts=(


### PR DESCRIPTION
Authored by: Ahmed Ghanem <ahmedg@delphix.com>
Reviewed by: Dan Kimmel <dan.kimmel@delphix.com>
Reviewed by: John Kennedy <john.kennedy@delphix.com>
Reviewed by: Kevin Greene <kevin.greene@delphix.com>

This change makes additions to the ZFS test suite that allows the
performance tests to run over NFS. The test is run and performance data
collected from the server side, while IO is generated on the NFS client.

This has been tested with Linux and illumos NFS clients.