### PR TITLE
10509 zpool_003_pos can't find core file

### DIFF
--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zfs/zfs_002_pos.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2019 RackTop Systems.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -63,7 +64,7 @@ log_assert "With ZFS_ABORT set, all zfs commands can abort and generate a " \
 log_onexit cleanup
 
 #preparation work for testing
-corepath=$TESTDIR/core
+corepath=$TESTDIR/cores
 if [[ -d $corepath ]]; then
 	rm -rf $corepath
 fi

--- a/usr/src/test/zfs-tests/tests/functional/cli_root/zpool/zpool_002_pos.ksh
+++ b/usr/src/test/zfs-tests/tests/functional/cli_root/zpool/zpool_002_pos.ksh
@@ -27,6 +27,7 @@
 
 #
 # Copyright (c) 2012, 2016 by Delphix. All rights reserved.
+# Copyright 2019 RackTop Systems.
 #
 
 . $STF_SUITE/include/libtest.shlib
@@ -59,7 +60,7 @@ log_assert "With ZFS_ABORT set, all zpool commands can abort and generate a core
 log_onexit cleanup
 
 #preparation work for testing
-corepath=$TESTDIR/core
+corepath=$TESTDIR/cores
 if [[ -d $corepath ]]; then
 	rm -rf $corepath
 fi


### PR DESCRIPTION
On a system configured to write core dumps to /var/cores zpool_003_pos is unable to properly verify a core file has been produced. The proposed fix is to call coreadm prior to running the zpool command to change the output path to a known location, something which zpool_002_pos already does.