### PR TITLE
10477 mdb_001_pos.ksh blows up because of missing backslash

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/mdb/mdb_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mdb/mdb_001_pos.ksh
@@ -50,7 +50,7 @@ function cleanup
 verify_runnable "global"
 log_onexit cleanup
 
-tmpfile=$(mktemp)
+typeset OUTFILE=$(mktemp)
 log_must zpool scrub $TESTPOOL
 
 typeset spa=$(mdb -ke "::spa" | awk "/$TESTPOOL/ {print \$1}")

--- a/usr/src/test/zfs-tests/tests/functional/mdb/mdb_001_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/mdb/mdb_001_pos.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2013, 2016 by Delphix. All rights reserved.
+# Copyright 2019 RackTop Systems.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -87,7 +88,7 @@ set -A dcmds "::abuf_find 1 2" \
 	"$spa ::walk metaslab | ::head -1 | ::metaslab_trace" \
 	"$spa ::walk zio_root | ::zio -c" \
 	"$spa ::walk zio_root | ::zio -r" \
-	"$spa ::walk zms_freelist"
+	"$spa ::walk zms_freelist" \
 	"$spa ::zfs_blkstats -v" \
 	"::dbufs" \
 	"::dbufs -n mos -o mdn -l 0 -b 0" \


### PR DESCRIPTION
```
SUCCESS: zpool scrub testpool
/opt/zfs-tests/tests/functional/mdb/mdb_001_pos[91]: ffffff0706a4e000 ::zfs_blkstats -v: not found [No such file or directory]
ASSERTION: Verify that the ZFS mdb dcmds and walkers are working as expected.
NOTE: Verifying: '::abuf_find 1 2'
/opt/zfs-tests/tests/functional/mdb/mdb_001_pos[109]: : cannot open
NOTE: Performing test-fail callback (/opt/zfs-tests/callbacks/zfs_dbgmsg)
```